### PR TITLE
Add means to render empty embedded collections

### DIFF
--- a/src/main/java/org/springframework/hateoas/hal/ResourcesMixin.java
+++ b/src/main/java/org/springframework/hateoas/hal/ResourcesMixin.java
@@ -30,7 +30,7 @@ public abstract class ResourcesMixin<T> extends Resources<T> {
 	@Override
 	@XmlElement(name = "embedded")
 	@JsonProperty("_embedded")
-	@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY, using = Jackson2HalModule.HalResourcesSerializer.class)
+	@JsonSerialize(using = Jackson2HalModule.HalResourcesSerializer.class)
 	@JsonDeserialize(using = Jackson2HalModule.HalResourcesDeserializer.class)
 	public abstract Collection<T> getContent();
 

--- a/src/test/java/org/springframework/hateoas/hal/Jackson2HalIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/hal/Jackson2HalIntegrationTest.java
@@ -62,10 +62,10 @@ public class Jackson2HalIntegrationTest extends AbstractJackson2MarshallingInteg
 
 	static final Links PAGINATION_LINKS = new Links(new Link("foo", Link.REL_NEXT), new Link("bar", Link.REL_PREVIOUS));
 
-	static final String CURIED_DOCUMENT = "{\"_links\":{\"self\":{\"href\":\"foo\"},\"foo:myrel\":{\"href\":\"bar\"},\"curies\":[{\"href\":\"http://localhost:8080/rels/{rel}\",\"name\":\"foo\",\"templated\":true}]}}";
-	static final String MULTIPLE_CURIES_DOCUMENT = "{\"_links\":{\"default:myrel\":{\"href\":\"foo\"},\"curies\":[{\"href\":\"bar\",\"name\":\"foo\"},{\"href\":\"foo\",\"name\":\"bar\"}]}}";
-	static final String SINGLE_NON_CURIE_LINK = "{\"_links\":{\"self\":{\"href\":\"foo\"}}}";
-	static final String EMPTY_DOCUMENT = "{}";
+	static final String CURIED_DOCUMENT = "{\"_links\":{\"self\":{\"href\":\"foo\"},\"foo:myrel\":{\"href\":\"bar\"},\"curies\":[{\"href\":\"http://localhost:8080/rels/{rel}\",\"name\":\"foo\",\"templated\":true}]},\"_embedded\":{}}";
+	static final String MULTIPLE_CURIES_DOCUMENT = "{\"_links\":{\"default:myrel\":{\"href\":\"foo\"},\"curies\":[{\"href\":\"bar\",\"name\":\"foo\"},{\"href\":\"foo\",\"name\":\"bar\"}]},\"_embedded\":{}}";
+	static final String SINGLE_NON_CURIE_LINK = "{\"_links\":{\"self\":{\"href\":\"foo\"}},\"_embedded\":{}}";
+	static final String EMPTY_DOCUMENT = "{\"_embedded\":{}}";
 
 	static final String LINK_TEMPLATE = "{\"_links\":{\"search\":{\"href\":\"/foo{?bar}\",\"templated\":true}}}";
 


### PR DESCRIPTION
An API should be consistent. If when we have elements in a collection, we get a response like

``` json
{
    "_embedded": {
        "users": [
            {
                "username": "bob"
            },
            {
                "username": "joe"
            }
        ]
    }
}
```

and then when there are no users found, we get a response like

``` json
{
}
```

it is not consistent and forces our clients to handle the special case of not having `_embedded.users` in a response.

Instead, what our clients reasonably expect is a response like

``` json
{
    "_embedded": {
        "users": [
        ]
    }
}
```
