### PR TITLE
issue #288 Allow links on particular rels to be displayed as an array even if there is only one link

### DIFF
--- a/src/main/java/org/springframework/hateoas/config/HypermediaSupportBeanDefinitionRegistrar.java
+++ b/src/main/java/org/springframework/hateoas/config/HypermediaSupportBeanDefinitionRegistrar.java
@@ -53,6 +53,7 @@ import org.springframework.hateoas.core.DelegatingRelProvider;
 import org.springframework.hateoas.core.EvoInflectorRelProvider;
 import org.springframework.hateoas.hal.CurieProvider;
 import org.springframework.hateoas.hal.HalLinkDiscoverer;
+import org.springframework.hateoas.hal.HalCollectionRels;
 import org.springframework.hateoas.hal.Jackson2HalModule;
 import org.springframework.hateoas.mvc.TypeConstrainedMappingJackson2HttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -288,6 +289,7 @@ class HypermediaSupportBeanDefinitionRegistrar implements ImportBeanDefinitionRe
 			}
 
 			CurieProvider curieProvider = getCurieProvider(beanFactory);
+			HalCollectionRels halCollectionRels = getHalMultipleLinkRels(beanFactory);
 			RelProvider relProvider = beanFactory.getBean(DELEGATING_REL_PROVIDER_BEAN_NAME, RelProvider.class);
 			ObjectMapper halObjectMapper = beanFactory.getBean(HAL_OBJECT_MAPPER_BEAN_NAME, ObjectMapper.class);
 			MessageSourceAccessor linkRelationMessageSource = beanFactory.getBean(MESSAGE_SOURCE_BEAN_NAME,
@@ -295,7 +297,10 @@ class HypermediaSupportBeanDefinitionRegistrar implements ImportBeanDefinitionRe
 
 			halObjectMapper.registerModule(new Jackson2HalModule());
 			halObjectMapper.setHandlerInstantiator(
-					new Jackson2HalModule.HalHandlerInstantiator(relProvider, curieProvider, linkRelationMessageSource));
+					new Jackson2HalModule.HalHandlerInstantiator(
+						relProvider, curieProvider, halCollectionRels, linkRelationMessageSource
+					)
+			);
 
 			MappingJackson2HttpMessageConverter halConverter = new TypeConstrainedMappingJackson2HttpMessageConverter(
 					ResourceSupport.class);
@@ -313,6 +318,14 @@ class HypermediaSupportBeanDefinitionRegistrar implements ImportBeanDefinitionRe
 			try {
 				return factory.getBean(CurieProvider.class);
 			} catch (NoSuchBeanDefinitionException e) {
+				return null;
+			}
+		}
+
+		private static HalCollectionRels getHalMultipleLinkRels(BeanFactory factory) {
+			try {
+				return factory.getBean(HalCollectionRels.class);
+			} catch(NoSuchBeanDefinitionException e) {
 				return null;
 			}
 		}

