### PR TITLE
Minor updates

### DIFF
--- a/src/main/java/org/springframework/hateoas/Link.java
+++ b/src/main/java/org/springframework/hateoas/Link.java
@@ -24,7 +24,7 @@ import org.springframework.util.Assert;
 
 /**
  * Value object for links.
- * 
+ *
  * @author Oliver Gierke
  */
 @XmlType(name = "link", namespace = Link.ATOM_NAMESPACE)
@@ -47,7 +47,7 @@ public class Link implements Serializable {
 
 	/**
 	 * Creates a new link to the given URI with the self rel.
-	 * 
+	 *
 	 * @see #REL_SELF
 	 * @param href must not be {@literal null} or empty.
 	 */
@@ -57,7 +57,7 @@ public class Link implements Serializable {
 
 	/**
 	 * Creates a new {@link Link} to the given URI with the given rel.
-	 * 
+	 *
 	 * @param href must not be {@literal null} or empty.
 	 * @param rel must not be {@literal null} or empty.
 	 */
@@ -72,30 +72,30 @@ public class Link implements Serializable {
 
 	/**
 	 * Empty constructor required by the marshalling framework.
+	 * <p><strong>Note: </strong> Sub-classes should not use this constructor!
 	 */
 	protected Link() {
-
 	}
 
 	/**
 	 * Returns the actual URI the link is pointing to.
-	 * 
+	 *
 	 * @return
 	 */
 	public String getHref() {
-		return href;
+		return this.href;
 	}
 
 	/**
 	 * Returns the rel of the link.
-	 * 
+	 *
 	 * @return
 	 */
 	public String getRel() {
-		return rel;
+		return this.rel;
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see java.lang.Object#equals(java.lang.Object)
 	 */
@@ -122,17 +122,17 @@ public class Link implements Serializable {
 	public int hashCode() {
 
 		int result = 17;
-		result += 31 * href.hashCode();
-		result += 31 * rel.hashCode();
+		result += 31 * this.href.hashCode();
+		result += 31 * this.rel.hashCode();
 		return result;
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see java.lang.Object#toString()
 	 */
 	@Override
 	public String toString() {
-		return String.format("{ rel : %s, href : %s }", rel, href);
+		return String.format("{ this.rel : %s, this.href : %s }", this.rel, this.href);
 	}
 }

--- a/src/main/java/org/springframework/hateoas/ResourceSupport.java
+++ b/src/main/java/org/springframework/hateoas/ResourceSupport.java
@@ -25,13 +25,13 @@ import org.springframework.util.Assert;
 
 /**
  * Base class for DTOs to collect links.
- * 
+ *
  * @author Oliver Gierke
  */
 public class ResourceSupport implements Identifiable<Link> {
 
 	@XmlElement(name = "link", namespace = Link.ATOM_NAMESPACE)
-	private List<Link> links;
+	private final List<Link> links;
 
 	public ResourceSupport() {
 		this.links = new ArrayList<Link>();
@@ -46,7 +46,7 @@ public class ResourceSupport implements Identifiable<Link> {
 
 	/**
 	 * Adds the given link to the resource.
-	 * 
+	 *
 	 * @param link
 	 */
 	public void add(Link link) {
@@ -75,13 +75,13 @@ public class ResourceSupport implements Identifiable<Link> {
 
 	/**
 	 * Returns the link with the given rel.
-	 * 
+	 *
 	 * @param rel
 	 * @return the link with the given rel or {@literal null} if none found.
 	 */
 	public Link getLink(String rel) {
 
-		for (Link link : links) {
+		for (Link link : this.links) {
 			if (link.getRel().equals(rel)) {
 				return link;
 			}
@@ -90,7 +90,7 @@ public class ResourceSupport implements Identifiable<Link> {
 		return null;
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see java.lang.Object#equals(java.lang.Object)
 	 */
@@ -110,7 +110,7 @@ public class ResourceSupport implements Identifiable<Link> {
 		return this.links.equals(that.links);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see java.lang.Object#hashCode()
 	 */
@@ -119,7 +119,7 @@ public class ResourceSupport implements Identifiable<Link> {
 		return this.links.hashCode();
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see java.lang.Object#toString()
 	 */

--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
@@ -30,26 +30,26 @@ import org.springframework.web.util.UriTemplate;
 
 /**
  * Builder to ease building {@link Link} instances pointing to Spring MVC controllers.
- * 
+ *
  * @author Oliver Gierke
  */
 public class ControllerLinkBuilder {
 
-	private final UriComponents builder;
+	private final UriComponents uriComponents;
 
 	/**
 	 * Creates a new {@link ControllerLinkBuilder}.
-	 * 
+	 *
 	 * @param builder must not be {@literal null}.
 	 */
 	private ControllerLinkBuilder(UriComponentsBuilder builder) {
 		Assert.notNull(builder);
-		this.builder = builder.build();
+		this.uriComponents = builder.build();
 	}
 
 	/**
 	 * Creates a new {@link ControllerLinkBuilder} with a base of the mapping annotated to the given controller class.
-	 * 
+	 *
 	 * @param controller
 	 * @return
 	 */
@@ -59,7 +59,7 @@ public class ControllerLinkBuilder {
 
 	public static ControllerLinkBuilder linkTo(Class<?> controller, Object... parameters) {
 
-		RequestMapping annotation = controller.getAnnotation(RequestMapping.class);
+		RequestMapping annotation = AnnotationUtils.findAnnotation(controller, RequestMapping.class);
 		String[] mapping = annotation == null ? new String[0] : (String[]) AnnotationUtils.getValue(annotation);
 
 		if (mapping.length > 1) {
@@ -78,7 +78,7 @@ public class ControllerLinkBuilder {
 
 	/**
 	 * Adds the given object's {@link String} representation as sub-resource to the current URI.
-	 * 
+	 *
 	 * @param object
 	 * @return
 	 */
@@ -89,13 +89,13 @@ public class ControllerLinkBuilder {
 		}
 
 		String[] segments = StringUtils.tokenizeToStringArray(object.toString(), "/");
-		return new ControllerLinkBuilder(UriComponentsBuilder.fromUri(builder.toUri()).pathSegment(segments));
+		return new ControllerLinkBuilder(UriComponentsBuilder.fromUri(this.uriComponents.toUri()).pathSegment(segments));
 	}
 
 	/**
 	 * Adds the given {@link AbstractEntity}'s id as sub-resource. Will simply return the current builder if the given
 	 * entity is {@literal null}.
-	 * 
+	 *
 	 * @param identifyable
 	 * @return
 	 */
@@ -110,11 +110,11 @@ public class ControllerLinkBuilder {
 
 	/**
 	 * Returns a URI resulting from the builder.
-	 * 
+	 *
 	 * @return
 	 */
 	public URI toUri() {
-		return builder.encode().toUri();
+		return this.uriComponents.encode().toUri();
 	}
 
 	public Link withRel(String rel) {

--- a/src/main/java/org/springframework/hateoas/mvc/ResourceAssemblerSupport.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ResourceAssemblerSupport.java
@@ -30,7 +30,7 @@ import org.springframework.util.Assert;
 /**
  * Base class to implement {@link ResourceAssembler}s. Will automate {@link ResourceSupport} instance creation and make
  * sure a self-link is always added.
- * 
+ *
  * @author Oliver Gierke
  */
 public abstract class ResourceAssemblerSupport<T extends Identifiable<?>, D extends ResourceSupport> implements
@@ -60,7 +60,7 @@ public abstract class ResourceAssemblerSupport<T extends Identifiable<?>, D exte
 
 	/**
 	 * Creates a new {@link ResourceAssemblerSupport} using the given controller class and resource type.
-	 * 
+	 *
 	 * @param controllerClass must not be {@literal null}.
 	 * @param resourceType must not be {@literal null}.
 	 */
@@ -75,7 +75,7 @@ public abstract class ResourceAssemblerSupport<T extends Identifiable<?>, D exte
 
 	/**
 	 * Converts all given entities into resources.
-	 * 
+	 *
 	 * @see #toResource(Object)
 	 * @param entities
 	 * @return
@@ -93,7 +93,7 @@ public abstract class ResourceAssemblerSupport<T extends Identifiable<?>, D exte
 
 	/**
 	 * Creates a new resource and adds a self link to it consisting using the {@link Identifiable}'s id.
-	 * 
+	 *
 	 * @param entity must not be {@literal null}.
 	 * @return
 	 */
@@ -107,7 +107,7 @@ public abstract class ResourceAssemblerSupport<T extends Identifiable<?>, D exte
 
 	/**
 	 * Creates a new resource with a self link to the given id.
-	 * 
+	 *
 	 * @param entity
 	 * @param id
 	 * @return
@@ -122,13 +122,13 @@ public abstract class ResourceAssemblerSupport<T extends Identifiable<?>, D exte
 		Assert.notNull(id);
 
 		D instance = instantiateResource(entity);
-		instance.add(linkTo(controllerClass, unwrapIdentifyables(parameters)).slash(id).withSelfRel());
+		instance.add(linkTo(this.controllerClass, unwrapIdentifyables(parameters)).slash(id).withSelfRel());
 		return instance;
 	}
 
 	/**
 	 * Extracts the ids of the given values in case they're {@link Identifiable}s. Returns all other objects as they are.
-	 * 
+	 *
 	 * @param values must not be {@literal null}.
 	 * @return
 	 */
@@ -147,11 +147,11 @@ public abstract class ResourceAssemblerSupport<T extends Identifiable<?>, D exte
 	 * Instantiates the resource object. Default implementation will assume a no-arg constructor and use reflection but
 	 * can be overridden to manually set up the object instance initially (e.g. to improve performance if this becomes an
 	 * issue).
-	 * 
+	 *
 	 * @param entity
 	 * @return
 	 */
 	protected D instantiateResource(T entity) {
-		return BeanUtils.instantiateClass(resourceType);
+		return BeanUtils.instantiateClass(this.resourceType);
 	}
 }

--- a/src/test/java/org/springframework/hateoas/LinkUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/LinkUnitTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 /**
  * Unit tests for {@link Link}.
- * 
+ *
  * @author Oliver Gierke
  */
 public class LinkUnitTest {
@@ -52,12 +52,12 @@ public class LinkUnitTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void rejectsEmptyHref() {
-		new Link("");
+		new Link(" ");
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void rejectsEmptyRel() {
-		new Link("foo", "");
+		new Link("foo", " ");
 	}
 
 	@Test

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
@@ -28,7 +28,7 @@ import org.springframework.hateoas.TestUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
- * 
+ *
  * @author Oliver Gierke
  */
 public class ControllerLinkBuilderUnitTest extends TestUtils {
@@ -108,7 +108,10 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 	}
 
 	@RequestMapping("/people")
-	class PersonController {
+	interface PersonControllerInterface {
+	}
+
+	class PersonController implements PersonControllerInterface {
 
 	}
 


### PR DESCRIPTION
The main one worth noting is how controller-level `@RequestMapping`
annotations are discovered. Using AnnotationUtils.findAnnotation
ensures they can be found on interfaces or base classes, which is
perfectly legitimate.
