### PR TITLE
add support for Traverson.toEntity(ParameterizedTypeReference<T> type)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -452,7 +452,7 @@
 		<dependency>
 			<groupId>org.springframework.plugin</groupId>
 			<artifactId>spring-plugin-core</artifactId>
-			<version>1.1.0.RELEASE</version>
+			<version>1.2.0.RELEASE</version>
 			<optional>true</optional>
 		</dependency>
 

--- a/src/main/java/org/springframework/hateoas/client/Traverson.java
+++ b/src/main/java/org/springframework/hateoas/client/Traverson.java
@@ -319,6 +319,18 @@ public class Traverson {
 			return operations.exchange(traverseToFinalUrl(true), GET, prepareRequest(headers), type);
 		}
 
+   		/**
+		 * Returns the raw {@link ResponseEntity} with the representation unmarshalled into an instance of the given {@link ParameterizedTypeReference}.
+		 * 
+		 * @param type must not be {@literal null}.
+		 * @return
+		 */
+		public <T> ResponseEntity<T> toEntity(ParameterizedTypeReference<T> type) {
+
+			Assert.notNull(type, "Target type must not be null!");
+			return operations.exchange(traverseToFinalUrl(true), GET, prepareRequest(headers), type);
+		}
+
 		/**
 		 * Returns the {@link Link} found for the last rel in the rels configured to follow. Will expand the final
 		 * {@link Link} using the

--- a/src/main/java/org/springframework/hateoas/client/Traverson.java
+++ b/src/main/java/org/springframework/hateoas/client/Traverson.java
@@ -320,7 +320,7 @@ public class Traverson {
 		}
 
    		/**
-		 * Returns the raw {@link ResponseEntity} with the representation unmarshalled into an instance of the given {@link ParameterizedTypeReference}.
+		 * Returns the raw {@link ResponseEntity} with the representation unmarshalled into an instance of the type wrapped by the given {@link ParameterizedTypeReference}.
 		 * 
 		 * @param type must not be {@literal null}.
 		 * @return


### PR DESCRIPTION
I think it makes sense to support `ParameterizedTypeReference` in `toEntity()` like it is already possible in `toObject()`. 
