### PR TITLE
Spring version 3.1.2 -> 3.1.0 for more liberal OSGi dependency matching.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 	</licenses>
 
 	<properties>
-		<spring.version>3.1.2.RELEASE</spring.version>
+		<spring.version>3.1.0.RELEASE</spring.version>
 		<jackson.version>1.9.10</jackson.version>
 		<jaxrs.version>1.0</jaxrs.version>
 		<bundlor.failOnWarnings>true</bundlor.failOnWarnings>


### PR DESCRIPTION
Would really love to put the Spring version two 3.1.0 as this is the Spring version currently installed on our OSGi server and OSGi dependency matching is much stricter than Maven. We're already using Spring 3.1.0 with Spring HATEOAS.
