### PR TITLE
Fix to Traverson double encoding issue (337) plus test case

### DIFF
--- a/src/main/java/org/springframework/hateoas/client/Traverson.java
+++ b/src/main/java/org/springframework/hateoas/client/Traverson.java
@@ -305,7 +305,7 @@ public class Traverson {
 		public <T> T toObject(Class<T> type) {
 
 			Assert.notNull(type, "Target type must not be null!");
-			return operations.exchange(traverseToFinalUrl(true), GET, prepareRequest(headers), type).getBody();
+			return operations.exchange(traverseToExpandedFinalUrl(), GET, prepareRequest(headers), type).getBody();
 		}
 
 		/**
@@ -318,7 +318,7 @@ public class Traverson {
 		public <T> T toObject(ParameterizedTypeReference<T> type) {
 
 			Assert.notNull(type, "Target type must not be null!");
-			return operations.exchange(traverseToFinalUrl(true), GET, prepareRequest(headers), type).getBody();
+			return operations.exchange(traverseToExpandedFinalUrl(), GET, prepareRequest(headers), type).getBody();
 		}
 
 		/**
@@ -332,7 +332,7 @@ public class Traverson {
 
 			Assert.hasText(jsonPath, "JSON path must not be null or empty!");
 
-			String forObject = operations.exchange(traverseToFinalUrl(true), GET, prepareRequest(headers), String.class)
+			String forObject = operations.exchange(traverseToExpandedFinalUrl(), GET, prepareRequest(headers), String.class)
 					.getBody();
 			return JsonPath.read(forObject, jsonPath);
 		}
@@ -346,7 +346,7 @@ public class Traverson {
 		public <T> ResponseEntity<T> toEntity(Class<T> type) {
 
 			Assert.notNull(type, "Target type must not be null!");
-			return operations.exchange(traverseToFinalUrl(true), GET, prepareRequest(headers), type);
+			return operations.exchange(traverseToExpandedFinalUrl(), GET, prepareRequest(headers), type);
 		}
 
 		/**
@@ -371,17 +371,23 @@ public class Traverson {
 			return traverseToLink(false);
 		}
 
-		private Link traverseToLink(boolean expandFinalUrl) {
+        private Link traverseToLink(boolean expandFinalUrl) {
 
-			Assert.isTrue(rels.size() > 0, "At least one rel needs to be provided!");
-			return new Link(traverseToFinalUrl(expandFinalUrl), rels.get(rels.size() - 1).getRel());
+            Assert.isTrue(rels.size() > 0, "At least one rel needs to be provided!");
+            return new Link(expandFinalUrl ? traverseToExpandedFinalUrl().toString() : traverseToFinalUrl(),
+                    rels.get(rels.size() - 1).getRel());
+        }
+
+		private String traverseToFinalUrl(){
+		    
+		    String uri = getAndFindLinkWithRel(baseUri.toString(), rels.iterator());
+            return new UriTemplate(uri).toString();
 		}
-
-		private String traverseToFinalUrl(boolean expandFinalUrl) {
+		
+		private URI traverseToExpandedFinalUrl() {
 
 			String uri = getAndFindLinkWithRel(baseUri.toString(), rels.iterator());
-			UriTemplate uriTemplate = new UriTemplate(uri);
-			return expandFinalUrl ? uriTemplate.expand(templateParameters).toString() : uriTemplate.toString();
+			return new UriTemplate(uri).expand(templateParameters);
 		}
 
 		private String getAndFindLinkWithRel(String uri, Iterator<Hop> rels) {

--- a/src/test/java/org/springframework/hateoas/client/Server.java
+++ b/src/test/java/org/springframework/hateoas/client/Server.java
@@ -147,6 +147,16 @@ public class Server implements Closeable {
 				respond(). //
 				withBody(springagramItemWithoutImageHalDocument). //
 				withContentType(MediaTypes.HAL_JSON.toString());
+		
+		// For Traverson URI double encoding test
+		
+		onRequest(). //
+				havingPathEqualTo("/springagram/items"). //
+				havingQueryString(equalTo("projection=no%20images")). //
+				respond(). //
+				withBody(springagramItemsHalDocument). //
+				withContentType(MediaTypes.HAL_JSON.toString());
+		
 	}
 
 	public String rootResource() {

--- a/src/test/java/org/springframework/hateoas/client/TraversonTest.java
+++ b/src/test/java/org/springframework/hateoas/client/TraversonTest.java
@@ -355,6 +355,23 @@ public class TraversonTest {
 		assertThat(item.image, equalTo(server.rootResource() + "/springagram/file/cat"));
 		assertThat(item.description, equalTo("cat"));
 	}
+	
+	/**
+	 * @see #337
+	 */
+	@Test
+	public void doesNotDoubleEncodeURI() {
+		
+		this.traverson = new Traverson(URI.create(server.rootResource() + "/springagram"), MediaTypes.HAL_JSON);
+
+		Resource<?> itemResource = traverson.//
+				follow(rel("items").withParameters(Collections.singletonMap("projection", "no images"))).//
+				toObject(Resource.class);
+
+		assertThat(itemResource.hasLink("self"), is(true));
+		assertThat(itemResource.getLink("self").expand().getHref(),
+				equalTo(server.rootResource() + "/springagram/items"));
+	}
 
 	private void setUpActors() {
 


### PR DESCRIPTION
@olivergierke @gregturn 

Hi guys, here's the PR with squashed commits, rebased onto current master (hope that's correct - first time doing some of this stuff for me..).  

It was a little more complicated in the end as my original change had broken another Traverson test case (`TraversonTest#returnsTemplatedLinkIfRequested`).  So there's now an additional private helper method in there to provide the option of traversing to a final, expanded `URI` (as required for the calls to `RESTOperations#exchange()`, or alternatively traverse to a templated String

Hope that makes sense, let me know what you think.