--- a/src/main/java/org/springframework/hateoas/core/EmbeddedWrappers.java
+++ b/src/main/java/org/springframework/hateoas/core/EmbeddedWrappers.java
@@ -33,7 +33,7 @@ public class EmbeddedWrappers {
 
 	/**
 	 * Creates a new {@link EmbeddedWrappers}.
-	 * 
+	 *
 	 * @param preferCollections whether wrappers for single elements should rather treat the value as collection.
 	 */
 	public EmbeddedWrappers(boolean preferCollections) {

--- a/src/main/java/org/springframework/hateoas/hal/HalCollectionRels.java
+++ b/src/main/java/org/springframework/hateoas/hal/HalCollectionRels.java
@@ -1,0 +1,33 @@
+package org.springframework.hateoas.hal;
+
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Class to maintain relations that must always be serialized to an array regardless of cardinality.
+ *
+ * In HAL, if there is only one element behind a rel, it can be serialized directly into a JSON object; otherwise
+ * the elements behind the rel are serialized into a JSON array of JSON objects.
+ *
+ * However, the HAL specification also says that the API designer can mandate that certain rels will always be
+ * represented as an array regardless of the cardinality of elements behind that rel. This class helps you do that
+ * If a rel is specified here, elements behind that rel will always be serialized into an array wherever it is
+ * used.
+ *
+ * @author Vivin Paliath
+ */
+public class HalCollectionRels {
+
+	private final Set<String> rels;
+
+	public HalCollectionRels(String... rels) {
+		this.rels = new HashSet<String>(Arrays.asList(rels));
+	}
+
+	public boolean containsRel(String rel) {
+		return rels.contains(rel);
+	}
+}

--- a/src/main/java/org/springframework/hateoas/hal/Jackson2HalModule.java
+++ b/src/main/java/org/springframework/hateoas/hal/Jackson2HalModule.java
@@ -707,7 +707,7 @@ public class Jackson2HalModule extends SimpleModule {
 		public HalHandlerInstantiator(RelProvider resolver, CurieProvider curieProvider,
 				HalCollectionRels halCollectionRels, MessageSourceAccessor messageSource, boolean enforceEmbeddedCollections) {
 
-			EmbeddedMapper mapper = new EmbeddedMapper(resolver, curieProvider, halCollectionRels, enforceEmbeddedCollections);
+			EmbeddedMapper mapper = new EmbeddedMapper(resolver, curieProvider, enforceEmbeddedCollections);
 
 			Assert.notNull(resolver, "RelProvider must not be null!");
 			this.instanceMap.put(HalResourcesSerializer.class, new HalResourcesSerializer(mapper));
@@ -839,7 +839,6 @@ public class Jackson2HalModule extends SimpleModule {
 
 		private RelProvider relProvider;
 		private CurieProvider curieProvider;
-		private HalCollectionRels halCollectionRels;
 		private boolean preferCollectionRels;
 
 		/**
@@ -850,14 +849,12 @@ public class Jackson2HalModule extends SimpleModule {
 		 * @param curieProvider can be {@literal null}.
 		 * @param preferCollectionRels
 		 */
-		public EmbeddedMapper(RelProvider relProvider, CurieProvider curieProvider,
-				HalCollectionRels halCollectionRels, boolean preferCollectionRels) {
+		public EmbeddedMapper(RelProvider relProvider, CurieProvider curieProvider, boolean preferCollectionRels) {
 
 			Assert.notNull(relProvider, "RelProvider must not be null!");
 
 			this.relProvider = relProvider;
 			this.curieProvider = curieProvider;
-			this.halCollectionRels = halCollectionRels;
 			this.preferCollectionRels = preferCollectionRels;
 		}
 

--- a/src/test/java/org/springframework/hateoas/core/EmbeddedWrappersUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/core/EmbeddedWrappersUnitTest.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import org.junit.Test;
+import org.springframework.hateoas.hal.HalCollectionRels;
 
 /**
  * Unit tests for {@link EmbeddedWrappers}.
@@ -30,7 +31,17 @@ import org.junit.Test;
  */
 public class EmbeddedWrappersUnitTest {
 
-	EmbeddedWrappers wrappers = new EmbeddedWrappers(false);
+	private static EmbeddedWrappers wrappers() {
+		return new EmbeddedWrappers(false);
+	}
+
+	private static EmbeddedWrappers collectionPreferredWrappers() {
+		return new EmbeddedWrappers(true);
+	}
+
+	private static EmbeddedWrappers collectionRelsWrappers() {
+		return new EmbeddedWrappers(false);
+	}
 
 	/**
 	 * @see #286
@@ -39,7 +50,7 @@ public class EmbeddedWrappersUnitTest {
 	@SuppressWarnings("rawtypes")
 	public void createsWrapperForEmptyCollection() {
 
-		EmbeddedWrapper wrapper = wrappers.emptyCollectionOf(String.class);
+		EmbeddedWrapper wrapper = wrappers().emptyCollectionOf(String.class);
 
 		assertEmptyCollectionValue(wrapper);
 		assertThat(wrapper.getRel(), is(nullValue()));
@@ -52,7 +63,7 @@ public class EmbeddedWrappersUnitTest {
 	@Test
 	public void createsWrapperForEmptyCollectionAndExplicitRel() {
 
-		EmbeddedWrapper wrapper = wrappers.wrap(Collections.emptySet(), "rel");
+		EmbeddedWrapper wrapper = wrappers().wrap(Collections.emptySet(), "rel");
 
 		assertEmptyCollectionValue(wrapper);
 		assertThat(wrapper.getRel(), is("rel"));
@@ -64,7 +75,7 @@ public class EmbeddedWrappersUnitTest {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void rejectsEmptyCollectionWithoutExplicitRel() {
-		wrappers.wrap(Collections.emptySet());
+		wrappers().wrap(Collections.emptySet());
 	}
 
 	private static void assertEmptyCollectionValue(EmbeddedWrapper wrapper) {

--- a/src/test/java/org/springframework/hateoas/hal/Jackson2HalIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/hal/Jackson2HalIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *	  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -41,6 +41,7 @@ import org.springframework.hateoas.ResourceSupport;
 import org.springframework.hateoas.Resources;
 import org.springframework.hateoas.UriTemplate;
 import org.springframework.hateoas.core.AnnotationRelProvider;
+import org.springframework.hateoas.core.EmbeddedWrapper;
 import org.springframework.hateoas.core.EmbeddedWrappers;
 import org.springframework.hateoas.hal.Jackson2HalModule.HalHandlerInstantiator;
 
@@ -55,10 +56,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class Jackson2HalIntegrationTest extends AbstractJackson2MarshallingIntegrationTest {
 
 	static final String SINGLE_LINK_REFERENCE = "{\"_links\":{\"self\":{\"href\":\"localhost\"}}}";
+	static final String SINGLE_LINK_ARRAY_REFERENCE = "{\"_links\":{\"multiple\":[{\"href\":\"localhost\"}]}}";
 	static final String LIST_LINK_REFERENCE = "{\"_links\":{\"self\":[{\"href\":\"localhost\"},{\"href\":\"localhost2\"}]}}";
 
 	static final String SIMPLE_EMBEDDED_RESOURCE_REFERENCE = "{\"_embedded\":{\"content\":[\"first\",\"second\"]},\"_links\":{\"self\":{\"href\":\"localhost\"}}}";
 	static final String SINGLE_EMBEDDED_RESOURCE_REFERENCE = "{\"_embedded\":{\"content\":[{\"text\":\"test1\",\"number\":1,\"_links\":{\"self\":{\"href\":\"localhost\"}}}]},\"_links\":{\"self\":{\"href\":\"localhost\"}}}";
+	static final String SINGLE_EMBEDDED_RESOURCE_ARRAY_REFERENCE = "{\"_embedded\":{\"multiple\":[{\"text\":\"test1\",\"number\":1}}}";
 	static final String LIST_EMBEDDED_RESOURCE_REFERENCE = "{\"_embedded\":{\"content\":[{\"text\":\"test1\",\"number\":1,\"_links\":{\"self\":{\"href\":\"localhost\"}}},{\"text\":\"test2\",\"number\":2,\"_links\":{\"self\":{\"href\":\"localhost\"}}}]},\"_links\":{\"self\":{\"href\":\"localhost\"}}}";
 
 	static final String ANNOTATED_EMBEDDED_RESOURCE_REFERENCE = "{\"_embedded\":{\"pojos\":[{\"text\":\"test1\",\"number\":1,\"_links\":{\"self\":{\"href\":\"localhost\"}}}]},\"_links\":{\"self\":{\"href\":\"localhost\"}}}";
@@ -114,6 +117,16 @@ public class Jackson2HalIntegrationTest extends AbstractJackson2MarshallingInteg
 		resourceSupport.add(new Link("localhost2"));
 
 		assertThat(write(resourceSupport), is(LIST_LINK_REFERENCE));
+	}
+
+	@Test
+	public void rendersSingleLinkAsArrayWhenConfigured() throws Exception {
+		mapper.setHandlerInstantiator(new HalHandlerInstantiator(new AnnotationRelProvider(), null, new HalCollectionRels("multiple"), null));
+
+		ResourceSupport resourceSupport = new ResourceSupport();
+		resourceSupport.add(new Link("localhost").withRel("multiple"));
+
+		assertThat(write(resourceSupport), is(SINGLE_LINK_ARRAY_REFERENCE));
 	}
 
 	@Test


### PR DESCRIPTION
This change allows links behind certain rels to always be wrapped by an array regardless of cardinality.

This is related to #291. Instead of trying to control the wrapping based on a resource-rel combination, this approach controls the representation of the link simply based on the rel. Hence, if the specified rels appear in _any_ resource, they will always be wrapped inside an array regardless of cardinality. 

I think this allows for the development of more-consistent representations. If there is ever more than one link behind a particular rel (under any resource), I think it makes more sense to maintain that consistency across all resources by ensuring that the links under that rel are always wrapped in an array. 
