### PR TITLE
Fixed classcast exception as a result of AnnotationMethodHandlerAdapter ...

### DIFF
--- a/src/main/java/org/springframework/hateoas/config/HypermediaSupportBeanDefinitionRegistrar.java
+++ b/src/main/java/org/springframework/hateoas/config/HypermediaSupportBeanDefinitionRegistrar.java
@@ -19,6 +19,7 @@ import static org.springframework.beans.factory.support.BeanDefinitionReaderUtil
 
 import java.util.List;
 import java.util.Map;
+import java.util.Arrays;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
@@ -201,7 +202,7 @@ class HypermediaSupportBeanDefinitionRegistrar implements ImportBeanDefinitionRe
 			}
 
 			if (bean instanceof AnnotationMethodHandlerAdapter) {
-				registerModule(((AnnotationMethodHandlerAdapter) bean).getMessageConverters());
+				registerModule(Arrays.asList(((AnnotationMethodHandlerAdapter) bean).getMessageConverters()));
 			}
 
 			if (bean instanceof ObjectMapper) {
@@ -265,14 +266,14 @@ class HypermediaSupportBeanDefinitionRegistrar implements ImportBeanDefinitionRe
 		@Override
 		public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
 
-			if (bean instanceof AnnotationMethodHandlerAdapter) {
-				registerModule(((AnnotationMethodHandlerAdapter) bean).getMessageConverters());
-			}
-
 			if (bean instanceof RequestMappingHandlerAdapter) {
 				registerModule(((RequestMappingHandlerAdapter) bean).getMessageConverters());
 			}
 
+			if (bean instanceof AnnotationMethodHandlerAdapter) {
+				registerModule(Arrays.asList(((AnnotationMethodHandlerAdapter) bean).getMessageConverters()));
+			}
+			
 			if (bean instanceof org.codehaus.jackson.map.ObjectMapper) {
 				registerModule(bean);
 			}


### PR DESCRIPTION
...returning an array of HttpMessageConverters, not a List

With an AnnotationMethodHandlerAdapter I run into a classcastException which says that a message converter cannot be cast to an ObjectMapper.
The reason is that AnnotationMethodHandlerAdapter returns an array for getMessageConverters and the overloaded registerModule(Object) kicks in.
