### PR TITLE
Upgrade JsonPath Version #297

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 		<jackson.version>2.4.1</jackson.version>
 		<jaxrs.version>1.0</jaxrs.version>
 		<minidevjson.version>1.1.1</minidevjson.version>
-		<jsonpath.version>0.9.1</jsonpath.version>
+		<jsonpath.version>1.2.0</jsonpath.version>
 		<objenesis.version>2.1</objenesis.version>
 		<slf4j.version>1.7.7</slf4j.version>
 		<evo.version>1.2</evo.version>

--- a/src/main/java/org/springframework/hateoas/hal/HalLinkDiscoverer.java
+++ b/src/main/java/org/springframework/hateoas/hal/HalLinkDiscoverer.java
@@ -27,6 +27,6 @@ import org.springframework.hateoas.core.JsonPathLinkDiscoverer;
 public class HalLinkDiscoverer extends JsonPathLinkDiscoverer {
 
 	public HalLinkDiscoverer() {
-		super("$_links..%s.href", MediaTypes.HAL_JSON);
+		super("$._links..%s..href", MediaTypes.HAL_JSON);
 	}
 }


### PR DESCRIPTION
upgraded jsonpath to version from 0.9.1 to 1.2.0
changed HalLinkDiscoverer pathTemplate to work with new jsonpath version