### PR TITLE
Added support for X-Forwarded-Ssl header during link construction.

### DIFF
--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
@@ -158,7 +158,8 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 
 	/**
 	 * Returns a {@link UriComponentsBuilder} obtained from the current servlet mapping with the host tweaked in case the
-	 * request contains an {@code X-Forwarded-Host} header.
+	 * request contains an {@code X-Forwarded-Host} header and the scheme tweaked in case the request contains an
+     * {@code X-Forwarded-Ssl} header
 	 * 
 	 * @return
 	 */
@@ -166,6 +167,12 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 
 		HttpServletRequest request = getCurrentRequest();
 		ServletUriComponentsBuilder builder = ServletUriComponentsBuilder.fromServletMapping(request);
+
+        String forwardedSsl = request.getHeader("X-Forwarded-Ssl");
+
+        if(StringUtils.hasText(forwardedSsl) && forwardedSsl.equalsIgnoreCase("on")) {
+            builder.scheme("https");
+        }
 
 		String header = request.getHeader("X-Forwarded-Host");
 

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
@@ -149,6 +149,34 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		assertThat(link.getHref(), startsWith("http://somethingDifferent"));
 	}
 
+    @Test
+    public void usesForwardedSslIfHeaderIsSet() {
+
+        request.addHeader("X-Forwarded-Ssl", "on");
+
+        Link link = linkTo(PersonControllerImpl.class).withSelfRel();
+        assertThat(link.getHref(), startsWith("https://"));
+    }
+
+    @Test
+    public void usesForwardedSslIfHeaderIsSetOff() {
+
+        request.addHeader("X-Forwarded-Ssl", "off");
+
+        Link link = linkTo(PersonControllerImpl.class).withSelfRel();
+        assertThat(link.getHref(), startsWith("http://"));
+    }
+
+    @Test
+    public void usesForwardedSslAndHostIfHeaderIsSet() {
+
+        request.addHeader("X-Forwarded-Host", "somethingDifferent");
+        request.addHeader("X-Forwarded-Ssl", "on");
+
+        Link link = linkTo(PersonControllerImpl.class).withSelfRel();
+        assertThat(link.getHref(), startsWith("https://somethingDifferent"));
+    }
+
 	/**
 	 * @see #26, #39
 	 */


### PR DESCRIPTION
I figure other people using a load balancer that is configured to send them X-Forwarded-Ssl might benefit from having this supported in the ControllerLinkBuilder much the same way the X-Forwarded-Host is supported. Unless there is another suggested way to do this using X-Forwarded-Host?
