### PR TITLE
Compile against latest JAX-RS API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 		<spring.version>4.1.7.RELEASE</spring.version>
 		<logback.version>1.1.3</logback.version>
 		<jackson.version>2.5.4</jackson.version>
-		<jaxrs.version>1.0</jaxrs.version>
+		<jaxrs.version>2.0.1</jaxrs.version>
 		<minidevjson.version>2.2</minidevjson.version>
 		<jsonpath.version>2.0.0</jsonpath.version>
 		<slf4j.version>1.7.12</slf4j.version>
@@ -447,7 +447,7 @@
 
 		<dependency>
 			<groupId>javax.ws.rs</groupId>
-			<artifactId>jsr311-api</artifactId>
+			<artifactId>javax.ws.rs-api</artifactId>
 			<version>${jaxrs.version}</version>
 			<optional>true</optional>
 		</dependency>


### PR DESCRIPTION
This PR updates Spring HATEOAS' optional dependency on the JAX-RS API to use the latest version (which uses a different artifact ID). This change will make things a little easier for the Spring IO
Platform which currently provides dependency management for Jersey 2.x (which uses JAX-RS 2.0), by allowing it to stop providing dependency management for the JAX-RS 1.0 API.