### PR TITLE
Added missing variable in call to ControllerLinkBuilder.linkTo(Class<?>controller, Method method, Object... parameters).

### DIFF
--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
@@ -93,7 +93,7 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 	 * @see org.springframework.hateoas.MethodLinkBuilderFactory#linkTo(Method, Object...)
 	 */
 	public static ControllerLinkBuilder linkTo(Method method, Object... parameters) {
-		return linkTo(method.getDeclaringClass(), method);
+		return linkTo(method.getDeclaringClass(), method, parameters);
 	}
 
 	/*


### PR DESCRIPTION
Inside ControllerLinkBuilder.linkTo(Method method, Object... parameters) the call to ControllerLinkBuilder.linkTo(Class<?> controller, Method method, Object... parameters) misses the "parameters" variable, leading to a java.lang.IllegalArgumentException when called.

This pull request addresses issue #237 and its duplicate #248.