### PR TITLE
Support for JSON-HAL with a custom Module and Jackson Mixin-Classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 .settings/
 .project
 .classpath
+bin/

--- a/src/main/java/org/springframework/hateoas/hal/HalJacksonModule.java
+++ b/src/main/java/org/springframework/hateoas/hal/HalJacksonModule.java
@@ -1,0 +1,17 @@
+package org.springframework.hateoas.hal;
+
+import org.codehaus.jackson.Version;
+import org.codehaus.jackson.map.module.SimpleModule;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.ResourceSupport;
+
+public class HalJacksonModule extends SimpleModule {
+
+	public HalJacksonModule() {
+		super("json-hal-module", new Version(1, 0, 0, null));
+
+		setMixInAnnotation(Link.class, LinkMixin.class);
+		setMixInAnnotation(ResourceSupport.class, ResourceSupportMixin.class);
+	}
+
+}

--- a/src/main/java/org/springframework/hateoas/hal/HalLinkListSerializer.java
+++ b/src/main/java/org/springframework/hateoas/hal/HalLinkListSerializer.java
@@ -1,0 +1,56 @@
+package org.springframework.hateoas.hal;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.codehaus.jackson.JsonGenerationException;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.map.SerializerProvider;
+import org.codehaus.jackson.map.TypeSerializer;
+import org.codehaus.jackson.map.ser.std.ContainerSerializerBase;
+import org.codehaus.jackson.map.ser.std.MapSerializer;
+import org.codehaus.jackson.map.type.TypeFactory;
+import org.codehaus.jackson.type.JavaType;
+import org.springframework.hateoas.Link;
+
+public class HalLinkListSerializer extends ContainerSerializerBase<List<Link>> {
+
+	public HalLinkListSerializer() {
+		super(List.class, false);
+	}
+
+	@Override
+	public void serialize(List<Link> value, JsonGenerator jgen, SerializerProvider provider) throws IOException,
+			JsonGenerationException {
+
+		// sort links according to their relation
+		Map<String, List<Link>> sortedLinks = new HashMap<String, List<Link>>();
+		for (Link link : value) {
+			if (sortedLinks.get(link.getRel()) == null) {
+				sortedLinks.put(link.getRel(), new ArrayList<Link>());
+			}
+			sortedLinks.get(link.getRel()).add(link);
+		}
+
+		TypeFactory typeFactory = provider.getConfig().getTypeFactory();
+		JavaType keyType = typeFactory.uncheckedSimpleType(String.class);
+		JavaType valueType = typeFactory.constructCollectionType(ArrayList.class, Link.class);
+		JavaType mapType = typeFactory.constructMapType(HashMap.class, keyType, valueType);
+
+		MapSerializer serializer = MapSerializer.construct(new String[] {}, mapType, true, null, null,
+				provider.findKeySerializer(keyType, null), new OptionalListSerializer(Link.class, false));
+
+		serializer.serialize(sortedLinks, jgen, provider);
+
+	}
+
+	@Override
+	public ContainerSerializerBase<?> _withValueTypeSerializer(TypeSerializer vts) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/src/main/java/org/springframework/hateoas/hal/LinkMixin.java
+++ b/src/main/java/org/springframework/hateoas/hal/LinkMixin.java
@@ -1,0 +1,7 @@
+package org.springframework.hateoas.hal;
+
+import org.springframework.hateoas.Link;
+
+public class LinkMixin extends Link {
+
+}

--- a/src/main/java/org/springframework/hateoas/hal/OptionalListSerializer.java
+++ b/src/main/java/org/springframework/hateoas/hal/OptionalListSerializer.java
@@ -1,0 +1,66 @@
+package org.springframework.hateoas.hal;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+import org.codehaus.jackson.JsonGenerationException;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.map.BeanProperty;
+import org.codehaus.jackson.map.JsonSerializer;
+import org.codehaus.jackson.map.SerializerProvider;
+import org.codehaus.jackson.map.TypeSerializer;
+import org.codehaus.jackson.map.ser.std.ContainerSerializerBase;
+
+public class OptionalListSerializer extends ContainerSerializerBase<Object> {
+
+	protected JsonSerializer<Object> _elementSerializer;
+	protected BeanProperty _property;
+	private JsonSerializer<Object> linkSer;
+
+	public OptionalListSerializer() {
+		super(List.class, false);
+	}
+
+	public OptionalListSerializer(Class<?> t, boolean dummy) {
+		super(t, dummy);
+	}
+
+	@Override
+	public ContainerSerializerBase<?> _withValueTypeSerializer(TypeSerializer vts) {
+		throw new UnsupportedOperationException("not implemented");
+	}
+
+	@Override
+	public void serialize(Object value, JsonGenerator jgen, SerializerProvider provider) throws IOException,
+			JsonGenerationException {
+
+		List list = (List) value;
+
+		if (list.size() == 1) {
+			serializeContents(list.iterator(), jgen, provider);
+			return;
+		}
+		jgen.writeStartArray();
+		serializeContents(list.iterator(), jgen, provider);
+		jgen.writeEndArray();
+	}
+
+	public void serializeContents(Iterator<?> value, JsonGenerator jgen, SerializerProvider provider) throws IOException,
+			JsonGenerationException {
+		if (value.hasNext()) {
+			final TypeSerializer typeSer = null;
+			do {
+				Object elem = value.next();
+				if (elem == null) {
+					provider.defaultSerializeNull(jgen);
+				} else {
+					if (linkSer == null) {
+						linkSer = provider.findValueSerializer(elem.getClass(), _property);
+					}
+					linkSer.serialize(elem, jgen, provider);
+				}
+			} while (value.hasNext());
+		}
+	}
+}

--- a/src/main/java/org/springframework/hateoas/hal/ResourceSupportMixin.java
+++ b/src/main/java/org/springframework/hateoas/hal/ResourceSupportMixin.java
@@ -1,0 +1,23 @@
+package org.springframework.hateoas.hal;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlElement;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.ResourceSupport;
+
+public class ResourceSupportMixin extends ResourceSupport {
+
+	@Override
+	@XmlElement(name = "link")
+	@JsonProperty("_links")
+	@JsonSerialize(include = Inclusion.NON_EMPTY, using = HalLinkListSerializer.class)
+	public List<Link> getLinks() {
+		// TODO Auto-generated method stub
+		return super.getLinks();
+	}
+}

--- a/src/test/java/org/springframework/hateoas/AbstractMarshallingIntegrationTests.java
+++ b/src/test/java/org/springframework/hateoas/AbstractMarshallingIntegrationTests.java
@@ -28,7 +28,7 @@ import org.junit.Before;
  */
 public abstract class AbstractMarshallingIntegrationTests {
 
-	ObjectMapper mapper;
+	protected ObjectMapper mapper;
 
 	@Before
 	public void setUp() {

--- a/src/test/java/org/springframework/hateoas/hal/HalResourceSupportSerialisationUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/hal/HalResourceSupportSerialisationUnitTest.java
@@ -1,0 +1,40 @@
+package org.springframework.hateoas.hal;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.hateoas.AbstractMarshallingIntegrationTests;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.ResourceSupport;
+
+public class HalResourceSupportSerialisationUnitTest extends AbstractMarshallingIntegrationTests {
+
+	static final String SINGLE_LINK_REFERENCE = "{\"_links\":{\"self\":{\"rel\":\"self\",\"href\":\"localhost\"}}}";
+	static final String LIST_LINK_REFERENCE = "{\"_links\":{\"self\":[{\"rel\":\"self\",\"href\":\"localhost\"},{\"rel\":\"self\",\"href\":\"localhost2\"}]}}";
+	static final String SINGLE_EMBEDDED_RESOURCE_REFERENCE = "{\"_embedded\":{\"test\":{}},\"_links\":{\"self\":[{\"rel\":\"self\",\"href\":\"localhost\"},{\"rel\":\"self\",\"href\":\"localhost2\"}]}}";
+	static final String LIST_EMBEDDED_RESOURCE_REFERENCE = "{\"_embedded\":{\"test\":[{},{}]},\"_links\":{\"self\":[{\"rel\":\"self\",\"href\":\"localhost\"},{\"rel\":\"self\",\"href\":\"localhost2\"}]}}";
+
+	@Before
+	public void setUpModule() {
+		mapper.registerModule(new HalJacksonModule());
+	}
+
+	@Test
+	public void rendersSingleLinkAsObject() throws Exception {
+		ResourceSupport resourceSupport = new ResourceSupport();
+		resourceSupport.add(new Link("localhost"));
+
+		assertThat(write(resourceSupport), is(SINGLE_LINK_REFERENCE));
+	}
+
+	@Test
+	public void rendersMultipleLinkAsArray() throws Exception {
+		ResourceSupport resourceSupport = new ResourceSupport();
+		resourceSupport.add(new Link("localhost"));
+		resourceSupport.add(new Link("localhost2"));
+
+		assertThat(write(resourceSupport), is(LIST_LINK_REFERENCE));
+	}
+}


### PR DESCRIPTION
just add the haljacksonmodule to the object mapper. the module adds mixin annotation classes to the object mapper that will overwrite the existing annotations on the classes in case of conflict. The new annotations force usage of custom serializers.

there are two problems with this version:

no support for _embedded: resourceSupport has only one list. there is no place to store those.

xml serialization: the mixin instances contain the correct xml annotations but just like json the configuration to use them will be provider specific
