### PR TITLE
LinkBuilderFactory linkTo parameter map support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spring.version>4.0.9.RELEASE</spring.version>
 		<logback.version>1.1.3</logback.version>
-		<jackson.version>2.4.6</jackson.version>
+		<jackson.version>2.5.4</jackson.version>
 		<jaxrs.version>1.0</jaxrs.version>
 		<minidevjson.version>2.1.1</minidevjson.version>
 		<jsonpath.version>0.9.1</jsonpath.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,12 +59,12 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spring.version>4.0.9.RELEASE</spring.version>
-		<logback.version>1.1.2</logback.version>
-		<jackson.version>2.4.3</jackson.version>
+		<logback.version>1.1.3</logback.version>
+		<jackson.version>2.4.6</jackson.version>
 		<jaxrs.version>1.0</jaxrs.version>
-		<minidevjson.version>2.1.0</minidevjson.version>
+		<minidevjson.version>2.1.1</minidevjson.version>
 		<jsonpath.version>0.9.1</jsonpath.version>
-		<slf4j.version>1.7.10</slf4j.version>
+		<slf4j.version>1.7.12</slf4j.version>
 		<evo.version>1.2.1</evo.version>
 		<bundlor.failOnWarnings>true</bundlor.failOnWarnings>
 		<source.level>1.6</source.level>
@@ -88,7 +88,7 @@
 		<profile>
 			<id>spring41</id>
 			<properties>
-				<spring.version>4.1.5.RELEASE</spring.version>
+				<spring.version>4.1.6.RELEASE</spring.version>
 			</properties>
 		</profile>
 
@@ -130,7 +130,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>2.10.1</version>
+						<version>2.10.3</version>
 						<executions>
 							<execution>
 								<goals>
@@ -167,7 +167,7 @@
 				<dependency>
 					<groupId>org.springframework.data.build</groupId>
 					<artifactId>spring-data-build-resources</artifactId>
-					<version>1.5.2.RELEASE</version>
+					<version>1.6.0.RELEASE</version>
 					<scope>provided</scope>
 					<type>zip</type>
 				</dependency>
@@ -305,7 +305,7 @@
 
 					<plugin>
 						<artifactId>maven-antrun-plugin</artifactId>
-						<version>1.7</version>
+						<version>1.8</version>
 						<executions>
 
 							<execution>
@@ -355,7 +355,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-assembly-plugin</artifactId>
-						<version>2.4</version>
+						<version>2.5.4</version>
 						<executions>
 							<execution>
 								<id>static</id>
@@ -377,7 +377,7 @@
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>wagon-maven-plugin</artifactId>
-						<version>1.0-beta-5</version>
+						<version>1.0</version>
 						<configuration>
 							<fromDir>${project.build.directory}</fromDir>
 						</configuration>
@@ -593,7 +593,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.2</version>
+				<version>3.3</version>
 				<configuration>
 					<source>${source.level}</source>
 					<target>${source.level}</target>
@@ -620,7 +620,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.5</version>
+				<version>2.6</version>
 				<configuration>
 					<useDefaultManifestFile>true</useDefaultManifestFile>
 				</configuration>
@@ -643,7 +643,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.1</version>
+				<version>2.10.3</version>
 				<configuration>
 					<breakiterator>true</breakiterator>
 					<header>${project.name}</header>
@@ -661,7 +661,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.8.1</version>
+				<version>2.8.2</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>

--- a/src/main/java/org/springframework/hateoas/LinkBuilderFactory.java
+++ b/src/main/java/org/springframework/hateoas/LinkBuilderFactory.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.hateoas;
 
+import java.util.Map;
+
 /**
  * Factory for {@link LinkBuilder} instances.
  * 
@@ -41,4 +43,15 @@ public interface LinkBuilderFactory<T extends LinkBuilder> {
 	 * @return
 	 */
 	T linkTo(Class<?> target, Object... parameters);
+
+	/**
+	 * Creates a new {@link LinkBuilder} with a base of the mapping annotated to the given target class (controller,
+	 * service, etc.). Parameter map is used to fill up potentially available path variables in the class scope request
+	 * mapping.
+	 *
+	 * @param target must not be {@literal null}.
+	 * @param parameters must not be {@literal null}.
+	 * @return
+	 */
+	T linkTo(Class<?> target, Map<String, ?> parameters);
 }

