### PR TITLE
#247 - Added HAL_JSON_VALUE in MediaTypes class

### DIFF
--- a/src/main/java/org/springframework/hateoas/MediaTypes.java
+++ b/src/main/java/org/springframework/hateoas/MediaTypes.java
@@ -26,12 +26,17 @@ import org.springframework.http.MediaType;
 public class MediaTypes {
 
 	/**
-	 * Public constant media type for {@code application/hal+json}.
-	 */
-	public static final MediaType HAL_JSON = MediaType.valueOf("application/hal+json");
-
-	/**
 	 * A String equivalent of {@link MediaTypes#HAL_JSON}.
 	 */
 	public static final String HAL_JSON_VALUE = "application/hal+json";
+
+	/**
+	 * Public constant media type for {@code application/hal+json}.
+	 */
+	public static final MediaType HAL_JSON;
+
+	static {
+		HAL_JSON = MediaType.valueOf(HAL_JSON_VALUE);
+	}
+
 }

--- a/src/main/java/org/springframework/hateoas/MediaTypes.java
+++ b/src/main/java/org/springframework/hateoas/MediaTypes.java
@@ -21,8 +21,17 @@ import org.springframework.http.MediaType;
  * Constants for well-known hypermedia types.
  * 
  * @author Oliver Gierke
+ * @author Przemek Nowak
  */
 public class MediaTypes {
 
+	/**
+	 * Public constant media type for {@code application/hal+json}.
+	 */
 	public static final MediaType HAL_JSON = MediaType.valueOf("application/hal+json");
+
+	/**
+	 * A String equivalent of {@link MediaTypes#HAL_JSON}.
+	 */
+	public static final String HAL_JSON_VALUE = "application/hal+json";
 }


### PR DESCRIPTION
It has been added the HAL_JSON_VALUE in MediaTypes class - similar like MediaType Spring class (pure string value which could be used i.e. @RequestMapping).