### PR TITLE
#209 - Added support for Map<String, String> and MultiValueMap<String, S...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.springframework.hateoas</groupId>
 	<artifactId>spring-hateoas</artifactId>
-	<version>0.14.0.RELEASE</version>
+	<version>0.14.0.BUILD-SNAPSHOT</version>
 
 	<name>Spring Hateoas</name>
 	<url>http://github.com/SpringSource/spring-hateoas</url>

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderFactoryUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderFactoryUnitTest.java
@@ -15,12 +15,6 @@
  */
 package org.springframework.hateoas.mvc;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.*;
-
-import java.util.Arrays;
-
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Test;
@@ -33,9 +27,22 @@ import org.springframework.hateoas.mvc.ControllerLinkBuilderUnitTest.ControllerW
 import org.springframework.hateoas.mvc.ControllerLinkBuilderUnitTest.PersonControllerImpl;
 import org.springframework.hateoas.mvc.ControllerLinkBuilderUnitTest.PersonsAddressesController;
 import org.springframework.http.HttpEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
 /**
  * Unit tests for {@link ControllerLinkBuilderFactory}.
@@ -119,6 +126,35 @@ public class ControllerLinkBuilderFactoryUnitTest extends TestUtils {
 		assertThat(link.getHref(), endsWith("/people/with%20blank/addresses"));
 	}
 
+	/**
+	 * @see #209
+	 */
+	@Test
+	public void createsLinkToControllerMethodWithMapRequestParam() {
+		Map<String, String> queryParams = new LinkedHashMap<String, String>();
+		queryParams.put("firstKey", "firstValue");
+		queryParams.put("secondKey", "secondValue");
+
+		Link link = factory.linkTo(methodOn(SampleController.class).sampleMethodWithMap(queryParams)).withSelfRel();
+
+		assertPointsToMockServer(link);
+		assertThat(link.getRel(), is(Link.REL_SELF));
+		assertThat(link.getHref(), endsWith("/sample/mapsupport?firstKey=firstValue&secondKey=secondValue"));
+	}
+
+	@Test
+	public void createsLinkToControllerMethodWithMultiValueMapRequestParam() {
+		MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
+		queryParams.put("key1", Arrays.asList("value1a", "value1b"));
+		queryParams.put("key2", Arrays.asList("value2a", "value2b"));
+
+		Link link = factory.linkTo(methodOn(SampleController.class).sampleMethodWithMap(queryParams)).withSelfRel();
+
+		assertPointsToMockServer(link);
+		assertThat(link.getRel(), is(Link.REL_SELF));
+		assertThat(link.getHref(), endsWith("/sample/multivaluemapsupport?key1=value1a&key1=value1b&key2=value2a&key2=value2b"));
+	}
+
 	static interface SampleController {
 
 		@RequestMapping("/sample/{id}")
@@ -126,6 +162,12 @@ public class ControllerLinkBuilderFactoryUnitTest extends TestUtils {
 
 		@RequestMapping("/sample/{time}")
 		HttpEntity<?> sampleMethod(@PathVariable("time") @DateTimeFormat(iso = ISO.DATE) DateTime time);
+
+		@RequestMapping("/sample/mapsupport")
+		HttpEntity<?> sampleMethodWithMap(@RequestParam Map<String, String> queryParams);
+
+		@RequestMapping("/sample/multivaluemapsupport")
+		HttpEntity<?> sampleMethodWithMap(@RequestParam MultiValueMap<String, String> queryParams);
 	}
 
 	static class SampleUriComponentsContributor implements UriComponentsContributor {


### PR DESCRIPTION
See [https://github.com/spring-projects/spring-hateoas/issues/209].

I've added unit tests to cover `@RequestParam` Controller arguments with no name that are Map<String, String> or MultiValueMap<String, String>. The only thing I'm not really happy about in this commit is the untyped cast from `Map` to `Map<String, String>` (and similarly for the other type) but as only these generified types are accepted I don't believe it's necessary to check for other types or add an exception handler around the cast.