--- a/src/main/java/org/springframework/hateoas/client/Hop.java
+++ b/src/main/java/org/springframework/hateoas/client/Hop.java
@@ -80,6 +80,15 @@ public class Hop {
 	}
 
 	/**
+	 * Returns whether the {@link Hop} has parameters declared.
+	 * 
+	 * @return
+	 */
+	boolean hasParameters() {
+		return !this.parameters.isEmpty();
+	}
+
+	/**
 	 * Create a new {@link Map} starting with the supplied template parameters. Then add the ones for this hop. This
 	 * allows a local hop to override global parameters.
 	 *

--- a/src/main/java/org/springframework/hateoas/client/Traverson.java
+++ b/src/main/java/org/springframework/hateoas/client/Traverson.java
@@ -391,8 +391,9 @@ public class Traverson {
 			}
 
 			HttpEntity<?> request = prepareRequest(headers);
+			UriTemplate template = new UriTemplate(uri);
 
-			ResponseEntity<String> responseEntity = operations.exchange(uri, GET, request, String.class);
+			ResponseEntity<String> responseEntity = operations.exchange(template.expand(), GET, request, String.class);
 			MediaType contentType = responseEntity.getHeaders().getContentType();
 			String responseBody = responseEntity.getBody();
 
@@ -409,7 +410,7 @@ public class Traverson {
 			/**
 			 * Don't expand if the parameters are empty
 			 */
