### PR TITLE
Expose Traverson default message converters in a convenience method

### DIFF
--- a/src/test/java/org/springframework/hateoas/client/TraversonTests.java
+++ b/src/test/java/org/springframework/hateoas/client/TraversonTests.java
@@ -176,6 +176,7 @@ public class TraversonTests {
 
 		RestTemplate restTemplate = new RestTemplate();
 		restTemplate.setInterceptors(Arrays.<ClientHttpRequestInterceptor> asList(interceptor));
+		restTemplate.setMessageConverters(Traverson.getDefaultMessageConverters(MediaTypes.HAL_JSON));
 
 		this.traverson = new Traverson(baseUri, MediaTypes.HAL_JSON);
 		this.traverson.setRestOperations(restTemplate);


### PR DESCRIPTION
The existing encapsulation of RestTemplate (via #201, #203) makes it the 
user's responibility to set up the correct message converters (which as argued
in #203, is necessary), but it doesn't give any help knowing what the
converters should be.

This change exposes the default message converters via a static convenience
method, e.g.

```
RestTemplate restTemplate = new RestTemplate();
restTemplate.setInterceptors(
    Arrays.<ClientHttpRequestInterceptor>asList(interceptor));
restTemplate.setMessageConverters(
    Traverson.getDefaultMessageConverters(MediaTypes.HAL_JSON));
```
