### PR TITLE
JSON-HAL support for Jackson 1 and Jackson 2

### DIFF
--- a/src/main/java/org/springframework/hateoas/hal/LinkMixin.java
+++ b/src/main/java/org/springframework/hateoas/hal/LinkMixin.java
@@ -1,0 +1,7 @@
+package org.springframework.hateoas.hal;
+
+import org.springframework.hateoas.Link;
+
+public class LinkMixin extends Link {
+
+}

--- a/src/main/java/org/springframework/hateoas/hal/ResourceSupportMixin.java
+++ b/src/main/java/org/springframework/hateoas/hal/ResourceSupportMixin.java
@@ -1,0 +1,19 @@
+package org.springframework.hateoas.hal;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlElement;
+
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.ResourceSupport;
+
+public abstract class ResourceSupportMixin extends ResourceSupport {
+
+	@Override
+	@XmlElement(name = "link")
+	@org.codehaus.jackson.annotate.JsonProperty("_links")
+	@com.fasterxml.jackson.annotation.JsonProperty("_links")
+	@org.codehaus.jackson.map.annotate.JsonSerialize(include = org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_EMPTY, using = org.springframework.hateoas.hal.jackson1.HalLinkListSerializer.class)
+	@com.fasterxml.jackson.databind.annotation.JsonSerialize(include = com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion.NON_EMPTY, using = org.springframework.hateoas.hal.jackson2.HalLinkListSerializer.class)
+	public abstract List<Link> getLinks();
+}

--- a/src/main/java/org/springframework/hateoas/hal/jackson1/HalJackson1Module.java
+++ b/src/main/java/org/springframework/hateoas/hal/jackson1/HalJackson1Module.java
@@ -1,0 +1,19 @@
+package org.springframework.hateoas.hal.jackson1;
+
+import org.codehaus.jackson.Version;
+import org.codehaus.jackson.map.module.SimpleModule;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.ResourceSupport;
+import org.springframework.hateoas.hal.LinkMixin;
+import org.springframework.hateoas.hal.ResourceSupportMixin;
+
+public class HalJackson1Module extends SimpleModule {
+
+	public HalJackson1Module() {
+		super("json-hal-module", new Version(1, 0, 0, null));
+
+		setMixInAnnotation(Link.class, LinkMixin.class);
+		setMixInAnnotation(ResourceSupport.class, ResourceSupportMixin.class);
+	}
+
+}