-			if (thisHop.getParameters().isEmpty()) {
+			if (!thisHop.hasParameters()) {
 				return getAndFindLinkWithRel(link.getHref(), rels);
 			} else {
 				return getAndFindLinkWithRel(link.expand(thisHop.getMergedParameters(templateParameters)).getHref(), rels);

--- a/src/main/java/org/springframework/hateoas/hal/Jackson2HalModule.java
+++ b/src/main/java/org/springframework/hateoas/hal/Jackson2HalModule.java
@@ -127,8 +127,8 @@ public class Jackson2HalModule extends SimpleModule {
 		 * @see com.fasterxml.jackson.databind.ser.std.StdSerializer#serialize(java.lang.Object, com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)
 		 */
 		@Override
-		public void serialize(List<Link> value, JsonGenerator jgen, SerializerProvider provider) throws IOException,
-				JsonGenerationException {
+		public void serialize(List<Link> value, JsonGenerator jgen, SerializerProvider provider)
+				throws IOException, JsonGenerationException {
 
 			// sort links according to their relation
 			Map<String, List<Object>> sortedLinks = new LinkedHashMap<String, List<Object>>();
@@ -200,12 +200,12 @@ public class Jackson2HalModule extends SimpleModule {
 			return null;
 		}
 
-		/*
+		/* 
 		 * (non-Javadoc)
-		 * @see com.fasterxml.jackson.databind.ser.ContainerSerializer#isEmpty(java.lang.Object)
+		 * @see com.fasterxml.jackson.databind.JsonSerializer#isEmpty(com.fasterxml.jackson.databind.SerializerProvider, java.lang.Object)
 		 */
 		@Override
-		public boolean isEmpty(List<Link> value) {
+		public boolean isEmpty(SerializerProvider provider, List<Link> value) {
 			return value.isEmpty();
 		}
 
@@ -293,7 +293,7 @@ public class Jackson2HalModule extends SimpleModule {
 		}
 
 		@Override
-		public boolean isEmpty(Collection<?> value) {
+		public boolean isEmpty(SerializerProvider provider, Collection<?> value) {
 			return value.isEmpty();
 		}
 
@@ -424,13 +424,12 @@ public class Jackson2HalModule extends SimpleModule {
 			return false;
 		}
 
-		/*
+		/* 
 		 * (non-Javadoc)
-		 * 
-		 * @see com.fasterxml.jackson.databind.ser.ContainerSerializer#isEmpty(java.lang.Object)
+		 * @see com.fasterxml.jackson.databind.JsonSerializer#isEmpty(com.fasterxml.jackson.databind.SerializerProvider, java.lang.Object)
 		 */
 		@Override
-		public boolean isEmpty(Object arg0) {
+		public boolean isEmpty(SerializerProvider provider, Object value) {
 			return false;
 		}
 

--- a/src/main/java/org/springframework/hateoas/hal/ResourceSupportMixin.java
+++ b/src/main/java/org/springframework/hateoas/hal/ResourceSupportMixin.java
@@ -22,6 +22,8 @@ import javax.xml.bind.annotation.XmlElement;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.ResourceSupport;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -31,7 +33,8 @@ abstract class ResourceSupportMixin extends ResourceSupport {
 	@Override
 	@XmlElement(name = "link")
 	@JsonProperty("_links")
-	@JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY, using = Jackson2HalModule.HalLinkListSerializer.class)
+	@JsonInclude(Include.NON_EMPTY)
+	@JsonSerialize(using = Jackson2HalModule.HalLinkListSerializer.class)
 	@JsonDeserialize(using = Jackson2HalModule.HalLinkListDeserializer.class)
 	public abstract List<Link> getLinks();
 }

--- a/src/main/java/org/springframework/hateoas/jaxrs/JaxRsLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/jaxrs/JaxRsLinkBuilder.java
@@ -25,6 +25,8 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.util.Map;
+
 /**
  * {@link LinkBuilder} to derive URI mappings from a JAX-RS {@link Path} annotation.
  * 
@@ -64,6 +66,24 @@ public class JaxRsLinkBuilder extends LinkBuilderSupport<JaxRsLinkBuilder> {
 	 * @return
 	 */
 	public static JaxRsLinkBuilder linkTo(Class<?> service, Object... parameters) {
+
+		JaxRsLinkBuilder builder = new JaxRsLinkBuilder(ServletUriComponentsBuilder.fromCurrentServletMapping());
+
+		UriComponents uriComponents = UriComponentsBuilder.fromUriString(DISCOVERER.getMapping(service)).build();
+		UriComponents expandedComponents = uriComponents.expand(parameters);
+		return builder.slash(expandedComponents);
+	}
+
+	/**
+	 * Creates a new {@link JaxRsLinkBuilder} instance to link to the {@link Path} mapping tied to the given class binding
+	 * the given parameters to the URI template.
+	 *
+	 * @param service the class to discover the annotation on, must not be {@literal null}.
+	 * @param parameters map of additional parameters to bind to the URI template declared in the annotation, must not be
+	 *          {@literal null}.
+	 * @return
+	 */
+	public static JaxRsLinkBuilder linkTo(Class<?> service, Map<String, ?> parameters) {
 
 		JaxRsLinkBuilder builder = new JaxRsLinkBuilder(ServletUriComponentsBuilder.fromCurrentServletMapping());
 

--- a/src/main/java/org/springframework/hateoas/jaxrs/JaxRsLinkBuilderFactory.java
+++ b/src/main/java/org/springframework/hateoas/jaxrs/JaxRsLinkBuilderFactory.java
@@ -18,6 +18,8 @@ package org.springframework.hateoas.jaxrs;
 import org.springframework.hateoas.LinkBuilder;
 import org.springframework.hateoas.LinkBuilderFactory;
 
+import java.util.Map;
+
 /**
  * Factory for {@link LinkBuilder} instances based on the path mapping annotated on the given JAX-RS service.
  * 
@@ -40,6 +42,15 @@ public class JaxRsLinkBuilderFactory implements LinkBuilderFactory<JaxRsLinkBuil
 	 */
 	@Override
 	public JaxRsLinkBuilder linkTo(Class<?> service, Object... parameters) {
+		return JaxRsLinkBuilder.linkTo(service, parameters);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.hateoas.LinkBuilderFactory#linkTo(java.lang.Class, java.util.Map)
+	 */
+	@Override
+	public JaxRsLinkBuilder linkTo(Class<?> service, Map<String, ?> parameters) {
 		return JaxRsLinkBuilder.linkTo(service, parameters);
 	}
 }

--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
@@ -19,6 +19,7 @@ import static org.springframework.util.StringUtils.*;
 
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -79,6 +80,29 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 	 * @return
 	 */
 	public static ControllerLinkBuilder linkTo(Class<?> controller, Object... parameters) {
+
+		Assert.notNull(controller);
+
+		ControllerLinkBuilder builder = new ControllerLinkBuilder(getBuilder());
+		String mapping = DISCOVERER.getMapping(controller);
+
+		UriComponents uriComponents = UriComponentsBuilder.fromUriString(mapping == null ? "/" : mapping).build();
+		UriComponents expandedComponents = uriComponents.expand(parameters);
+
+		return builder.slash(expandedComponents);
+	}
+
+	/**
+	 * Creates a new {@link ControllerLinkBuilder} with a base of the mapping annotated to the given controller class.
+	 * Parameter map is used to fill up potentially available path variables in the class scope request
+	 * mapping.
+	 *
+	 * @param controller the class to discover the annotation on, must not be {@literal null}.
+	 * @param parameters additional parameters to bind to the URI template declared in the annotation, must not be
+	 *          {@literal null}.
+	 * @return
+	 */
+	public static ControllerLinkBuilder linkTo(Class<?> controller, Map<String, ?> parameters) {
 
 		Assert.notNull(controller);
 

--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilderFactory.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilderFactory.java
@@ -96,6 +96,15 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 
 	/* 
 	 * (non-Javadoc)
+	 * @see org.springframework.hateoas.LinkBuilderFactory#linkTo(java.lang.Class, java.util.Map)
+	 */
+	@Override
+	public ControllerLinkBuilder linkTo(Class<?> controller, Map<String, ?> parameters) {
+		return ControllerLinkBuilder.linkTo(controller, parameters);
+	}
+
+	/* 
+	 * (non-Javadoc)
 	 * @see org.springframework.hateoas.MethodLinkBuilderFactory#linkTo(java.lang.Class, java.lang.reflect.Method, java.lang.Object[])
 	 */
 	@Override

--- a/src/main/java/org/springframework/hateoas/mvc/TypeConstrainedMappingJackson2HttpMessageConverter.java
+++ b/src/main/java/org/springframework/hateoas/mvc/TypeConstrainedMappingJackson2HttpMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package org.springframework.hateoas.mvc;
 
+import java.lang.reflect.Type;
+
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.util.Assert;
@@ -24,7 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 /**
  * Extension of {@link MappingJackson2HttpMessageConverter} to constrain the ability to read and write HTTP message
  * based on the target type. Useful in case the {@link ObjectMapper} about to be configured has customizations that
- * sholny be applied to object trees of a certain base type.
+ * shall only be applied to object trees of a certain base type.
  * 
  * @author Oliver Gierke
  */
@@ -49,7 +51,21 @@ public class TypeConstrainedMappingJackson2HttpMessageConverter extends MappingJ
 	 */
 	@Override
 	public boolean canRead(Class<?> clazz, MediaType mediaType) {
-		return type.isAssignableFrom(clazz) && super.canRead(clazz, mediaType);
+		return type.isAssignableFrom(clazz) && super.canRead(mediaType);
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.http.converter.json.MappingJackson2HttpMessageConverter#canRead(java.lang.reflect.Type, java.lang.Class, org.springframework.http.MediaType)
+	 */
+	@Override
+	public boolean canRead(Type type, Class<?> contextClass, MediaType mediaType) {
+
+		if (type instanceof Class) {
+			return canRead((Class<?>) type, mediaType);
+		}
+
+		return super.canRead(type, contextClass, mediaType);
 	}
 
 	/* 

--- a/src/main/java/org/springframework/hateoas/mvc/TypeConstrainedMappingJackson2HttpMessageConverter.java
+++ b/src/main/java/org/springframework/hateoas/mvc/TypeConstrainedMappingJackson2HttpMessageConverter.java
@@ -51,7 +51,7 @@ public class TypeConstrainedMappingJackson2HttpMessageConverter extends MappingJ
 	 */
 	@Override
 	public boolean canRead(Class<?> clazz, MediaType mediaType) {
-		return type.isAssignableFrom(clazz) && super.canRead(mediaType);
+		return type.isAssignableFrom(clazz) && super.canRead(clazz, mediaType);
 	}
 
 	/* 
@@ -60,12 +60,8 @@ public class TypeConstrainedMappingJackson2HttpMessageConverter extends MappingJ
 	 */
 	@Override
 	public boolean canRead(Type type, Class<?> contextClass, MediaType mediaType) {
-
-		if (type instanceof Class) {
-			return canRead((Class<?>) type, mediaType);
-		}
-
-		return super.canRead(type, contextClass, mediaType);
+		return this.type.isAssignableFrom(getJavaType(type, contextClass).getRawClass())
+				&& super.canRead(type, contextClass, mediaType);
 	}
 
 	/* 

--- a/src/test/java/org/springframework/hateoas/jaxrs/JaxRsLinkBuilderFactoryUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/jaxrs/JaxRsLinkBuilderFactoryUnitTest.java
@@ -24,6 +24,9 @@ import org.junit.Test;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.TestUtils;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /**
  * Unit test for {@link JaxRsLinkBuilderFactory}.
  * 
@@ -63,6 +66,17 @@ public class JaxRsLinkBuilderFactoryUnitTest extends TestUtils {
 
 		assertThat(link.getRel(), is(Link.REL_SELF));
 		assertThat(link.getHref(), endsWith("/people/with%20blank/addresses"));
+	}
+
+	@Test
+	public void createsLinkToParameterizedServiceRootWithParameterMap() {
+		Map<String, String> pathParams = new LinkedHashMap<String, String>();
+		pathParams.put("id", "17");
+
+		Link link = factory.linkTo(PersonsAddressesService.class, pathParams).withSelfRel();
+
+		assertThat(link.getRel(), is(Link.REL_SELF));
+		assertThat(link.getHref(), endsWith("/people/17/addresses"));
 	}
 
 	@Path("/people")

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderFactoryUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderFactoryUnitTest.java
@@ -75,6 +75,18 @@ public class ControllerLinkBuilderFactoryUnitTest extends TestUtils {
 	}
 
 	@Test
+	public void createsLinkToParameterizedControllerRootWithParameterMap() {
+		Map<String, String> pathParams = new LinkedHashMap<String, String>();
+		pathParams.put("id", "17");
+
+		Link link = factory.linkTo(PersonsAddressesController.class, pathParams).withSelfRel();
+
+		assertPointsToMockServer(link);
+		assertThat(link.getRel(), is(Link.REL_SELF));
+		assertThat(link.getHref(), endsWith("/people/17/addresses"));
+	}
+
+	@Test
 	public void appliesParameterValueIfContributorConfigured() {
 
 		ControllerLinkBuilderFactory factory = new ControllerLinkBuilderFactory();

--- a/src/test/java/org/springframework/hateoas/mvc/TypeConstrainedMappingJackson2HttpMessageConverterUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/TypeConstrainedMappingJackson2HttpMessageConverterUnitTest.java
@@ -76,6 +76,5 @@ public class TypeConstrainedMappingJackson2HttpMessageConverterUnitTest {
 	private static void assertCanWrite(GenericHttpMessageConverter<Object> converter, Class<?> type, boolean expected) {
 
 		assertThat(converter.canWrite(type, APPLICATION_JSON), is(expected));
-		assertThat(converter.canWrite(type, type, APPLICATION_JSON), is(expected));
 	}
 }

--- a/src/test/java/org/springframework/hateoas/mvc/TypeConstrainedMappingJackson2HttpMessageConverterUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/TypeConstrainedMappingJackson2HttpMessageConverterUnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.ResourceSupport;
 import org.springframework.http.MediaType;
+import org.springframework.http.converter.GenericHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 
 /**
@@ -65,5 +66,17 @@ public class TypeConstrainedMappingJackson2HttpMessageConverterUnitTest {
 		assertThat(converter.canWrite(Object.class, MediaType.APPLICATION_JSON), is(false));
 		assertThat(converter.canWrite(ResourceSupport.class, MediaType.APPLICATION_JSON), is(true));
 		assertThat(converter.canWrite(Resource.class, MediaType.APPLICATION_JSON), is(true));
+	}
+
+	/**
+	 * @see #360
+	 */
+	@Test
+	public void doesNotSupportAnythingButTheConfiguredClassForCanReadWithContextClass() {
+
+		GenericHttpMessageConverter<Object> converter = new TypeConstrainedMappingJackson2HttpMessageConverter(
+				ResourceSupport.class);
+
+		assertThat(converter.canRead(String.class, Object.class, MediaType.APPLICATION_JSON), is(false));
 	}
 }

--- a/src/test/java/org/springframework/hateoas/mvc/TypeConstrainedMappingJackson2HttpMessageConverterUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/TypeConstrainedMappingJackson2HttpMessageConverterUnitTest.java
@@ -17,13 +17,12 @@ package org.springframework.hateoas.mvc;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
+import static org.springframework.http.MediaType.*;
 
 import org.junit.Test;
 import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.ResourceSupport;
-import org.springframework.http.MediaType;
 import org.springframework.http.converter.GenericHttpMessageConverter;
-import org.springframework.http.converter.HttpMessageConverter;
 
 /**
  * Unit tests for {@link TypeConstrainedMappingJackson2HttpMessageConverter}.
@@ -41,42 +40,42 @@ public class TypeConstrainedMappingJackson2HttpMessageConverterUnitTest {
 	}
 
 	/**
-	 * @see #219
+	 * @see #219, #360
 	 */
 	@Test
 	public void canReadTypeIfAssignableToConfiguredType() {
 
-		HttpMessageConverter<Object> converter = new TypeConstrainedMappingJackson2HttpMessageConverter(
+		GenericHttpMessageConverter<Object> converter = new TypeConstrainedMappingJackson2HttpMessageConverter(
 				ResourceSupport.class);
 
-		assertThat(converter.canRead(Object.class, MediaType.APPLICATION_JSON), is(false));
-		assertThat(converter.canRead(ResourceSupport.class, MediaType.APPLICATION_JSON), is(true));
-		assertThat(converter.canRead(Resource.class, MediaType.APPLICATION_JSON), is(true));
+		assertCanRead(converter, Object.class, false);
+		assertCanRead(converter, ResourceSupport.class, true);
+		assertCanRead(converter, Resource.class, true);
 	}
 
 	/**
-	 * @see #219
+	 * @see #219, #360
 	 */
 	@Test
 	public void canWriteTypeIfAssignableToConfiguredType() {
 
-		HttpMessageConverter<Object> converter = new TypeConstrainedMappingJackson2HttpMessageConverter(
-				ResourceSupport.class);
-
-		assertThat(converter.canWrite(Object.class, MediaType.APPLICATION_JSON), is(false));
-		assertThat(converter.canWrite(ResourceSupport.class, MediaType.APPLICATION_JSON), is(true));
-		assertThat(converter.canWrite(Resource.class, MediaType.APPLICATION_JSON), is(true));
-	}
-
-	/**
-	 * @see #360
-	 */
-	@Test
-	public void doesNotSupportAnythingButTheConfiguredClassForCanReadWithContextClass() {
-
 		GenericHttpMessageConverter<Object> converter = new TypeConstrainedMappingJackson2HttpMessageConverter(
 				ResourceSupport.class);
 
-		assertThat(converter.canRead(String.class, Object.class, MediaType.APPLICATION_JSON), is(false));
+		assertCanWrite(converter, Object.class, false);
+		assertCanWrite(converter, ResourceSupport.class, true);
+		assertCanWrite(converter, Resource.class, true);
+	}
+
+	private static void assertCanRead(GenericHttpMessageConverter<Object> converter, Class<?> type, boolean expected) {
+
+		assertThat(converter.canRead(type, APPLICATION_JSON), is(expected));
+		assertThat(converter.canRead(type, type, APPLICATION_JSON), is(expected));
+	}
+
+	private static void assertCanWrite(GenericHttpMessageConverter<Object> converter, Class<?> type, boolean expected) {
+
+		assertThat(converter.canWrite(type, APPLICATION_JSON), is(expected));
+		assertThat(converter.canWrite(type, type, APPLICATION_JSON), is(expected));
 	}
 }


### PR DESCRIPTION
JaxRsLinkBuilder has two linkTo methods:

```
linkTo(Class<?> service)
linkTo(Class<?> service, Object... parameters)
```

Yet there is no method for a map, which is extremely useful in case you are using UriInfo#getPathParameters() to extract parameter values.

Also, UriComponents has expand method that takes a map as an argument, so it seems logical to me to have another linkTo method:
```
linkTo(Clas<?> service, Map<String,?> parameters)
```

P.S.
Implementing this method only for JaxRsLinkBuilder wouldn't be right, so I also did it for LinkBuilderFactory and descendants