### PR TITLE
issue #288: (Approach #2) Allow links on a particular rel to be displayed as an array even if there is only one link

### DIFF
--- a/src/main/java/org/springframework/hateoas/Link.java
+++ b/src/main/java/org/springframework/hateoas/Link.java
@@ -55,6 +55,7 @@ public class Link implements Serializable {
 	@XmlAttribute private String rel;
 	@XmlAttribute private String href;
 	@XmlTransient @JsonIgnore private UriTemplate template;
+	@XmlTransient @JsonIgnore private Class<? extends ResourceSupport> owningResource;
 
 	/**
 	 * Creates a new link to the given URI with the self rel.
@@ -194,10 +195,18 @@ public class Link implements Serializable {
 		return template;
 	}
 
-	/* 
-	 * (non-Javadoc)
-	 * @see java.lang.Object#equals(java.lang.Object)
-	 */
+	public Class<? extends ResourceSupport> getOwningResource() {
+		return this.owningResource;
+	}
+
+	void setOwningResource(Class<? extends ResourceSupport> owningResource) {
+		this.owningResource = owningResource;
+	}
+
+	/*
+         * (non-Javadoc)
+         * @see java.lang.Object#equals(java.lang.Object)
+         */
 	@Override
 	public boolean equals(Object obj) {
 

--- a/src/main/java/org/springframework/hateoas/ResourceSupport.java
+++ b/src/main/java/org/springframework/hateoas/ResourceSupport.java
@@ -53,6 +53,7 @@ public class ResourceSupport implements Identifiable<Link> {
 	 */
 	public void add(Link link) {
 		Assert.notNull(link, "Link must not be null!");
+		link.setOwningResource(this.getClass());
 		this.links.add(link);
 	}
 
@@ -64,6 +65,7 @@ public class ResourceSupport implements Identifiable<Link> {
 	public void add(Iterable<Link> links) {
 		Assert.notNull(links, "Given links must not be null!");
 		for (Link candidate : links) {
+			candidate.setOwningResource(this.getClass());
 			add(candidate);
 		}
 	}

--- a/src/main/java/org/springframework/hateoas/hal/ForceMultipleLinksOnRels.java
+++ b/src/main/java/org/springframework/hateoas/hal/ForceMultipleLinksOnRels.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.hal;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.hateoas.core.ControllerEntityLinks;
+
+/**
+ * Annotation to force links under specified rels to be serialized as a JSON array regardless of cardinality.
+ *
+ * @author Vivin Paliath
+ */
+@Inherited
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ForceMultipleLinksOnRels {
+    public String[] value();
+}

--- a/src/test/java/org/springframework/hateoas/hal/Jackson2HalIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/hal/Jackson2HalIntegrationTest.java
@@ -26,15 +26,8 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.hateoas.AbstractJackson2MarshallingIntegrationTest;
-import org.springframework.hateoas.Link;
-import org.springframework.hateoas.Links;
-import org.springframework.hateoas.PagedResources;
+import org.springframework.hateoas.*;
 import org.springframework.hateoas.PagedResources.PageMetadata;
-import org.springframework.hateoas.Resource;
-import org.springframework.hateoas.ResourceSupport;
-import org.springframework.hateoas.Resources;
-import org.springframework.hateoas.UriTemplate;
 import org.springframework.hateoas.core.AnnotationRelProvider;
 import org.springframework.hateoas.hal.Jackson2HalModule.HalHandlerInstantiator;
 
@@ -49,6 +42,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class Jackson2HalIntegrationTest extends AbstractJackson2MarshallingIntegrationTest {
 
 	static final String SINGLE_LINK_REFERENCE = "{\"_links\":{\"self\":{\"href\":\"localhost\"}}}";
+	static final String SINGLE_LINK_REFERENCE_AS_MULTIPLE = "{\"_links\":{\"multiple\":[{\"href\":\"localhost\"}]}}";
 	static final String LIST_LINK_REFERENCE = "{\"_links\":{\"self\":[{\"href\":\"localhost\"},{\"href\":\"localhost2\"}]}}";
 
 	static final String SIMPLE_EMBEDDED_RESOURCE_REFERENCE = "{\"_links\":{\"self\":{\"href\":\"localhost\"}},\"_embedded\":{\"content\":[\"first\",\"second\"]}}";
@@ -93,6 +87,13 @@ public class Jackson2HalIntegrationTest extends AbstractJackson2MarshallingInteg
 		ResourceSupport expected = new ResourceSupport();
 		expected.add(new Link("localhost"));
 		assertThat(read(SINGLE_LINK_REFERENCE, ResourceSupport.class), is(expected));
+	}
+
+	@Test
+	public void rendersSingleLinkAsArrayWhenForced() throws Exception {
+		ResourceWithForcedMultipleLink expected = new ResourceWithForcedMultipleLink();
+		expected.add(new Link("localhost").withRel("multiple"));
+		assertThat(read(SINGLE_LINK_REFERENCE_AS_MULTIPLE, ResourceWithForcedMultipleLink.class), is(expected));
 	}
 
 	/**
@@ -383,5 +384,9 @@ public class Jackson2HalIntegrationTest extends AbstractJackson2MarshallingInteg
 		mapper.setHandlerInstantiator(new HalHandlerInstantiator(new AnnotationRelProvider(), provider));
 
 		return mapper;
+	}
+
+	@ForceMultipleLinksOnRels({"multiple"})
+	private static class ResourceWithForcedMultipleLink extends ResourceSupport {
 	}
 }


### PR DESCRIPTION
Allows links under a single rel to be represented as a multiple (i.e., serialized to an array) even if there is only one.

This approach is a little better than the other one. Here, I created a new annotation that you can attach to a resource class. This annotation will contain a list of `rel`s that will always be serialized as multiple links (i.e., in a JSON array) regardless of cardinality. 

I did have to add a propertly to the `Link` class, which is just the class of the owning resource. The setter is package-private and so no one else can mess with it. The value of the field is set automatically when links are added.

I have also added a test for this case.