### PR TITLE
issue #288: (Approach #1) Allow links on a particular rel to be displayed as an array even if there is only one link

### DIFF
--- a/src/main/java/org/springframework/hateoas/Link.java
+++ b/src/main/java/org/springframework/hateoas/Link.java
@@ -55,6 +55,7 @@ public class Link implements Serializable {
 	@XmlAttribute private String rel;
 	@XmlAttribute private String href;
 	@XmlTransient @JsonIgnore private UriTemplate template;
+	@XmlTransient @JsonIgnore private boolean multiple;
 
 	/**
 	 * Creates a new link to the given URI with the self rel.
@@ -137,6 +138,16 @@ public class Link implements Serializable {
 	}
 
 	/**
+	 * Ensures that the rel for this {@link Link} always maps to an array instead of an
+	 * object. Only applicable to HAL+JSON.
+	 * @return
+	 */
+	public Link asMultiple() {
+		this.multiple = true;
+		return this;
+	}
+
+	/**
 	 * Returns the variable names contained in the template.
 	 * 
 	 * @return
@@ -163,6 +174,15 @@ public class Link implements Serializable {
 	 */
 	public boolean isTemplated() {
 		return !getUriTemplate().getVariables().isEmpty();
+	}
+
+	/**
+	 * Returns whether this link should be represented as a multiple.
+	 *
+	 * @return
+	 */
+	public boolean isMultiple() {
+		return multiple;
 	}
 
 	/**

--- a/src/main/java/org/springframework/hateoas/hal/Jackson2HalModule.java
+++ b/src/main/java/org/springframework/hateoas/hal/Jackson2HalModule.java
@@ -361,8 +361,11 @@ public class Jackson2HalModule extends SimpleModule {
 			}
 
 			if (list.size() == 1) {
-				serializeContents(list.iterator(), jgen, provider);
-				return;
+				if(!(list.get(0) instanceof Link) ||
+						!((Link) list.get(0)).isMultiple()) {
+                    serializeContents(list.iterator(), jgen, provider);
+                    return;
+				}
 			}
 
 			jgen.writeStartArray();

--- a/src/test/java/org/springframework/hateoas/hal/Jackson2HalIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/hal/Jackson2HalIntegrationTest.java
@@ -49,6 +49,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class Jackson2HalIntegrationTest extends AbstractJackson2MarshallingIntegrationTest {
 
 	static final String SINGLE_LINK_REFERENCE = "{\"_links\":{\"self\":{\"href\":\"localhost\"}}}";
+	static final String SINGLE_LINK_REFERENCE_AS_MULTIPLE = "{\"_links\":{\"self\":[{\"href\":\"localhost\"}]}}";
 	static final String LIST_LINK_REFERENCE = "{\"_links\":{\"self\":[{\"href\":\"localhost\"},{\"href\":\"localhost2\"}]}}";
 
 	static final String SIMPLE_EMBEDDED_RESOURCE_REFERENCE = "{\"_links\":{\"self\":{\"href\":\"localhost\"}},\"_embedded\":{\"content\":[\"first\",\"second\"]}}";
@@ -86,6 +87,15 @@ public class Jackson2HalIntegrationTest extends AbstractJackson2MarshallingInteg
 		resourceSupport.add(new Link("localhost"));
 
 		assertThat(write(resourceSupport), is(SINGLE_LINK_REFERENCE));
+	}
+
+	@Test
+	public void rendersSingleLinkAsArrayWhenMultiple() throws Exception {
+
+		ResourceSupport resourceSupport = new ResourceSupport();
+		resourceSupport.add(new Link("localhost").asMultiple());
+
+
 	}
 
 	@Test


### PR DESCRIPTION
Allows links under a single rel to be represented as a multiple (i.e., serialized to an array) even if there is only one.

This is one, possible approach. I don't like this too much since it is adding a rather-specific concern to the `Link` object (i.e., one that only comes into play in the case of HAL+JSON). Also, is it the responsibility of the `Link` to convey the information that must be serialized into an array under the `rel` that it belongs? 