### PR TITLE
HTTP method added to links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target/
 .settings/
 .project
 .classpath
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	
+
 	<groupId>org.springframework.hateoas</groupId>
 	<artifactId>spring-hateoas</artifactId>
 	<version>0.3.0.BUILD-SNAPSHOT</version>
-	
+
 	<name>Spring Hateoas</name>
 	<url>http://github.com/SpringSource/spring-hateoas</url>
 	<description>
-		Library to support implementing represnetaitons for 
+		Library to support implementing represnetaitons for
 		hyper-text driven REST web services.
 	</description>
-	
+
 	<inceptionYear>2012</inceptionYear>
-	
+
 	<organization>
 		<name>SpringSource, a division of VMware</name>
 		<url>http://www.springsource.org</url>
 	</organization>
-	
+
 	<developers>
 		<developer>
 			<id>ogierke</id>
@@ -32,20 +32,20 @@
 			<timezone>+1</timezone>
 		</developer>
 	</developers>
-	
+
 	<licenses>
 		<license>
 			<name>Apache License, Version 2.0</name>
 			<url>http://www.apache.org/licenses/LICENSE-2.0</url>
 			<comments>
 			Copyright 2011 the original author or authors.
-			 
+
 			Licensed under the Apache License, Version 2.0 (the "License");
 			you may not use this file except in compliance with the License.
 			You may obtain a copy of the License at
-			
+
 			     http://www.apache.org/licenses/LICENSE-2.0
-			
+
 			Unless required by applicable law or agreed to in writing, software
 			distributed under the License is distributed on an "AS IS" BASIS,
 			WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
@@ -61,6 +61,8 @@
 		<jackson.version>1.9.7</jackson.version>
 		<jaxrs.version>1.0</jaxrs.version>
 		<bundlor.failOnWarnings>true</bundlor.failOnWarnings>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
 
 	<dependencies>
@@ -75,19 +77,26 @@
 			<artifactId>spring-webmvc</artifactId>
 			<version>${spring.version}</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>servlet-api</artifactId>
 			<version>2.5</version>
 			<scope>provided</scope>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-core-asl</artifactId>
 			<version>${jackson.version}</version>
 			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.codehaus.jackson</groupId>
+			<artifactId>jackson-mapper-asl</artifactId>
+			<version>${jackson.version}</version>
+            <optional>true</optional>
 		</dependency>
 
 		<dependency>
@@ -97,12 +106,6 @@
 			<optional>true</optional>
 		</dependency>
 
-		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-mapper-asl</artifactId>
-			<version>${jackson.version}</version>
-			<scope>test</scope>
-		</dependency>
 
 		<dependency>
 			<groupId>org.hamcrest</groupId>
@@ -124,7 +127,7 @@
 			<version>${spring.version}</version>
 			<scope>test</scope>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
@@ -145,7 +148,7 @@
 					<target>1.6</target>
 				</configuration>
 			</plugin>
-			
+
 			<plugin>
 				<groupId>com.springsource.bundlor</groupId>
 				<artifactId>com.springsource.bundlor.maven</artifactId>
@@ -162,7 +165,7 @@
 					</execution>
 				</executions>
 			</plugin>
-			
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
@@ -171,7 +174,7 @@
 					<useDefaultManifestFile>true</useDefaultManifestFile>
 				</configuration>
 			</plugin>
-			
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
@@ -185,7 +188,7 @@
 					</execution>
 				</executions>
 			</plugin>
-			
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
@@ -214,21 +217,21 @@
 					</links>
 				</configuration>
 			</plugin>
-			
+
 		</plugins>
 	</build>
-	
+
 	<pluginRepositories>
 		<pluginRepository>
 			<id>spring-plugins-release</id>
 			<url>http://repo.springsource.org/plugins-release</url>
 		</pluginRepository>
 	</pluginRepositories>
-	
+
 	 <scm>
         <url>https://github.com/SpringSource/spring-hateoas</url>
         <connection>scm:git:git://github.com/SpringSource/spring-hateoas.git</connection>
         <developerConnection>scm:git:ssh://git@github.com:SpringSource/spring-hateoas.git</developerConnection>
     </scm>
-	
+
 </project>

--- a/src/main/java/org/springframework/hateoas/Link.java
+++ b/src/main/java/org/springframework/hateoas/Link.java
@@ -15,17 +15,19 @@
  */
 package org.springframework.hateoas;
 
