### PR TITLE
Added ResourceMixin and HalResourceSerializer

### DIFF
--- a/src/main/java/org/springframework/hateoas/Resource.java
+++ b/src/main/java/org/springframework/hateoas/Resource.java
@@ -38,7 +38,7 @@ public class Resource<T> extends ResourceSupport {
 	/**
 	 * Creates an empty {@link Resource}.
 	 */
-	Resource() {
+	protected Resource() {
 		this.content = null;
 	}
 

--- a/src/main/java/org/springframework/hateoas/hal/ResourceMixin.java
+++ b/src/main/java/org/springframework/hateoas/hal/ResourceMixin.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.hal;
+
+import org.springframework.hateoas.Resource;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+public abstract class ResourceMixin<T> extends Resource<T> {
+
+	@Override
+	@JsonSerialize(using = Jackson2HalModule.HalResourceSerializer.class)
+	public abstract T getContent();
+
+}

--- a/src/test/java/org/springframework/hateoas/hal/Jackson2HalIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/hal/Jackson2HalIntegrationTest.java
@@ -22,7 +22,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -38,6 +40,7 @@ import org.springframework.hateoas.UriTemplate;
 import org.springframework.hateoas.core.AnnotationRelProvider;
 import org.springframework.hateoas.hal.Jackson2HalModule.HalHandlerInstantiator;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -52,13 +55,14 @@ public class Jackson2HalIntegrationTest extends AbstractJackson2MarshallingInteg
 	static final String LIST_LINK_REFERENCE = "{\"_links\":{\"self\":[{\"href\":\"localhost\"},{\"href\":\"localhost2\"}]}}";
 
 	static final String SIMPLE_EMBEDDED_RESOURCE_REFERENCE = "{\"_links\":{\"self\":{\"href\":\"localhost\"}},\"_embedded\":{\"content\":[\"first\",\"second\"]}}";
-	static final String SINGLE_EMBEDDED_RESOURCE_REFERENCE = "{\"_links\":{\"self\":{\"href\":\"localhost\"}},\"_embedded\":{\"content\":[{\"text\":\"test1\",\"number\":1,\"_links\":{\"self\":{\"href\":\"localhost\"}}}]}}";
-	static final String LIST_EMBEDDED_RESOURCE_REFERENCE = "{\"_links\":{\"self\":{\"href\":\"localhost\"}},\"_embedded\":{\"content\":[{\"text\":\"test1\",\"number\":1,\"_links\":{\"self\":{\"href\":\"localhost\"}}},{\"text\":\"test2\",\"number\":2,\"_links\":{\"self\":{\"href\":\"localhost\"}}}]}}";
+	static final String SINGLE_EMBEDDED_RESOURCE_REFERENCE = "{\"_links\":{\"self\":{\"href\":\"localhost\"}},\"_embedded\":{\"content\":[{\"_links\":{\"self\":{\"href\":\"localhost\"}},\"text\":\"test1\",\"number\":1}]}}";
+	static final String LIST_EMBEDDED_RESOURCE_REFERENCE = "{\"_links\":{\"self\":{\"href\":\"localhost\"}},\"_embedded\":{\"content\":[{\"_links\":{\"self\":{\"href\":\"localhost\"}},\"text\":\"test1\",\"number\":1},{\"_links\":{\"self\":{\"href\":\"localhost\"}},\"text\":\"test2\",\"number\":2}]}}";
+	static final String SIMPLE_POJO_RESOURCE_REFERENCE = "{\"_links\":{\"self\":{\"href\":\"localhost\"}},\"text\":\"test1\",\"number\":1}";
 
-	static final String ANNOTATED_EMBEDDED_RESOURCE_REFERENCE = "{\"_links\":{\"self\":{\"href\":\"localhost\"}},\"_embedded\":{\"pojos\":[{\"text\":\"test1\",\"number\":1,\"_links\":{\"self\":{\"href\":\"localhost\"}}}]}}";
-	static final String ANNOTATED_EMBEDDED_RESOURCES_REFERENCE = "{\"_embedded\":{\"pojos\":[{\"text\":\"test1\",\"number\":1,\"_links\":{\"self\":{\"href\":\"localhost\"}}},{\"text\":\"test2\",\"number\":2,\"_links\":{\"self\":{\"href\":\"localhost\"}}}]}}";
+	static final String ANNOTATED_EMBEDDED_RESOURCE_REFERENCE = "{\"_links\":{\"self\":{\"href\":\"localhost\"}},\"_embedded\":{\"pojos\":[{\"_links\":{\"self\":{\"href\":\"localhost\"}},\"text\":\"test1\",\"number\":1}]}}";
+	static final String ANNOTATED_EMBEDDED_RESOURCES_REFERENCE = "{\"_embedded\":{\"pojos\":[{\"_links\":{\"self\":{\"href\":\"localhost\"}},\"text\":\"test1\",\"number\":1},{\"_links\":{\"self\":{\"href\":\"localhost\"}},\"text\":\"test2\",\"number\":2}]}}";
 
-	static final String ANNOTATED_PAGED_RESOURCES = "{\"_links\":{\"next\":{\"href\":\"foo\"},\"prev\":{\"href\":\"bar\"}},\"_embedded\":{\"pojos\":[{\"text\":\"test1\",\"number\":1,\"_links\":{\"self\":{\"href\":\"localhost\"}}},{\"text\":\"test2\",\"number\":2,\"_links\":{\"self\":{\"href\":\"localhost\"}}}]},\"page\":{\"size\":2,\"totalElements\":4,\"totalPages\":2,\"number\":0}}";
+	static final String ANNOTATED_PAGED_RESOURCES = "{\"_links\":{\"next\":{\"href\":\"foo\"},\"prev\":{\"href\":\"bar\"}},\"_embedded\":{\"pojos\":[{\"_links\":{\"self\":{\"href\":\"localhost\"}},\"text\":\"test1\",\"number\":1},{\"_links\":{\"self\":{\"href\":\"localhost\"}},\"text\":\"test2\",\"number\":2}]},\"page\":{\"size\":2,\"totalElements\":4,\"totalPages\":2,\"number\":0}}";
 
 	static final Links PAGINATION_LINKS = new Links(new Link("foo", Link.REL_NEXT), new Link("bar", Link.REL_PREVIOUS));
 
@@ -217,6 +221,91 @@ public class Jackson2HalIntegrationTest extends AbstractJackson2MarshallingInteg
 	}
 
 	/**
+	 * @see #191
+	 */
+	@Test
+	public void serializesResourceOfSimplePojo() throws Exception {
+
+		Resource<SimplePojo> pojo = new Resource<SimplePojo>(new SimplePojo("test1", 1));
+		pojo.add(new Link("localhost"));
+
+		assertThat(write(pojo), is(SIMPLE_POJO_RESOURCE_REFERENCE));
+	}
+
+	/**
+	 * @see #191
+	 */
+	@Test
+	public void serializesResourceOfJsonNode() throws Exception {
+
+		SimplePojo simplePojo = new SimplePojo("test1", 1);
+		JsonNode jsonNode = new ObjectMapper().valueToTree(simplePojo);
+		Resource<JsonNode> pojo = new Resource<JsonNode>(jsonNode);
+		pojo.add(new Link("localhost"));
+
+		assertThat(write(pojo), is(SIMPLE_POJO_RESOURCE_REFERENCE));
+	}
+
+	/**
+	 * @see #191
+	 */
+	@Test
+	public void serializesResourcesOfArrayNodeAsEmbedded() throws Exception {
+
+		List<String> content = new ArrayList<String>();
+		content.add("first");
+		content.add("second");
+		JsonNode arrayNode = new ObjectMapper().valueToTree(content);
+
+		Resources<JsonNode> resources = new Resources<JsonNode>(arrayNode);
+		resources.add(new Link("localhost"));
+
+		assertThat(write(resources), is(SIMPLE_EMBEDDED_RESOURCE_REFERENCE));
+	}
+
+	/**
+	 * @see #191
+	 */
+	@Test
+	public void rendersResourceResourcesOfJsonNodeAsEmbedded() throws Exception {
+
+		Resources<Resource<JsonNode>> resources = setupResourcesOfJsonNode();
+		resources.add(new Link("localhost"));
+
+		assertThat(write(resources), is(LIST_EMBEDDED_RESOURCE_REFERENCE));
+	}
+
+	/**
+	 * @see #191
+	 */
+	@Test
+	public void serializesEmbeddedResourceOfJsonNode() throws Exception {
+
+		SimplePojo simplePojo = new SimplePojo("test1", 1);
+		JsonNode jsonNode = new ObjectMapper().valueToTree(simplePojo);
+		Resource<JsonNode> pojo = new Resource<JsonNode>(jsonNode);
+		pojo.add(new Link("localhost"));
+
+		assertThat(write(pojo), is(SIMPLE_POJO_RESOURCE_REFERENCE));
+	}
+
+	/**
+	 * @see #191
+	 */
+	@Test
+	public void serializesResourceOfMap() throws Exception {
+
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("text", "test1");
+		map.put("number", 1);
+		JsonNode jsonNode = new ObjectMapper().valueToTree(map);
+		Resource<JsonNode> pojo = new Resource<JsonNode>(jsonNode);
+		pojo.add(new Link("localhost"));
+
+		assertThat(write(pojo), is(SIMPLE_POJO_RESOURCE_REFERENCE));
+	}
+
+	/**
 	 * @see #47, #60
 	 */
 	@Test
@@ -369,6 +458,16 @@ public class Jackson2HalIntegrationTest extends AbstractJackson2MarshallingInteg
 		content.add(new Resource<SimplePojo>(new SimplePojo("test2", 2), new Link("localhost")));
 
 		return new Resources<Resource<SimplePojo>>(content);
+	}
+
+	private static Resources<Resource<JsonNode>> setupResourcesOfJsonNode() {
+
+		ObjectMapper mapper = new ObjectMapper();
+		List<Resource<JsonNode>> content = new ArrayList<Resource<JsonNode>>();
+		content.add(new Resource<JsonNode>(mapper.valueToTree(new SimplePojo("test1", 1)), new Link("localhost")));
+		content.add(new Resource<JsonNode>(mapper.valueToTree(new SimplePojo("test2", 2)), new Link("localhost")));
+
+		return new Resources<Resource<JsonNode>>(content);
 	}
 
 	private static ObjectMapper getCuriedObjectMapper() {


### PR DESCRIPTION
Fixes #191. A side-effect of this change is that the order of attributes on embedded beans is now links-first, but that seems acceptable since the example HAL documents use the same ordering.
