### PR TITLE
Add type and title properties to Link class

### DIFF
--- a/src/main/java/org/springframework/hateoas/Link.java
+++ b/src/main/java/org/springframework/hateoas/Link.java
@@ -26,6 +26,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -34,118 +35,40 @@ import org.springframework.util.StringUtils;
  * @author Oliver Gierke
  */
 @XmlType(name = "link", namespace = Link.ATOM_NAMESPACE)
-public class Link implements Serializable
-{
+public class Link implements Serializable {
 
 	private static final long serialVersionUID = -9037755944661782121L;
+	private static final String ATOM_LINK_SPEC_URL = "http://tools.ietf.org/html/rfc4287#section-4.2.7";
+	private static Pattern ATOM_MEDIA_TYPE_PATTERN = Pattern.compile(".+/.+");
+	// private static final String ATOM_LINK_HREF = "href";
+	private static final String ATOM_LINK_REL = "rel";
+	private static final String ATOM_LINK_TITLE = "title";
+	private static final String ATOM_LINK_TYPE = "type";
 
 	public static final String ATOM_NAMESPACE = "http://www.w3.org/2005/Atom";
-	// see: http://tools.ietf.org/html/rfc4287#section-4.2.7
-
 	public static final String REL_SELF = "self";
 	public static final String REL_FIRST = "first";
 	public static final String REL_PREVIOUS = "prev";
 	public static final String REL_NEXT = "next";
 	public static final String REL_LAST = "last";
 
-	/**
-	 * Parses the links attributes from the given source {@link String}.
-	 * 
-	 * @param source
-	 * @return
-	 */
-	private static Map<String, String> getAttributeMap(String source)
-	{
-
-		if (!StringUtils.hasText(source))
-		{
-			return Collections.emptyMap();
-		}
-
-		Map<String, String> attributes = new HashMap<String, String>();
-		Pattern keyAndValue = Pattern.compile("(\\w+)=\\\"(\\p{Alnum}*)\"");
-		Matcher matcher = keyAndValue.matcher(source);
-
-		while (matcher.find())
-		{
-			attributes.put(matcher.group(1), matcher.group(2));
-		}
-
-		return attributes;
-	}
-
-	/**
-	 * Factory method to easily create {@link Link} instances from RFC-5988
-	 * compatible {@link String} representations of a link. Will return
-	 * {@literal null} if an empty or {@literal null} {@link String} is given.
-	 * 
-	 * @param element
-	 *          an RFC-5899 compatible representation of a link.
-	 * @throws IllegalArgumentException
-	 *           if a non-empty {@link String} was given that does not adhere to
-	 *           RFC-5899.
-	 * @throws IllegalArgumentException
-	 *           if no {@code rel} attribute could be found.
-	 * @return
-	 */
-	public static Link valueOf(String element)
-	{
-
-		if (!StringUtils.hasText(element))
-		{
-			return null;
-		}
-
-		Pattern uriAndAttributes = Pattern.compile("<(.*)>;(.*)");
-		Matcher matcher = uriAndAttributes.matcher(element);
-
-		if (matcher.find())
-		{
-
-			Map<String, String> attributes = getAttributeMap(matcher.group(2));
-
-			if (!attributes.containsKey("rel"))
-			{
-				throw new IllegalArgumentException("Link does not provide a rel attribute!");
-			}
-
-			return new Link(matcher.group(1), attributes.get("rel"));
-
-		}
-		else
-		{
-			throw new IllegalArgumentException(String.format("Given link header %s is not RFC5988 compliant!", element));
-		}
-	}
-
 	@XmlAttribute
 	private String rel;
 	@XmlAttribute
 	private String href;
-
-	@XmlAttribute
-	private String type; // should contain at least 1 '/'
-
 	@XmlAttribute
 	private String title;
-
-	/**
-	 * Empty constructor required by the marshalling framework.
-	 */
-	protected Link()
-	{
-
-	}
+	@XmlAttribute
+	private String type;
 
 	/**
 	 * Creates a new link to the given URI with the self rel.
 	 * 
 	 * @see #REL_SELF
 	 * @param href
-	 *          must not be {@literal null} or empty.
+	 *            must not be {@literal null} or empty.
 	 */
-	public Link(String href)
-	{
+	public Link(String href) {
 		this(href, REL_SELF);
 	}
 
@@ -153,43 +76,55 @@ public class Link implements Serializable
 	 * Creates a new {@link Link} to the given URI with the given rel.
 	 * 
 	 * @param href
-	 *          must not be {@literal null} or empty.
+	 *            must not be {@literal null} or empty.
 	 * @param rel
-	 *          must not be {@literal null} or empty.
+	 *            must not be {@literal null} or empty.
 	 */
-	public Link(String href, String rel)
-	{
+	public Link(String href, String rel) {
+		this(href, rel, null, null);
+	}
+
+	/**
+	 * Creates a new {@link Link} to the given URI with the given rel.
+	 * 
+	 * @param href
+	 *            must not be {@literal null} or empty.
+	 * @param rel
+	 *            must not be {@literal null} or empty.
+	 * @param title
+	 *            may be {@literal null} or empty.
+	 * @param type
+	 *            may be {@literal null} or empty.
+	 */
+	public Link(String href, String rel, String title, String type) {
 
 		Assert.hasText(href, "Href must not be null or empty!");
 		Assert.hasText(rel, "Rel must not be null or empty!");
+		Assert.isTrue((title == null) || StringUtils.hasText(title), "Title must not be empty!");
+		Assert.isTrue((type == null) || isAtomMediaType(type), "Type must be valid atom media type! (see " + ATOM_LINK_SPEC_URL + ")");
 
 		this.href = href;
 		this.rel = rel;
+		this.title = title;
+		this.type = type;
 	}
 
-	/*
-	 * (non-Javadoc)
+	/**
+	 * returns check whether passed string is valid atom media type per
+	 * {@value #ATOM_LINK_SPEC_URL}
 	 * 
-	 * @see java.lang.Object#equals(java.lang.Object)
+	 * @param type
+	 * @return
 	 */
-	@Override
-	public boolean equals(Object obj)
-	{
+	private boolean isAtomMediaType(String type) {
+		return ATOM_MEDIA_TYPE_PATTERN.matcher(type).matches();
+	}
 
-		if (this == obj)
-		{
-			return true;
-		}
+	/**
+	 * Empty constructor required by the marshalling framework.
+	 */
+	protected Link() {
 
-		if (!(obj instanceof Link))
-		{
-			return false;
-		}
-
-		Link that = (Link) obj;
-
-		return this.href.equals(that.href) && this.rel.equals(that.rel) && this.title.equals(that.title)
-				&& this.type.equals(that.type);
 	}
 
 	/**
@@ -197,8 +132,7 @@ public class Link implements Serializable
 	 * 
 	 * @return
 	 */
-	public String getHref()
-	{
+	public String getHref() {
 		return href;
 	}
 
@@ -207,57 +141,26 @@ public class Link implements Serializable
 	 * 
 	 * @return
 	 */
-	public String getRel()
-	{
+	public String getRel() {
 		return rel;
 	}
 
-	public String getTitle()
-	{
+	/**
+	 * Returns the title of the link (may be null)
+	 * 
+	 * @return
+	 */
+	public String getTitle() {
 		return title;
 	}
 
-	public String getType()
-	{
+	/**
+	 * Returns the type of the link (may be null)
+	 * 
+	 * @return
+	 */
+	public String getType() {
 		return type;
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see java.lang.Object#hashCode()
-	 */
-	@Override
-	public int hashCode()
-	{
-
-		int result = 17;
-		result += 31 * href.hashCode();
-		result += 31 * rel.hashCode();
-		result += 31 * title.hashCode();
-		result += 31 * type.hashCode();
-		return result;
-	}
-
-	public void setTitle(String title)
-	{
-		this.title = title;
-	}
-
-	public void setType(String type)
-	{
-		this.type = type;
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString()
-	{
-		return String.format("<%s>;rel=\"%s\"", href, rel);
 	}
 
 	/**
@@ -265,11 +168,10 @@ public class Link implements Serializable
 	 * relation.
 	 * 
 	 * @param rel
-	 *          must not be {@literal null} or empty.
+	 *            must not be {@literal null} or empty.
 	 * @return
 	 */
-	public Link withRel(String rel)
-	{
+	public Link withRel(String rel) {
 		return new Link(href, rel);
 	}
 
@@ -279,34 +181,152 @@ public class Link implements Serializable
 	 * 
 	 * @return
 	 */
-	public Link withSelfRel()
-	{
+	public Link withSelfRel() {
 		return withRel(Link.REL_SELF);
 	}
 
 	/**
-	 * Returns this {@link Link} with title
+	 * Returns a {@link Link} based on current Link, but with given title
 	 * 
 	 * @param title
-	 *          must not be {@literal null} or empty.
+	 *            may be {@literal null} or non-empty.
 	 * @return
 	 */
-	public Link withTitle(String title)
-	{
-		this.setTitle(title);
-		return this;
+	public Link withTitle(String title) {
+		return new Link(href, rel, title, type);
 	}
 
 	/**
-	 * Returns this {@link Link} with type
+	 * Returns a {@link Link} based on current Link, but with given title
 	 * 
 	 * @param type
-	 *          must not be {@literal null} or empty.
+	 *            may be {@literal null} or valid atom media type per
+	 *            {@value #ATOM_LINK_SPEC_URL}
 	 * @return
 	 */
-	public Link withType(String type)
-	{
-		this.setType(type);
-		return this;
+	public Link withType(String type) {
+		return new Link(href, rel, title, type);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+
+		if (this == obj) {
+			return true;
+		}
+
+		if (!(obj instanceof Link)) {
+			return false;
+		}
+
+		Link that = (Link) obj;
+
+		return this.href.equals(that.href) && this.rel.equals(that.rel) && ObjectUtils.nullSafeEquals(this.title, that.title)
+				&& ObjectUtils.nullSafeEquals(this.type, that.type);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see java.lang.Object#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		
+		int result = 17;
+		result += 31 * href.hashCode();
+		result += 31 * rel.hashCode();
+		result += 31 * ObjectUtils.nullSafeHashCode(title);
+		result += 31 * ObjectUtils.nullSafeHashCode(type);
+		return result;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		String result = String.format("<%s>;%s=\"%s\"", href, ATOM_LINK_REL, rel);
+		if (title != null) {
+			result += String.format("%s;%s=\"%s\"", result, ATOM_LINK_TITLE, title);
+		}
+		if (type != null) {
+			result += String.format("%s;%s=\"%s\"", result, ATOM_LINK_TYPE, type);
+		}
+		return result;
+	}
+
+	/**
+	 * Factory method to easily create {@link Link} instances from RFC-5988
+	 * compatible {@link String} representations of a link. Will return
+	 * {@literal null} if an empty or {@literal null} {@link String} is given.
+	 * 
+	 * @param element
+	 *            an RFC-5988 compatible representation of a link.
+	 * @throws IllegalArgumentException
+	 *             if a non-empty {@link String} was given that does not adhere
+	 *             to RFC-5988.
+	 * @throws IllegalArgumentException
+	 *             if no {@code rel} attribute could be found.
+	 * @return
+	 */
+	public static Link valueOf(String element) {
+
+		if (!StringUtils.hasText(element)) {
+			return null;
+		}
+
+		Pattern uriAndAttributes = Pattern.compile("<(.*)>;(.*)");
+		Matcher matcher = uriAndAttributes.matcher(element);
+
+		if (matcher.find()) {
+
+			Map<String, String> attributes = getAttributeMap(matcher.group(2));
+
+			if (!attributes.containsKey(ATOM_LINK_REL)) {
+				throw new IllegalArgumentException("Link does not provide a rel attribute!");
+			}
+
+			return new Link(matcher.group(1), attributes.get(ATOM_LINK_REL), attributes.get(ATOM_LINK_TITLE), attributes.get(ATOM_LINK_TYPE));
+
+		} else {
+			throw new IllegalArgumentException(String.format("Given link header %s is not RFC5988 compliant!", element));
+		}
+	}
+
+	/**
+	 * Parses the links attributes from the given source {@link String}.
+	 * 
+	 * @param source
+	 * @return
+	 */
+	private static Map<String, String> getAttributeMap(String source) {
+
+		if (!StringUtils.hasText(source)) {
+			return Collections.emptyMap();
+		}
+
+		Map<String, String> attributes = new HashMap<String, String>();
+		Pattern keyAndValue = Pattern.compile("(\\w+)=\\\"(\\p{Print}*)\"");
+		String[] keyAndValues = source.split(";");
+		for (int i = 0; i < keyAndValues.length; i++) {
+
+			Matcher matcher = keyAndValue.matcher(keyAndValues[i]);
+
+			if (matcher.find()) {
+				attributes.put(matcher.group(1), matcher.group(2));
+			} else {
+				throw new RuntimeException(String.format("unexpected token found parsing link attributes [%s]", keyAndValues[i]));
+			}
+		}
+
+		return attributes;
 	}
 }

--- a/src/test/java/org/springframework/hateoas/AbstractJackson2MarshallingIntegrationTests.java
+++ b/src/test/java/org/springframework/hateoas/AbstractJackson2MarshallingIntegrationTests.java
@@ -5,6 +5,7 @@ import java.io.Writer;
 
 import org.junit.Before;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -20,6 +21,7 @@ public abstract class AbstractJackson2MarshallingIntegrationTests {
 	@Before
 	public void setUp() {
 		mapper = new ObjectMapper();
+		mapper.setSerializationInclusion(Include.NON_NULL);
 	}
 
 	protected String write(Object object) throws Exception {

--- a/src/test/java/org/springframework/hateoas/AbstractMarshallingIntegrationTests.java
+++ b/src/test/java/org/springframework/hateoas/AbstractMarshallingIntegrationTests.java
@@ -19,6 +19,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 
 import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.SerializationConfig;
 import org.junit.Before;
 
 /**
@@ -33,6 +34,8 @@ public abstract class AbstractMarshallingIntegrationTests {
 	@Before
 	public void setUp() {
 		mapper = new ObjectMapper();
+		mapper.configure(SerializationConfig.Feature.WRITE_NULL_PROPERTIES, false);
+		//mapper.getSerializationConfig().withSerializationInclusion(JsonSerialize.Inclusion.NON_EMPTY);
 	}
 
 	protected String write(Object object) throws Exception {

--- a/src/test/java/org/springframework/hateoas/LinkUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/LinkUnitTest.java
@@ -103,7 +103,14 @@ public class LinkUnitTest {
 	public void parsesRFC5988HeaderIntoLink() {
 
 		assertThat(Link.valueOf("</something>;rel=\"foo\""), is(new Link("/something", "foo")));
-		assertThat(Link.valueOf("</something>;rel=\"foo\";title=\"Some title\""), is(new Link("/something", "foo")));
+		assertThat(Link.valueOf("</something>;rel=\"foo\";title=\"Some title\""), is(new Link("/something", "foo", "Some title", null)));
+		assertThat(Link.valueOf("</something>;rel=\"foo\";title=\"Some title\";type=\"application/json\""), is(new Link("/something", "foo",
+				"Some title", "application/json")));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void disallowsInvalidAtomMediaType() {
+		new Link("/foo-href", "foo-rel", "foo-title", "foo-type");
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/src/test/java/org/springframework/hateoas/VndErrorsMarshallingTests.java
+++ b/src/test/java/org/springframework/hateoas/VndErrorsMarshallingTests.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.hateoas;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -30,6 +30,7 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Marshaller;
 
 import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.SerializationConfig;
 import org.codehaus.jackson.map.SerializationConfig.Feature;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,6 +39,7 @@ import org.springframework.hateoas.VndErrors.VndError;
 import org.springframework.hateoas.hal.Jackson1HalModule;
 import org.springframework.hateoas.hal.Jackson2HalModule;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
 /**
@@ -61,17 +63,21 @@ public class VndErrorsMarshallingTests {
 		xmlReference = readFile(new ClassPathResource("vnderror.xml"));
 	}
 
+	@SuppressWarnings("deprecation")
 	@Before
 	public void setUp() throws Exception {
 
 		jackson1Mapper = new ObjectMapper();
 		jackson1Mapper.registerModule(new Jackson1HalModule());
 		jackson1Mapper.configure(Feature.INDENT_OUTPUT, true);
-
+		//jackson1Mapper.getSerializationConfig().withSerializationInclusion(JsonSerialize.Inclusion.NON_EMPTY);
+		jackson1Mapper.configure(SerializationConfig.Feature.WRITE_NULL_PROPERTIES, false);
+		
 		jackson2Mapper = new com.fasterxml.jackson.databind.ObjectMapper();
 		jackson2Mapper.registerModule(new Jackson2HalModule());
 		jackson2Mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
-
+		jackson2Mapper.setSerializationInclusion(Include.NON_NULL);
+		
 		JAXBContext context = JAXBContext.newInstance(VndErrors.class);
 		marshaller = context.createMarshaller();
 


### PR DESCRIPTION
Simple proposal for change to allow type and title properties to Link class, of course, on board with any alternate which allows for same end result. The following example set values for new 'title' property of Link:

``` json
[ {
  "links" : [ {
    "rel" : "self",
    "href" : "http://localhost:8080/acme-widget-hateoas-web-api/widgets/1"
  } ],
  "name" : "widget-0",
  "whatsitLinks" : [ {
    "rel" : "whatsit",
    "href" : "http://localhost:8080/acme-widget-hateoas-web-api/whatsits/1",
    "title" : "whatsit-0-0"
  }, {
    "rel" : "whatsit",
    "href" : "http://localhost:8080/acme-widget-hateoas-web-api/whatsits/2",
    "title" : "whatsit-0-1"
  } ]
}, {
  "links" : [ {
    "rel" : "self",
    "href" : "http://localhost:8080/acme-widget-hateoas-web-api/widgets/2"
  } ],
  "name" : "widget-1",
  "whatsitLinks" : [ {
    "rel" : "whatsit",
    "href" : "http://localhost:8080/acme-widget-hateoas-web-api/whatsits/3",
    "title" : "whatsit-1-0"
  }, {
    "rel" : "whatsit",
    "href" : "http://localhost:8080/acme-widget-hateoas-web-api/whatsits/4",
    "title" : "whatsit-1-1"
  } ]
}, {
  "links" : [ {
    "rel" : "self",
    "href" : "http://localhost:8080/acme-widget-hateoas-web-api/widgets/3"
  } ],
  "name" : "widget-2",
  "whatsitLinks" : [ {
    "rel" : "whatsit",
    "href" : "http://localhost:8080/acme-widget-hateoas-web-api/whatsits/5",
    "title" : "whatsit-2-0"
  }, {
    "rel" : "whatsit",
    "href" : "http://localhost:8080/acme-widget-hateoas-web-api/whatsits/6",
    "title" : "whatsit-2-1"
  } ]
} ]
```