--- a/src/main/java/org/springframework/hateoas/hal/jackson1/HalLinkListSerializer.java
+++ b/src/main/java/org/springframework/hateoas/hal/jackson1/HalLinkListSerializer.java
@@ -1,0 +1,56 @@
+package org.springframework.hateoas.hal.jackson1;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.codehaus.jackson.JsonGenerationException;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.map.SerializerProvider;
+import org.codehaus.jackson.map.TypeSerializer;
+import org.codehaus.jackson.map.ser.std.ContainerSerializerBase;
+import org.codehaus.jackson.map.ser.std.MapSerializer;
+import org.codehaus.jackson.map.type.TypeFactory;
+import org.codehaus.jackson.type.JavaType;
+import org.springframework.hateoas.Link;
+
+public class HalLinkListSerializer extends ContainerSerializerBase<List<Link>> {
+
+	public HalLinkListSerializer() {
+		super(List.class, false);
+	}
+
+	@Override
+	public void serialize(List<Link> value, JsonGenerator jgen, SerializerProvider provider) throws IOException,
+			JsonGenerationException {
+
+		// sort links according to their relation
+		Map<String, List<Link>> sortedLinks = new HashMap<String, List<Link>>();
+		for (Link link : value) {
+			if (sortedLinks.get(link.getRel()) == null) {
+				sortedLinks.put(link.getRel(), new ArrayList<Link>());
+			}
+			sortedLinks.get(link.getRel()).add(link);
+		}
+
+		TypeFactory typeFactory = provider.getConfig().getTypeFactory();
+		JavaType keyType = typeFactory.uncheckedSimpleType(String.class);
+		JavaType valueType = typeFactory.constructCollectionType(ArrayList.class, Link.class);
+		JavaType mapType = typeFactory.constructMapType(HashMap.class, keyType, valueType);
+
+		MapSerializer serializer = MapSerializer.construct(new String[] {}, mapType, true, null, null,
+				provider.findKeySerializer(keyType, null), new OptionalListSerializer(Link.class, false));
+
+		serializer.serialize(sortedLinks, jgen, provider);
+
+	}
+
+	@Override
+	public ContainerSerializerBase<?> _withValueTypeSerializer(TypeSerializer vts) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/src/main/java/org/springframework/hateoas/hal/jackson1/OptionalListSerializer.java
+++ b/src/main/java/org/springframework/hateoas/hal/jackson1/OptionalListSerializer.java
@@ -1,0 +1,66 @@
+package org.springframework.hateoas.hal.jackson1;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+import org.codehaus.jackson.JsonGenerationException;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.map.BeanProperty;
+import org.codehaus.jackson.map.JsonSerializer;
+import org.codehaus.jackson.map.SerializerProvider;
+import org.codehaus.jackson.map.TypeSerializer;
+import org.codehaus.jackson.map.ser.std.ContainerSerializerBase;
+
+public class OptionalListSerializer extends ContainerSerializerBase<Object> {
+
+	protected JsonSerializer<Object> _elementSerializer;
+	protected BeanProperty _property;
+	private JsonSerializer<Object> linkSer;
+
+	public OptionalListSerializer() {
+		super(List.class, false);
+	}
+
+	public OptionalListSerializer(Class<?> t, boolean dummy) {
+		super(t, dummy);
+	}
+
+	@Override
+	public ContainerSerializerBase<?> _withValueTypeSerializer(TypeSerializer vts) {
+		throw new UnsupportedOperationException("not implemented");
+	}
+
+	@Override
+	public void serialize(Object value, JsonGenerator jgen, SerializerProvider provider) throws IOException,
+			JsonGenerationException {
+
+		List list = (List) value;
+
+		if (list.size() == 1) {
+			serializeContents(list.iterator(), jgen, provider);
+			return;
+		}
+		jgen.writeStartArray();
+		serializeContents(list.iterator(), jgen, provider);
+		jgen.writeEndArray();
+	}
+
+	public void serializeContents(Iterator<?> value, JsonGenerator jgen, SerializerProvider provider) throws IOException,
+			JsonGenerationException {
+		if (value.hasNext()) {
+			final TypeSerializer typeSer = null;
+			do {
+				Object elem = value.next();
+				if (elem == null) {
+					provider.defaultSerializeNull(jgen);
+				} else {
+					if (linkSer == null) {
+						linkSer = provider.findValueSerializer(elem.getClass(), _property);
+					}
+					linkSer.serialize(elem, jgen, provider);
+				}
+			} while (value.hasNext());
+		}
+	}
+}

--- a/src/main/java/org/springframework/hateoas/hal/jackson2/HalJackson2Module.java
+++ b/src/main/java/org/springframework/hateoas/hal/jackson2/HalJackson2Module.java
@@ -1,0 +1,20 @@
+package org.springframework.hateoas.hal.jackson2;
+
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.ResourceSupport;
+import org.springframework.hateoas.hal.LinkMixin;
+import org.springframework.hateoas.hal.ResourceSupportMixin;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class HalJackson2Module extends SimpleModule {
+
+	public HalJackson2Module() {
+		super("json-hal-module", new Version(1, 0, 0, null));
+
+		setMixInAnnotation(Link.class, LinkMixin.class);
+		setMixInAnnotation(ResourceSupport.class, ResourceSupportMixin.class);
+	}
+
+}

--- a/src/main/java/org/springframework/hateoas/hal/jackson2/HalLinkListSerializer.java
+++ b/src/main/java/org/springframework/hateoas/hal/jackson2/HalLinkListSerializer.java
@@ -1,0 +1,93 @@
+package org.springframework.hateoas.hal.jackson2;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.hateoas.Link;
+
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.ser.ContainerSerializer;
+import com.fasterxml.jackson.databind.ser.ContextualSerializer;
+import com.fasterxml.jackson.databind.ser.std.MapSerializer;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+public class HalLinkListSerializer extends ContainerSerializer<List<Link>> implements ContextualSerializer {
+
+	private BeanProperty _property;
+
+	public HalLinkListSerializer() {
+		super(List.class, false);
+	}
+
+	public HalLinkListSerializer(BeanProperty property) {
+		super(List.class, false);
+		this._property = property;
+	}
+
+	@Override
+	public void serialize(List<Link> value, JsonGenerator jgen, SerializerProvider provider) throws IOException,
+			JsonGenerationException {
+
+		// sort links according to their relation
+		Map<String, List<Link>> sortedLinks = new HashMap<String, List<Link>>();
+		for (Link link : value) {
+			if (sortedLinks.get(link.getRel()) == null) {
+				sortedLinks.put(link.getRel(), new ArrayList<Link>());
+			}
+			sortedLinks.get(link.getRel()).add(link);
+		}
+
+		TypeFactory typeFactory = provider.getConfig().getTypeFactory();
+		JavaType keyType = typeFactory.uncheckedSimpleType(String.class);
+		JavaType valueType = typeFactory.constructCollectionType(ArrayList.class, Link.class);
+		JavaType mapType = typeFactory.constructMapType(HashMap.class, keyType, valueType);
+
+		MapSerializer serializer = MapSerializer.construct(new String[] {}, mapType, true, null,
+				provider.findKeySerializer(keyType, null), new OptionalListSerializer(_property));
+
+		serializer.serialize(sortedLinks, jgen, provider);
+	}
+
+	@Override
+	public JsonSerializer<?> createContextual(SerializerProvider provider, BeanProperty property)
+			throws JsonMappingException {
+		return new HalLinkListSerializer(property);
+	}
+
+	@Override
+	public JavaType getContentType() {
+		return null;
+	}
+
+	@Override
+	public JsonSerializer<?> getContentSerializer() {
+		return null;
+	}
+
+	@Override
+	public boolean isEmpty(List<Link> value) {
+		return false;
+	}
+
+	@Override
+	public boolean hasSingleElement(List<Link> value) {
+		return false;
+	}
+
+	@Override
+	protected ContainerSerializer<?> _withValueTypeSerializer(TypeSerializer vts) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/src/main/java/org/springframework/hateoas/hal/jackson2/OptionalListSerializer.java
+++ b/src/main/java/org/springframework/hateoas/hal/jackson2/OptionalListSerializer.java
@@ -1,0 +1,95 @@
+package org.springframework.hateoas.hal.jackson2;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.ser.ContainerSerializer;
+import com.fasterxml.jackson.databind.ser.ContextualSerializer;
+
+public class OptionalListSerializer extends ContainerSerializer<Object> implements ContextualSerializer {
+
+	protected BeanProperty _property;
+	private JsonSerializer<Object> _linkSer;
+
+	public OptionalListSerializer() {
+		super(List.class, false);
+	}
+
+	public OptionalListSerializer(BeanProperty property) {
+		this();
+		_property = property;
+	}
+
+	@Override
+	public ContainerSerializer<?> _withValueTypeSerializer(TypeSerializer vts) {
+		throw new UnsupportedOperationException("not implemented");
+	}
+
+	@Override
+	public void serialize(Object value, JsonGenerator jgen, SerializerProvider provider) throws IOException,
+			JsonGenerationException {
+
+		List list = (List) value;
+
+		if (list.size() == 1) {
+			serializeContents(list.iterator(), jgen, provider);
+			return;
+		}
+		jgen.writeStartArray();
+		serializeContents(list.iterator(), jgen, provider);
+		jgen.writeEndArray();
+	}
+
+	public void serializeContents(Iterator<?> value, JsonGenerator jgen, SerializerProvider provider) throws IOException,
+			JsonGenerationException {
+		if (value.hasNext()) {
+			final TypeSerializer typeSer = null;
+			do {
+				Object elem = value.next();
+				if (elem == null) {
+					provider.defaultSerializeNull(jgen);
+				} else {
+					if (_linkSer == null) {
+						_linkSer = provider.findValueSerializer(elem.getClass(), _property);
+					}
+					_linkSer.serialize(elem, jgen, provider);
+				}
+			} while (value.hasNext());
+		}
+	}
+
+	@Override
+	public JsonSerializer<?> getContentSerializer() {
+		return _linkSer;
+	}
+
+	@Override
+	public JavaType getContentType() {
+		return null;
+	}
+
+	@Override
+	public boolean hasSingleElement(Object arg0) {
+		return false;
+	}
+
+	@Override
+	public boolean isEmpty(Object arg0) {
+		return false;
+	}
+
+	@Override
+	public JsonSerializer<?> createContextual(SerializerProvider provider, BeanProperty property)
+			throws JsonMappingException {
+		return new OptionalListSerializer(property);
+	}
+}

--- a/src/test/java/org/springframework/hateoas/AbstractJackson2MarshallingIntegrationTests.java
+++ b/src/test/java/org/springframework/hateoas/AbstractJackson2MarshallingIntegrationTests.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public abstract class AbstractJackson2MarshallingIntegrationTests {
 
-	ObjectMapper mapper;
+	protected ObjectMapper mapper;
 
 	@Before
 	public void setUp() {

--- a/src/test/java/org/springframework/hateoas/AbstractMarshallingIntegrationTests.java
+++ b/src/test/java/org/springframework/hateoas/AbstractMarshallingIntegrationTests.java
@@ -28,7 +28,7 @@ import org.junit.Before;
  */
 public abstract class AbstractMarshallingIntegrationTests {
 
-	ObjectMapper mapper;
+	protected ObjectMapper mapper;
 
 	@Before
 	public void setUp() {

--- a/src/test/java/org/springframework/hateoas/hal/HalResourceSupportJackson1SerialisationUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/hal/HalResourceSupportJackson1SerialisationUnitTest.java
@@ -1,0 +1,41 @@
+package org.springframework.hateoas.hal;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.hateoas.AbstractJackson2MarshallingIntegrationTests;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.ResourceSupport;
+import org.springframework.hateoas.hal.jackson2.HalJackson2Module;
+
+public class HalResourceSupportJackson1SerialisationUnitTest extends AbstractJackson2MarshallingIntegrationTests {
+
+	static final String SINGLE_LINK_REFERENCE = "{\"_links\":{\"self\":{\"rel\":\"self\",\"href\":\"localhost\"}}}";
+	static final String LIST_LINK_REFERENCE = "{\"_links\":{\"self\":[{\"rel\":\"self\",\"href\":\"localhost\"},{\"rel\":\"self\",\"href\":\"localhost2\"}]}}";
+	static final String SINGLE_EMBEDDED_RESOURCE_REFERENCE = "{\"_embedded\":{\"test\":{}},\"_links\":{\"self\":[{\"rel\":\"self\",\"href\":\"localhost\"},{\"rel\":\"self\",\"href\":\"localhost2\"}]}}";
+	static final String LIST_EMBEDDED_RESOURCE_REFERENCE = "{\"_embedded\":{\"test\":[{},{}]},\"_links\":{\"self\":[{\"rel\":\"self\",\"href\":\"localhost\"},{\"rel\":\"self\",\"href\":\"localhost2\"}]}}";
+
+	@Before
+	public void setUpModule() {
+		mapper.registerModule(new HalJackson2Module());
+	}
+
+	@Test
+	public void rendersSingleLinkAsObject() throws Exception {
+		ResourceSupport resourceSupport = new ResourceSupport();
+		resourceSupport.add(new Link("localhost"));
+
+		assertThat(write(resourceSupport), is(SINGLE_LINK_REFERENCE));
+	}
+
+	@Test
+	public void rendersMultipleLinkAsArray() throws Exception {
+		ResourceSupport resourceSupport = new ResourceSupport();
+		resourceSupport.add(new Link("localhost"));
+		resourceSupport.add(new Link("localhost2"));
+
+		assertThat(write(resourceSupport), is(LIST_LINK_REFERENCE));
+	}
+}

--- a/src/test/java/org/springframework/hateoas/hal/HalResourceSupportJackson2SerialisationUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/hal/HalResourceSupportJackson2SerialisationUnitTest.java
@@ -1,0 +1,41 @@
+package org.springframework.hateoas.hal;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.hateoas.AbstractMarshallingIntegrationTests;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.ResourceSupport;
+import org.springframework.hateoas.hal.jackson1.HalJackson1Module;
+
+public class HalResourceSupportJackson2SerialisationUnitTest extends AbstractMarshallingIntegrationTests {
+
+	static final String SINGLE_LINK_REFERENCE = "{\"_links\":{\"self\":{\"rel\":\"self\",\"href\":\"localhost\"}}}";
+	static final String LIST_LINK_REFERENCE = "{\"_links\":{\"self\":[{\"rel\":\"self\",\"href\":\"localhost\"},{\"rel\":\"self\",\"href\":\"localhost2\"}]}}";
+	static final String SINGLE_EMBEDDED_RESOURCE_REFERENCE = "{\"_embedded\":{\"test\":{}},\"_links\":{\"self\":[{\"rel\":\"self\",\"href\":\"localhost\"},{\"rel\":\"self\",\"href\":\"localhost2\"}]}}";
+	static final String LIST_EMBEDDED_RESOURCE_REFERENCE = "{\"_embedded\":{\"test\":[{},{}]},\"_links\":{\"self\":[{\"rel\":\"self\",\"href\":\"localhost\"},{\"rel\":\"self\",\"href\":\"localhost2\"}]}}";
+
+	@Before
+	public void setUpModule() {
+		mapper.registerModule(new HalJackson1Module());
+	}
+
+	@Test
+	public void rendersSingleLinkAsObject() throws Exception {
+		ResourceSupport resourceSupport = new ResourceSupport();
+		resourceSupport.add(new Link("localhost"));
+
+		assertThat(write(resourceSupport), is(SINGLE_LINK_REFERENCE));
+	}
+
+	@Test
+	public void rendersMultipleLinkAsArray() throws Exception {
+		ResourceSupport resourceSupport = new ResourceSupport();
+		resourceSupport.add(new Link("localhost"));
+		resourceSupport.add(new Link("localhost2"));
+
+		assertThat(write(resourceSupport), is(LIST_LINK_REFERENCE));
+	}
+}


### PR DESCRIPTION
All in one commit.
- added jackson 1 and 2 mixins and serializers to create json-hal out of
  links
- changed visibility of of the mapper in test classes
- added simple serialization test
