### PR TITLE
Add maven lifecycle mapping for springsource bundlor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -556,6 +556,36 @@
 	</dependencies>
 
 	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.eclipse.m2e</groupId>
+					<artifactId>lifecycle-mapping</artifactId>
+					<version>1.0.0</version>
+					<configuration>
+						<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>com.springsource.bundlor</groupId>
+										<artifactId>com.springsource.bundlor.maven</artifactId>
+										<versionRange>[1.0,2.0)</versionRange>
+										<goals>
+											<goal>bundlor</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<execute>
+											<runOnIncremental>true</runOnIncremental>
+										</execute>
+									</action>
+								</pluginExecution>
+							</pluginExecutions>
+						</lifecycleMappingMetadata>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>	
 
 		<extensions>
 			<extension>
@@ -566,6 +596,7 @@
 		</extensions>
 
 		<plugins>
+		
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -596,7 +596,6 @@
 		</extensions>
 
 		<plugins>
-		
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
When using spring-hateoas with the eclipse ide and its integrated maven support m2e, the project leaves a warning that it does not know how to interact with the springsource OSGi bundlor plugin for the reasons explained [here] (https://www.eclipse.org/m2e/documentation/m2e-execution-not-covered.html).

This patch explains it to run the plugin on any build and removes the warning.