-import java.io.Serializable;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+import org.springframework.http.HttpMethod;
+import org.springframework.util.Assert;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
-
-import org.springframework.util.Assert;
+import java.io.Serializable;
 
 /**
  * Value object for links.
- * 
+ *
  * @author Oliver Gierke
+ * @author Daniel Sawano
  */
 @XmlType(name = "link", namespace = Link.ATOM_NAMESPACE)
 public class Link implements Serializable {
@@ -44,10 +46,13 @@ public class Link implements Serializable {
 	private String rel;
 	@XmlAttribute
 	private String href;
+    @XmlAttribute
+    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+    private HttpMethod method;
 
 	/**
 	 * Creates a new link to the given URI with the self rel.
-	 * 
+	 *
 	 * @see #REL_SELF
 	 * @param href must not be {@literal null} or empty.
 	 */
@@ -55,20 +60,32 @@ public class Link implements Serializable {
 		this(href, REL_SELF);
 	}
 
-	/**
-	 * Creates a new {@link Link} to the given URI with the given rel.
-	 * 
-	 * @param href must not be {@literal null} or empty.
-	 * @param rel must not be {@literal null} or empty.
-	 */
-	public Link(String href, String rel) {
+    /**
+     * Creates a new {@link Link} to the given URI with the given rel.
+     *
+     * @param href must not be {@literal null} or empty.
+     * @param rel must not be {@literal null} or empty.
+     */
+    public Link(String href, String rel) {
+        this(href, rel, null);
+    }
 
-		Assert.hasText(href, "Href must not be null or empty!");
-		Assert.hasText(rel, "Rel must not be null or empty!");
+    /**
+     * Creates a new {@link Link} to the given URI with the given rel and the given HTTP method.
+     *
+     * @param href must not be {@literal null} or empty.
+     * @param rel must not be {@literal null} or empty.
+     * @param  method can be null
+     */
+	public Link(String href, String rel, HttpMethod method) {
 
-		this.href = href;
-		this.rel = rel;
-	}
+        Assert.hasText(href, "Href must not be null or empty!");
+        Assert.hasText(rel, "Rel must not be null or empty!");
+
+        this.href = href;
+        this.rel = rel;
+        this.method = method;
+    }
 
 	/**
 	 * Empty constructor required by the marshalling framework.
@@ -79,7 +96,7 @@ public class Link implements Serializable {
 
 	/**
 	 * Returns the actual URI the link is pointing to.
-	 * 
+	 *
 	 * @return
 	 */
 	public String getHref() {
@@ -88,51 +105,50 @@ public class Link implements Serializable {
 
 	/**
 	 * Returns the rel of the link.
-	 * 
+	 *
 	 * @return
 	 */
 	public String getRel() {
 		return rel;
 	}
 
-	/* 
-	 * (non-Javadoc)
-	 * @see java.lang.Object#equals(java.lang.Object)
-	 */
-	@Override
-	public boolean equals(Object obj) {
+    /**
+     * Returns the method of the link.
+     *
+     * @return
+     */
+    public HttpMethod getMethod() {
+        return method;
+    }
 
-		if (this == obj) {
-			return true;
-		}
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Link)) return false;
 
-		if (!(obj instanceof Link)) {
-			return false;
-		}
+        final Link link = (Link) o;
 
-		Link that = (Link) obj;
+        if (href != null ? !href.equals(link.href) : link.href != null) return false;
+        if (method != link.method) return false;
+        if (rel != null ? !rel.equals(link.rel) : link.rel != null) return false;
 
-		return this.href.equals(that.href) && this.rel.equals(that.rel);
-	}
+        return true;
+    }
 
-	/* (non-Javadoc)
-	 * @see java.lang.Object#hashCode()
-	 */
-	@Override
-	public int hashCode() {
+    @Override
+    public int hashCode() {
+        int result = rel != null ? rel.hashCode() : 0;
+        result = 31 * result + (href != null ? href.hashCode() : 0);
+        result = 31 * result + (method != null ? method.hashCode() : 0);
+        return result;
+    }
 
-		int result = 17;
-		result += 31 * href.hashCode();
-		result += 31 * rel.hashCode();
-		return result;
-	}
-
-	/* 
-	 * (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return String.format("{ rel : %s, href : %s }", rel, href);
-	}
+    @Override
+    public String toString() {
+        return "Link{" +
+                "rel='" + rel + '\'' +
+                ", href='" + href + '\'' +
+                ", method=" + method +
+                '}';
+    }
 }

--- a/src/main/java/org/springframework/hateoas/LinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/LinkBuilder.java
@@ -15,18 +15,21 @@
  */
 package org.springframework.hateoas;
 
+import org.springframework.http.HttpMethod;
+
 import java.net.URI;
 
 /**
  * Builder to ease building {@link Link} instances.
- * 
+ *
  * @author Ricardo Gladwell
+ * @author Daniel Sawano
  */
 public interface LinkBuilder {
 
 	/**
 	 * Adds the given object's {@link String} representation as sub-resource to the current URI.
-	 * 
+	 *
 	 * @param object
 	 * @return
 	 */
@@ -35,22 +38,31 @@ public interface LinkBuilder {
 	/**
 	 * Adds the given {@link Identifiable}'s id as sub-resource. Will simply return the {@link LinkBuilder} as is if the
 	 * given entity is {@literal null}.
-	 * 
+	 *
 	 * @param identifiable
 	 * @return
 	 */
 	LinkBuilder slash(Identifiable<?> identifiable);
 
+    /**
+     * Adds the given HTTP method as the method for the current URI.
+     *
+     * @param method
+     *         the HTTP method
+     * @return a {@literal LinkBuilder}
+     */
+    LinkBuilder method(HttpMethod method);
+
 	/**
 	 * Creates a URI of the link built by the current builder instance.
-	 * 
+	 *
 	 * @return
 	 */
 	URI toUri();
 
 	/**
 	 * Creates the {@link Link} built by the current builder instance with the given rel.
-	 * 
+	 *
 	 * @param rel must not be {@literal null} or empty.
 	 * @return
 	 */
@@ -58,7 +70,7 @@ public interface LinkBuilder {
 
 	/**
 	 * Creates the {@link Link} built by the current builder instance with the default self rel.
-	 * 
+	 *
 	 * @see Link#REL_SELF
 	 * @return
 	 */

--- a/src/main/java/org/springframework/hateoas/jaxrs/JaxRsLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/jaxrs/JaxRsLinkBuilder.java
@@ -15,34 +15,34 @@
  */
 package org.springframework.hateoas.jaxrs;
 
-import javax.ws.rs.Path;
-
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.hateoas.LinkBuilder;
+import org.springframework.hateoas.mvc.LinkComponents;
 import org.springframework.hateoas.mvc.UriComponentsLinkBuilder;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
-import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.util.UriTemplate;
+
+import javax.ws.rs.Path;
 
 /**
  * {@link LinkBuilder} to derive URI mappings from a JAX-RS {@link Path} annotation.
- * 
+ *
  * @author Oliver Gierke
  */
 public class JaxRsLinkBuilder extends UriComponentsLinkBuilder<JaxRsLinkBuilder> {
 
 	/**
-	 * Creates a new {@link JaxRsLinkBuilder} from the given {@link UriComponentsBuilder}.
-	 * 
-	 * @param builder must not be {@literal null}.
+	 * Creates a new {@link JaxRsLinkBuilder} from the given {@link LinkComponents}.
+	 *
+	 * @param linkComponents must not be {@literal null}.
 	 */
-	private JaxRsLinkBuilder(UriComponentsBuilder builder) {
-		super(builder);
+	private JaxRsLinkBuilder(LinkComponents linkComponents) {
+		super(linkComponents);
 	}
 
 	/**
 	 * Creates a {@link JaxRsLinkBuilder} instance to link to the {@link Path} mapping tied to the given class.
-	 * 
+	 *
 	 * @param service the class to discover the annotation on, must not be {@literal null}.
 	 * @return
 	 */
@@ -53,7 +53,7 @@ public class JaxRsLinkBuilder extends UriComponentsLinkBuilder<JaxRsLinkBuilder>
 	/**
 	 * Creates a new {@link JaxRsLinkBuilder} instance to link to the {@link Path} mapping tied to the given class binding
 	 * the given parameters to the URI template.
-	 * 
+	 *
 	 * @param service the class to discover the annotation on, must not be {@literal null}.
 	 * @param parameters additional parameters to bind to the URI template declared in the annotation, must not be
 	 *          {@literal null}.
@@ -64,13 +64,13 @@ public class JaxRsLinkBuilder extends UriComponentsLinkBuilder<JaxRsLinkBuilder>
 		Path annotation = AnnotationUtils.findAnnotation(service, Path.class);
 		String path = (String) AnnotationUtils.getValue(annotation);
 
-		JaxRsLinkBuilder builder = new JaxRsLinkBuilder(ServletUriComponentsBuilder.fromCurrentServletMapping());
+		JaxRsLinkBuilder builder = new JaxRsLinkBuilder(new LinkComponents(ServletUriComponentsBuilder.fromCurrentServletMapping().build(), null));
 
 		UriTemplate template = new UriTemplate(path);
 		return builder.slash(template.expand(parameters));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.hateoas.UriComponentsLinkBuilder#getThis()
 	 */
@@ -79,12 +79,12 @@ public class JaxRsLinkBuilder extends UriComponentsLinkBuilder<JaxRsLinkBuilder>
 		return this;
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.hateoas.UriComponentsLinkBuilder#createNewInstance(org.springframework.web.util.UriComponentsBuilder)
 	 */
 	@Override
-	protected JaxRsLinkBuilder createNewInstance(UriComponentsBuilder builder) {
-		return new JaxRsLinkBuilder(builder);
+	protected JaxRsLinkBuilder createNewInstance(LinkComponents linkComponents) {
+		return new JaxRsLinkBuilder(linkComponents);
 	}
 }

--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
@@ -20,28 +20,27 @@ import org.springframework.hateoas.Link;
 import org.springframework.util.Assert;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
-import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.util.UriTemplate;
 
 /**
  * Builder to ease building {@link Link} instances pointing to Spring MVC controllers.
- * 
+ *
  * @author Oliver Gierke
  */
 public class ControllerLinkBuilder extends UriComponentsLinkBuilder<ControllerLinkBuilder> {
 
 	/**
-	 * Creates a new {@link ControllerLinkBuilder} using the given {@link UriComponentsBuilder}.
-	 * 
-	 * @param builder must not be {@literal null}.
+	 * Creates a new {@link ControllerLinkBuilder} using the given {@link LinkComponents}.
+	 *
+	 * @param linkComponents must not be {@literal null}.
 	 */
-	private ControllerLinkBuilder(UriComponentsBuilder builder) {
-		super(builder);
+	private ControllerLinkBuilder(LinkComponents linkComponents) {
+		super(linkComponents);
 	}
 
 	/**
 	 * Creates a new {@link ControllerLinkBuilder} with a base of the mapping annotated to the given controller class.
-	 * 
+	 *
 	 * @param controller the class to discover the annotation on, must not be {@literal null}.
 	 * @return
 	 */
@@ -52,7 +51,7 @@ public class ControllerLinkBuilder extends UriComponentsLinkBuilder<ControllerLi
 	/**
 	 * Creates a new {@link ControllerLinkBuilder} with a base of the mapping annotated to the given controller class. The
 	 * additional parameters are used to fill up potentially available path variables in the class scop request mapping.
-	 * 
+	 *
 	 * @param controller the class to discover the annotation on, must not be {@literal null}.
 	 * @param parameters additional parameters to bind to the URI template declared in the annotation, must not be
 	 *          {@literal null}.
@@ -69,7 +68,8 @@ public class ControllerLinkBuilder extends UriComponentsLinkBuilder<ControllerLi
 			throw new IllegalStateException("Multiple controller mappings defined! Unable to build URI!");
 		}
 
-		ControllerLinkBuilder builder = new ControllerLinkBuilder(ServletUriComponentsBuilder.fromCurrentServletMapping());
+        ControllerLinkBuilder builder =
+                new ControllerLinkBuilder(new LinkComponents(ServletUriComponentsBuilder.fromCurrentServletMapping().build(), null));
 
 		if (mapping.length == 0) {
 			return builder;
@@ -79,7 +79,7 @@ public class ControllerLinkBuilder extends UriComponentsLinkBuilder<ControllerLi
 		return builder.slash(template.expand(parameters));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.hateoas.UriComponentsLinkBuilder#getThis()
 	 */
@@ -88,12 +88,12 @@ public class ControllerLinkBuilder extends UriComponentsLinkBuilder<ControllerLi
 		return this;
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.hateoas.UriComponentsLinkBuilder#createNewInstance(org.springframework.web.util.UriComponentsBuilder)
 	 */
 	@Override
-	protected ControllerLinkBuilder createNewInstance(UriComponentsBuilder builder) {
-		return new ControllerLinkBuilder(builder);
+	protected ControllerLinkBuilder createNewInstance(LinkComponents linkComponents) {
+		return new ControllerLinkBuilder(linkComponents);
 	}
 }

--- a/src/main/java/org/springframework/hateoas/mvc/LinkComponents.java
+++ b/src/main/java/org/springframework/hateoas/mvc/LinkComponents.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.hateoas.mvc;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.util.Assert;
+import org.springframework.web.util.UriComponents;
+
+/**
+ * @author Daniel Sawano
+ */
+public class LinkComponents {
+    private final UriComponents uriComponents;
+    private final HttpMethod method;
+
+    public LinkComponents(UriComponents uriComponents, HttpMethod method) {
+        Assert.notNull(uriComponents);
+
+        this.uriComponents = uriComponents;
+        this.method = method;
+    }
+
+    public UriComponents getUriComponents() {
+        return uriComponents;
+    }
+
+    public HttpMethod getMethod() {
+        return method;
+    }
+}

--- a/src/test/java/org/springframework/hateoas/LinkUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/LinkUnitTest.java
@@ -19,10 +19,11 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
+import org.springframework.http.HttpMethod;
 
 /**
  * Unit tests for {@link Link}.
- * 
+ *
  * @author Oliver Gierke
  */
 public class LinkUnitTest {
@@ -60,7 +61,12 @@ public class LinkUnitTest {
 		new Link("foo", "");
 	}
 
-	@Test
+    @Test
+    public void acceptsNullMethod() throws Exception {
+        new Link("href", "rel", null);
+    }
+
+    @Test
 	public void sameRelAndHrefMakeSameLink() {
 
 		Link left = new Link("foo", Link.REL_SELF);
@@ -69,11 +75,20 @@ public class LinkUnitTest {
 		TestUtils.assertEqualAndSameHashCode(left, right);
 	}
 
+    @Test
+	public void sameRelAndHrefAndMethodMakeSameLink() {
+
+		Link left = new Link("foo", Link.REL_SELF, HttpMethod.DELETE);
+		Link right = new Link("foo", Link.REL_SELF, HttpMethod.DELETE);
+
+		TestUtils.assertEqualAndSameHashCode(left, right);
+	}
+
 	@Test
 	public void differentRelMakesDifferentLink() {
 
-		Link left = new Link("foo", Link.REL_PREVIOUS);
-		Link right = new Link("foo", Link.REL_NEXT);
+		Link left = new Link("foo", Link.REL_PREVIOUS, HttpMethod.GET);
+		Link right = new Link("foo", Link.REL_NEXT, HttpMethod.GET);
 
 		TestUtils.assertNotEqualAndDifferentHashCode(left, right);
 	}
@@ -81,8 +96,17 @@ public class LinkUnitTest {
 	@Test
 	public void differentHrefMakesDifferentLink() {
 
-		Link left = new Link("foo", Link.REL_SELF);
-		Link right = new Link("bar", Link.REL_SELF);
+		Link left = new Link("foo", Link.REL_SELF, HttpMethod.GET);
+		Link right = new Link("bar", Link.REL_SELF, HttpMethod.GET);
+
+		TestUtils.assertNotEqualAndDifferentHashCode(left, right);
+	}
+
+    @Test
+	public void differentMethodMakesDifferentLink() {
+
+		Link left = new Link("foo", Link.REL_SELF, HttpMethod.GET);
+		Link right = new Link("foo", Link.REL_SELF, HttpMethod.PUT);
 
 		TestUtils.assertNotEqualAndDifferentHashCode(left, right);
 	}

--- a/src/test/java/org/springframework/hateoas/jaxrs/JaxRsLinkBuilderFactoryUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/jaxrs/JaxRsLinkBuilderFactoryUnitTest.java
@@ -1,19 +1,23 @@
 package org.springframework.hateoas.jaxrs;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-
-import javax.ws.rs.Path;
-
 import org.junit.Test;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.TestUtils;
+import org.springframework.http.HttpMethod;
+
+import javax.ws.rs.Path;
+
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 /**
  * Unit test for {@link JaxRsLinkBuilderFactory}.
- * 
+ *
  * @author Ricardo Gladwell
  * @author Oliver Gierke
+ * @author Daniel Sawano
  */
 public class JaxRsLinkBuilderFactoryUnitTest extends TestUtils {
 
@@ -27,6 +31,26 @@ public class JaxRsLinkBuilderFactoryUnitTest extends TestUtils {
 		assertThat(link.getRel(), is(Link.REL_SELF));
 		assertThat(link.getHref(), endsWith("/people"));
 	}
+
+    @Test
+	public void createsPostLinkToServiceRoot() {
+
+		Link link = factory.linkTo(PersonServiceImpl.class).method(HttpMethod.POST).withSelfRel();
+
+		assertThat(link.getRel(), is(Link.REL_SELF));
+		assertThat(link.getHref(), endsWith("/people"));
+        assertThat(link.getMethod(), is(HttpMethod.POST));
+	}
+
+    @Test
+    public void builderShouldNotBeAffectedByCallingOrder() throws Exception {
+        Link link1 =
+                factory.linkTo(PersonServiceImpl.class).method(HttpMethod.DELETE).slash("someValue").withSelfRel();
+        Link link2 =
+                factory.linkTo(PersonServiceImpl.class).slash("someValue").method(HttpMethod.DELETE).withSelfRel();
+
+        assertEquals(link1, link2);
+    }
 
 	@Test
 	public void createsLinkToParameterizedServiceRoot() {

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderFactoryUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderFactoryUnitTest.java
@@ -23,12 +23,14 @@ import org.springframework.hateoas.Link;
 import org.springframework.hateoas.TestUtils;
 import org.springframework.hateoas.mvc.ControllerLinkBuilderUnitTest.PersonControllerImpl;
 import org.springframework.hateoas.mvc.ControllerLinkBuilderUnitTest.PersonsAddressesController;
+import org.springframework.http.HttpMethod;
 
 /**
  * Unit tests for {@link ControllerLinkBuilderFactory}.
- * 
+ *
  * @author Ricardo Gladwell
  * @author Oliver Gierke
+ * @author Daniel Sawano
  */
 public class ControllerLinkBuilderFactoryUnitTest extends TestUtils {
 
@@ -41,6 +43,16 @@ public class ControllerLinkBuilderFactoryUnitTest extends TestUtils {
 
 		assertThat(link.getRel(), is(Link.REL_SELF));
 		assertThat(link.getHref(), endsWith("/people"));
+	}
+
+    @Test
+	public void createsPutLinkToControllerRoot() {
+
+		Link link = factory.linkTo(PersonControllerImpl.class).method(HttpMethod.PUT).withSelfRel();
+
+		assertThat(link.getRel(), is(Link.REL_SELF));
+		assertThat(link.getHref(), endsWith("/people"));
+        assertThat(link.getMethod(), is(HttpMethod.PUT));
 	}
 
 	@Test

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
@@ -15,20 +15,24 @@
  */
 package org.springframework.hateoas.mvc;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.*;
-
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.springframework.hateoas.Identifiable;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.TestUtils;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 
 /**
  * @author Oliver Gierke
+ * @author Daniel Sawano
  */
 public class ControllerLinkBuilderUnitTest extends TestUtils {
 
@@ -40,7 +44,25 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		assertThat(link.getHref(), Matchers.endsWith("/people"));
 	}
 
-	@Test
+    @Test
+	public void createsPostLinkToControllerRoot() {
+
+		Link link = linkTo(PersonControllerImpl.class).method(HttpMethod.POST).withSelfRel();
+
+		assertThat(link.getRel(), is(Link.REL_SELF));
+		assertThat(link.getHref(), Matchers.endsWith("/people"));
+        assertThat(link.getMethod(), is(HttpMethod.POST));
+	}
+
+    @Test
+    public void builderShouldNotBeAffectedByCallingOrder() throws Exception {
+        Link link1 = linkTo(PersonController.class).method(HttpMethod.DELETE).slash("someValue").withSelfRel();
+        Link link2 = linkTo(PersonController.class).slash("someValue").method(HttpMethod.DELETE).withSelfRel();
+
+        assertEquals(link1, link2);
+    }
+
+    @Test
 	public void createsLinkToParameterizedControllerRoot() {
 
 		Link link = linkTo(PersonsAddressesController.class, 15).withSelfRel();


### PR DESCRIPTION
GET is considered to be default if the 'method' field is omitted. Otherwise the specified method is written out.

E.g.:

``` javascript
  "links" : [ {
    "rel" : "self",
    "href" : "http://foo.com/bar"
  }, {
    "rel" : "create",
    "href" : "http://foo.com/bar",
    "method" : "PUT"
  } ]
```
