### PR TITLE
Fixed problem with Controllers having a path parameter on the class mapp...

### DIFF
--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilderFactory.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilderFactory.java
@@ -63,7 +63,7 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 	/**
 	 * Configures the {@link UriComponentsContributor} to be used when building {@link Link} instances from method
 	 * invocations.
-	 * 
+	 *
 	 * @see #linkTo(Object)
 	 * @param uriComponentsContributors the uriComponentsContributors to set
 	 */
@@ -89,7 +89,7 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 		return ControllerLinkBuilder.linkTo(controller, parameters);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.hateoas.MethodLinkBuilderFactory#linkTo(java.lang.Object)
 	 */
@@ -109,10 +109,10 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 		UriTemplate template = new UriTemplate(mapping);
 		Map<String, Object> values = new HashMap<String, Object>();
 
-		if (classMappingParameters.hasNext()) {
-			for (String variable : template.getVariableNames()) {
-				values.put(variable, classMappingParameters.next());
-			}
+		Iterator<String> names = template.getVariableNames().iterator();
+		while (classMappingParameters.hasNext()) {
+			String variable = names.next();
+			values.put(variable, classMappingParameters.next());
 		}
 
 		for (BoundMethodParameter parameter : PATH_VARIABLE_ACCESSOR.getBoundParameters(invocation)) {
@@ -137,7 +137,7 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 		return new ControllerLinkBuilder(UriComponentsBuilder.fromUri(components.toUri()));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.hateoas.MethodLinkBuilderFactory#linkTo(java.lang.reflect.Method, java.lang.Object[])
 	 */
@@ -148,7 +148,7 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 
 	/**
 	 * Applies the configured {@link UriComponentsContributor}s to the given {@link UriComponentsBuilder}.
-	 * 
+	 *
 	 * @param builder will never be {@literal null}.
 	 * @param invocation will never be {@literal null}.
 	 * @return

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
@@ -28,11 +28,14 @@ import org.mockito.Mockito;
 import org.springframework.hateoas.Identifiable;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.TestUtils;
+import org.springframework.hateoas.action.ActionDescriptor;
+import org.springframework.hateoas.mvc.ControllerActionBuilderTest.PersonControllerForForm;
 import org.springframework.http.HttpEntity;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -58,6 +61,14 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		Link link = linkTo(PersonsAddressesController.class, 15).withSelfRel();
 		assertThat(link.getRel(), is(Link.REL_SELF));
 		assertThat(link.getHref(), endsWith("/people/15/addresses"));
+	}
+
+	@Test
+	public void createsLinkToMethodOnParameterizedControllerRoot() {
+
+		Link link = linkTo(methodOn(PersonsAddressesController.class, 15).getAddressesForCountry("DE")).withSelfRel();
+		assertThat(link.getRel(), is(Link.REL_SELF));
+		assertThat(link.getHref(), endsWith("/people/15/addresses/DE"));
 	}
 
 	@Test
@@ -218,8 +229,12 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 	}
 
 	@RequestMapping("/people/{id}/addresses")
-	class PersonsAddressesController {
+	public static class PersonsAddressesController {
 
+		@RequestMapping("/{country}")
+		public HttpEntity<Void> getAddressesForCountry(@PathVariable String country) {
+			return null;
+		}
 	}
 
 	@RequestMapping({ "/persons", "/people" })
@@ -256,4 +271,5 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 			return null;
 		}
 	}
+
 }


### PR DESCRIPTION
For a controller that has a path variable in the class-level RequestMapping _and_ uses a path variable for a method it was not possible to link to the method

```
linkTo(methodOn(ControllerWithClassMappingVariable.class, "bar").getFoo("baz") ;
```

so that the resulting path would correctly contain the substituted variables bar and baz.

See test and solution in the pull request.
