### PR TITLE
#187: Traverson correctly applies headers when using JsonPath to evaluat...

### DIFF
--- a/src/main/java/org/springframework/hateoas/client/Traverson.java
+++ b/src/main/java/org/springframework/hateoas/client/Traverson.java
@@ -226,7 +226,7 @@ public class Traverson {
 
 			Assert.hasText(jsonPath, "JSON path must not be null or empty!");
 
-			String forObject = template.getForObject(traverseToFinalUrl(), String.class);
+			String forObject = template.exchange(traverseToFinalUrl(), GET, prepareRequest(headers), String.class).getBody();
 			return JsonPath.read(forObject, jsonPath);
 		}
 

--- a/src/test/java/org/springframework/hateoas/client/TraversonTests.java
+++ b/src/test/java/org/springframework/hateoas/client/TraversonTests.java
@@ -29,6 +29,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.Resource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
 /**
@@ -89,6 +90,24 @@ public class TraversonTests {
 				havingHeader("Accept", hasItem("application/hal+json"));
 	}
 
+	/**
+	 * @see #187
+	 */
+	@Test
+	public void sendsConfiguredHeadersForJsonPathExpression() {
+
+		HttpHeaders headers = new HttpHeaders();
+		String expectedHeader = "<http://www.example.com>;rel=\"home\"";
+		headers.add("Link", expectedHeader);
+		assertThat(traverson.follow(//
+				"$._links.movies.href", //
+				"$._links.movie.href", //
+				"$._links.actor.href").withHeaders(headers).<String> toObject("$.name"), is("Keanu Reaves"));
+
+		verifyThatRequest(). //
+				havingPathEqualTo("/actors/d95dbf62-f900-4dfa-9de8-0fc71e02ffa4"). //
+				havingHeader("Link", hasItem(expectedHeader));
+	}
 	/**
 	 * @see #131
 	 */


### PR DESCRIPTION
...e GET result: accepts the media types it is configured for and preserves additional headers.
