### PR TITLE
Proxy header detection should honor X-Forwarded-Port.

### DIFF
--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
@@ -174,13 +174,13 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 			builder.scheme("https");
 		}
 
-		String header = request.getHeader("X-Forwarded-Host");
+		String host = request.getHeader("X-Forwarded-Host");
 
-		if (!StringUtils.hasText(header)) {
+		if (!StringUtils.hasText(host)) {
 			return builder;
 		}
 
-		String[] hosts = StringUtils.commaDelimitedListToStringArray(header);
+		String[] hosts = StringUtils.commaDelimitedListToStringArray(host);
 		String hostToUse = hosts[0];
 
 		if (hostToUse.contains(":")) {
@@ -192,6 +192,12 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 
 		} else {
 			builder.host(hostToUse);
+			builder.port(-1); // reset port if it was forwarded from default port
+		}
+		
+		String port = request.getHeader("X-Forwarded-Port");
+		if (StringUtils.hasText(port)) {
+			builder.port(Integer.parseInt(port));
 		}
 
 		return builder;

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
@@ -29,6 +29,7 @@ import org.springframework.hateoas.Identifiable;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.TestUtils;
 import org.springframework.http.HttpEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -269,6 +270,30 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		assertThat(link.getHref(), startsWith("http://barfoo:8888"));
 	}
 
+	@Test
+	public void usesForwardedPortFromHeader() {
+
+		// Request is forwarded from "http://foobarhost:9090/*" to "http://internal:8080/*"
+		// and "X-Forwarded-Port" is set instead of padding "X-Forwarded-Host"
+		request.addHeader("X-Forwarded-Host", "foobarhost");
+		request.addHeader("X-Forwarded-Port", "9090");
+		((MockHttpServletRequest)request).setServerPort(8080);
+
+		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
+		assertThat(link.getHref(), startsWith("http://foobarhost:9090/"));
+	}
+	
+	@Test
+	public void usesForwardedHostFromHeaderWithDefaultPort() {
+
+		// Request is forwarded from "http://foobarhost/*" to "http://internal:8080/*"
+		request.addHeader("X-Forwarded-Host", "foobarhost");
+		((MockHttpServletRequest)request).setServerPort(8080);
+
+		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
+		assertThat(link.getHref(), startsWith("http://foobarhost/"));
+	}
+	
 	/**
 	 * @see #122
 	 */


### PR DESCRIPTION
A common situation is that external proxy listens to default ports (HTTP - 80, HTTPS - 443), but forwards request to internal services running on custom ports.

For example: https://example.com/* is forwarded to http://internal.ip:8080/*

Usually "X-Forwarded-Host" header in this case will refer to "example.com", and current logic will generate invalid external resource URLs as: https://example.com:8080/* (if "X-Forwarded-Ssl" is set to "on").

This patch will reset the port in URI builder if "X-Forwarded-Host" does not contain port information.
It also provides support for "X-Forwarded-Port" header in case of more complex scenarios.
