### PR TITLE
Add support for X-Forwarded-Proto headers

### DIFF
--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
@@ -187,8 +187,9 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 		ServletUriComponentsBuilder builder = ServletUriComponentsBuilder.fromServletMapping(request);
 
 		String forwardedSsl = request.getHeader("X-Forwarded-Ssl");
+		String forwardedProto = request.getHeader("X-Forwarded-Proto");
 
-		if (StringUtils.hasText(forwardedSsl) && forwardedSsl.equalsIgnoreCase("on")) {
+		if (StringUtils.hasText(forwardedSsl) && forwardedSsl.equalsIgnoreCase("on") || StringUtils.hasText(forwardedProto) && forwardedProto.equalsIgnoreCase("https")) {
 			builder.scheme("https");
 		}
 

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
@@ -378,6 +378,29 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		assertThat(link.getHref(), endsWith("/root"));
 	}
 
+    /**
+     * @see #107
+     */
+    @Test
+    public void setLinkSchemaToUseHttpsIfXForwardProtoHeaderIsSetToHttps() {
+
+        request.addHeader("X-Forwarded-Proto", "https");
+
+        Link link = linkTo(PersonControllerImpl.class).withSelfRel();
+        assertThat(link.getHref(), startsWith("https://"));
+    }
+    /**
+     * @see #107
+     */
+    @Test
+    public void ignoreXForwardProtoHeaderIfValueNotHttps() {
+
+        request.addHeader("X-Forwarded-Proto", "not https");
+
+        Link link = linkTo(PersonControllerImpl.class).withSelfRel();
+        assertThat(link.getHref(), startsWith("http://"));
+    }
+
 	private static UriComponents toComponents(Link link) {
 		return UriComponentsBuilder.fromUriString(link.getHref()).build();
 	}


### PR DESCRIPTION
I have added support for `X-Forwarded-Proto`

When using Amazon AWS, and off-loading SSL at the AWS Load Balancer, the X-Forward headers are [limited](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/TerminologyandKeyConcepts.html#x-forwarded-headers) to `X-Forwarded-Proto`, as these machines are not configurable by users.
