### PR TITLE
Support for HATEOAS-Links in Json-Views

### DIFF
--- a/src/main/java/org/springframework/hateoas/Link.java
+++ b/src/main/java/org/springframework/hateoas/Link.java
@@ -43,8 +43,6 @@ import com.fasterxml.jackson.annotation.JsonView;
 @JsonIgnoreProperties("templated")
 public class Link implements Serializable {
 
-	public interface LinkView {}
-	
 	private static final long serialVersionUID = -9037755944661782121L;
 
 	public static final String ATOM_NAMESPACE = "http://www.w3.org/2005/Atom";
@@ -107,7 +105,7 @@ public class Link implements Serializable {
 	 * 
 	 * @return
 	 */
-	@JsonView(LinkView.class)
+	@JsonView(ResourcesLinksVisible.class)
 	public String getHref() {
 		return href;
 	}
@@ -117,7 +115,7 @@ public class Link implements Serializable {
 	 * 
 	 * @return
 	 */
-	@JsonView(LinkView.class)
+	@JsonView(ResourcesLinksVisible.class)
 	public String getRel() {
 		return rel;
 	}

--- a/src/main/java/org/springframework/hateoas/Link.java
+++ b/src/main/java/org/springframework/hateoas/Link.java
@@ -32,6 +32,7 @@ import org.springframework.util.StringUtils;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonView;
 
 /**
  * Value object for links.
@@ -42,6 +43,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties("templated")
 public class Link implements Serializable {
 
+	public interface LinkView {}
+	
 	private static final long serialVersionUID = -9037755944661782121L;
 
 	public static final String ATOM_NAMESPACE = "http://www.w3.org/2005/Atom";
@@ -104,6 +107,7 @@ public class Link implements Serializable {
 	 * 
 	 * @return
 	 */
+	@JsonView(LinkView.class)
 	public String getHref() {
 		return href;
 	}
@@ -113,6 +117,7 @@ public class Link implements Serializable {
 	 * 
 	 * @return
 	 */
+	@JsonView(LinkView.class)
 	public String getRel() {
 		return rel;
 	}

--- a/src/main/java/org/springframework/hateoas/PagedResources.java
+++ b/src/main/java/org/springframework/hateoas/PagedResources.java
@@ -26,6 +26,7 @@ import org.springframework.util.Assert;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
 
 /**
  * DTO to implement binding response representations of pageable collections.
@@ -75,6 +76,7 @@ public class PagedResources<T> extends Resources<T> {
 	 * @return the metadata
 	 */
 	@JsonProperty("page")
+	@JsonView(ResourcesLinksVisible.class)
 	public PageMetadata getMetadata() {
 		return metadata;
 	}

--- a/src/main/java/org/springframework/hateoas/Resource.java
+++ b/src/main/java/org/springframework/hateoas/Resource.java
@@ -74,7 +74,7 @@ public class Resource<T> extends ResourceSupport {
 	 */
 	@JsonUnwrapped
 	@XmlAnyElement
-	@JsonView(Link.LinkView.class)
+	@JsonView(ResourcesLinksVisible.class)
 	public T getContent() {
 		return content;
 	}

--- a/src/main/java/org/springframework/hateoas/Resource.java
+++ b/src/main/java/org/springframework/hateoas/Resource.java
@@ -24,6 +24,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import org.springframework.util.Assert;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.annotation.JsonView;
 
 /**
  * A simple {@link Resource} wrapping a domain object and adding links to it.
@@ -73,6 +74,7 @@ public class Resource<T> extends ResourceSupport {
 	 */
 	@JsonUnwrapped
 	@XmlAnyElement
+	@JsonView(Link.LinkView.class)
 	public T getContent() {
 		return content;
 	}

--- a/src/main/java/org/springframework/hateoas/ResourceSupport.java
+++ b/src/main/java/org/springframework/hateoas/ResourceSupport.java
@@ -25,6 +25,7 @@ import org.springframework.util.Assert;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
 
 /**
  * Base class for DTOs to collect links.

--- a/src/main/java/org/springframework/hateoas/ResourceSupport.java
+++ b/src/main/java/org/springframework/hateoas/ResourceSupport.java
@@ -106,7 +106,7 @@ public class ResourceSupport implements Identifiable<Link> {
 	 */
 	@XmlElement(name = "link", namespace = Link.ATOM_NAMESPACE)
 	@JsonProperty("links")
-	@JsonView(Link.LinkView.class)
+	@JsonView(ResourcesLinksVisible.class)
 	public List<Link> getLinks() {
 		return links;
 	}

--- a/src/main/java/org/springframework/hateoas/ResourceSupport.java
+++ b/src/main/java/org/springframework/hateoas/ResourceSupport.java
@@ -105,6 +105,7 @@ public class ResourceSupport implements Identifiable<Link> {
 	 */
 	@XmlElement(name = "link", namespace = Link.ATOM_NAMESPACE)
 	@JsonProperty("links")
+	@JsonView(Link.LinkView.class)
 	public List<Link> getLinks() {
 		return links;
 	}

--- a/src/main/java/org/springframework/hateoas/Resources.java
+++ b/src/main/java/org/springframework/hateoas/Resources.java
@@ -28,6 +28,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 import org.springframework.util.Assert;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.annotation.JsonView;
 
 /**
  * General helper to easily create a wrapper for a collection of entities.
@@ -101,6 +103,7 @@ public class Resources<T> extends ResourceSupport implements Iterable<T> {
 	@XmlAnyElement
 	@XmlElementWrapper
 	@JsonProperty("content")
+	@JsonView(Link.LinkView.class)
 	public Collection<T> getContent() {
 		return Collections.unmodifiableCollection(content);
 	}

--- a/src/main/java/org/springframework/hateoas/Resources.java
+++ b/src/main/java/org/springframework/hateoas/Resources.java
@@ -28,7 +28,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 import org.springframework.util.Assert;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.annotation.JsonView;
 
 /**
@@ -103,7 +102,7 @@ public class Resources<T> extends ResourceSupport implements Iterable<T> {
 	@XmlAnyElement
 	@XmlElementWrapper
 	@JsonProperty("content")
-	@JsonView(Link.LinkView.class)
+	@JsonView(ResourcesLinksVisible.class)
 	public Collection<T> getContent() {
 		return Collections.unmodifiableCollection(content);
 	}

--- a/src/main/java/org/springframework/hateoas/ResourcesLinksVisible.java
+++ b/src/main/java/org/springframework/hateoas/ResourcesLinksVisible.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas;
+
+/**
+ * Parent interface to mark {@link Resource}(s) beans that {@link Link}s and Resource
+ * {@code content} are part of a JSON view.
+ * 
+ * Usage: subinterface and mark all view relevant properties of your bean
+ * {@code @JSonView(SubInterface.class)}. Then serialize bean of {@code new Resource<>(bean)} to
+ * JSON. Your ({@code content} with) relevant properties and all associated {@code labels} will be
+ * visible.
+ * 
+ * @see com.fasterxml.jackson.annotation.JsonView
+ * @since 0.18.0
+ *
+ * @author Karsten Tinnefeld
+ */
+public interface ResourcesLinksVisible {}

--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
@@ -235,6 +235,7 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 	 * 
 	 * @return
 	 */
+	@SuppressWarnings("null")
 	private static HttpServletRequest getCurrentRequest() {
 
 		RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();

--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
@@ -235,7 +235,6 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 	 * 
 	 * @return
 	 */
-	@SuppressWarnings("null")
 	private static HttpServletRequest getCurrentRequest() {
 
 		RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();

--- a/src/test/java/org/springframework/hateoas/ResourceLinksVisibleTest.java
+++ b/src/test/java/org/springframework/hateoas/ResourceLinksVisibleTest.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for the {@link ResourcesLinksVisible} marker interface.
+ * 
+ * The marker face is used to enable JSON serialization filter annotations applied to {@Resource}s
+ * as intended by providing a reasonable base marker interface for those annotations.
+ * 
+ * The {@link JsonView} annotation supports filtering class trees in order to provide custom views
+ * on specific partial data
+ * 
+ * The main purpose of {@link ResourcesLinksVisible} is to provide a means of views including the
+ * links properties of REST models using {@link Resource}/{@link Resources} support.
+ * 
+ * <b>Usage</b> extend {@link ResourcesLinksVisible} to denote your view properties or use a common
+ * subinterface including {@link ResourcesLinksVisible}.
+ *
+ * @see https://spring.io/blog/2014/12/02/latest-jackson-integration-improvements-in-spring
+ * @author Karsten Tinnefeld
+ */
+public class ResourceLinksVisibleTest {
+
+	private ObjectMapper mapper;
+	private Link someLink;
+
+	@Before
+	public void setUp() {
+
+		mapper = new ObjectMapper();
+		mapper.setSerializationInclusion(NON_NULL);
+
+		someLink = new Link("localhost");
+	}
+
+	/**
+	 * Under normal processing, {@link Resource}s just map to a JSON object with a links field
+	 * added.
+	 * 
+	 * @throws JsonProcessingException Treat JSON processing errors as test failures.
+	 */
+	@Test
+	public void resourceSerializationHasVisibleFieldsAndLinks()
+			throws JsonProcessingException {
+
+		SomeBean someBean = new SomeBean();
+		String serializedBean = mapper.writeValueAsString(someBean);
+
+		assertContains("text field missing", serializedBean, "content");
+		assertContains("number field missing", serializedBean, "1.5");
+		assertDoesNotContains("invisible field found", serializedBean, "true");
+		assertDoesNotContains("where do these links come from", serializedBean,
+				"localhost");
+
+		String serializedResource =
+				mapper.writeValueAsString(new Resource<SomeBean>(someBean, someLink));
+
+		assertContains("text field missing", serializedResource, "content");
+		assertContains("number field missing", serializedResource, "1.5");
+		assertDoesNotContains("invisible field found", serializedResource, "true");
+		assertContains("links missing", serializedResource, "localhost");
+	}
+
+	/**
+	 * Under normal processing, {@link Resources} map to a JSON array with a links field added.
+	 * 
+	 * @throws JsonProcessingException Treat JSON processing errors as test failures.
+	 */
+	@Test
+	public void resourcesSerializationHasVisibleFieldsAndLinks()
+			throws JsonProcessingException {
+
+		SomeBean someBean = new SomeBean();
+		Collection<SomeBean> someBeans = Arrays.asList(someBean, someBean, someBean);
+
+		String serializedResources =
+				mapper.writeValueAsString(new Resources<SomeBean>(someBeans, someLink));
+
+		assertContains("text field missing", serializedResources, "content");
+		assertContains("number field missing", serializedResources, "1.5");
+		assertDoesNotContains("invisible field found", serializedResources, "true");
+
+		assertHasSeveralOf("text field expected three times", serializedResources, 3,
+				"number");
+		assertContains("links missing", serializedResources, "localhost");
+	}
+
+	/**
+	 * Under processing with a view, however, {@link Resource}s just map to the empty object and are
+	 * thus not very useful.
+	 * 
+	 * Annotation based usage would be something like
+	 * 
+	 * <pre>
+	 * &#64;RestController
+	 * &#64;JsonView(NewJsonView.class)
+	 * public Resource<BeanWithView> viewToABean() { ... }
+	 * </pre>
+	 * 
+	 * @throws JsonProcessingException Treat JSON processing errors as test failures.
+	 */
+	@Test
+	public void resourceSerializationOfViewMissesLinks() throws JsonProcessingException {
+
+		ObjectWriter newJsonViewBasedWriter = mapper.writerWithView(NewJsonView.class);
+
+		BeanWithView someBean = new BeanWithView();
+		String serializedBean = newJsonViewBasedWriter.writeValueAsString(someBean);
+
+		assertContains("text field missing", serializedBean, "content");
+		assertContains("number field missing", serializedBean, "1.5");
+		assertDoesNotContains("invisible field found", serializedBean, "true");
+		assertDoesNotContains("where do these links come from", serializedBean,
+				"localhost");
+
+		String serializedResource = newJsonViewBasedWriter
+				.writeValueAsString(new Resource<BeanWithView>(someBean, someLink));
+		assertEquals("Empty JSON object expected", "{}", serializedResource);
+	}
+
+	/**
+	 * Under processing with a view, however, {@link Resources} just map to the empty object and are
+	 * thus not very useful.
+	 * 
+	 * Annotation based usage would be something like
+	 * 
+	 * <pre>
+	 * &#64;RestController
+	 * &#64;JsonView(NewJsonView.class)
+	 * public Resources<BeanWithView> viewToSomeBean() { ... }
+	 * </pre>
+	 * 
+	 * @throws JsonProcessingException Treat JSON processing errors as test failures.
+	 */
+	@Test
+	public void resourcesSerializationOfViewMissesLinks() throws JsonProcessingException {
+
+		ObjectWriter newJsonViewBasedWriter = mapper.writerWithView(NewJsonView.class);
+
+		BeanWithView someBean = new BeanWithView();
+		Collection<BeanWithView> someBeans = Arrays.asList(someBean, someBean, someBean);
+
+		String serializedResources = newJsonViewBasedWriter
+				.writeValueAsString(new Resources<BeanWithView>(someBeans, someLink));
+
+		assertEquals("Empty JSON object expected", "{}", serializedResources);
+	}
+
+	/**
+	 * Using views which inherit from the {@link ResourcesLinksVisible} marker interface, however,
+	 * views to objects are processed in more a sensible way.
+	 * 
+	 * @throws JsonProcessingException Treat JSON processing errors as test failures.
+	 */
+	@Test
+	public void resourceSerializationWithResourcesLinksVisibleSeesLinks()
+			throws JsonProcessingException {
+
+		ObjectWriter jsonViewWithLinksBasedWriter =
+				mapper.writerWithView(JSonViewWithLinks.class);
+
+		BeanWithView someBean = new BeanWithView();
+		String serializedBean = jsonViewWithLinksBasedWriter.writeValueAsString(someBean);
+
+		assertContains("text field missing", serializedBean, "content");
+		assertContains("number field missing", serializedBean, "1.5");
+		assertDoesNotContains("invisible field found", serializedBean, "true");
+		assertDoesNotContains("where do these links come from", serializedBean,
+				"localhost");
+
+		String serializedResource = jsonViewWithLinksBasedWriter
+				.writeValueAsString(new Resource<BeanWithView>(someBean, someLink));
+
+		assertContains("text field missing", serializedResource, "content");
+		assertContains("number field missing", serializedResource, "1.5");
+		assertDoesNotContains("invisible field found", serializedResource, "true");
+		assertContains("links missing", serializedResource, "localhost");
+	}
+
+	/**
+	 * Using views which inherit from the {@link ResourcesLinksVisible} marker interface, however,
+	 * views to objects are processed in more a sensible way.
+	 * 
+	 * @throws JsonProcessingException Treat JSON processing errors as test failures.
+	 */
+	@Test
+	public void resourcesSerializationWithResourcesLinksVisibleSeesLinks()
+			throws JsonProcessingException {
+
+		ObjectWriter jsonViewWithLinksBasedWriter =
+				mapper.writerWithView(JSonViewWithLinks.class);
+
+		BeanWithView someBean = new BeanWithView();
+		Collection<BeanWithView> someBeans = Arrays.asList(someBean, someBean, someBean);
+
+		String serializedResources = jsonViewWithLinksBasedWriter
+				.writeValueAsString(new Resources<BeanWithView>(someBeans, someLink));
+
+		assertContains("text field missing", serializedResources, "content");
+		assertContains("number field missing", serializedResources, "1.5");
+		assertDoesNotContains("invisible field found", serializedResources, "true");
+
+		assertHasSeveralOf("text field expected three times", serializedResources, 3,
+				"number");
+		assertContains("links missing", serializedResources, "localhost");
+	}
+
+	public static interface NewJsonView {}
+	public static interface JSonViewWithLinks
+			extends ResourcesLinksVisible, NewJsonView {}
+
+	public static class SomeBean {
+		public double getNumber() {
+			return 1.5d;
+		}
+
+		public String getText() {
+			return "content";
+		}
+
+		@JsonIgnore
+		public boolean isInvisible() {
+			return true;
+		}
+	}
+
+	public static class BeanWithView {
+		@JsonView(NewJsonView.class)
+		public double getNumber() {
+			return 1.5d;
+		}
+
+		@JsonView(NewJsonView.class)
+		public String getText() {
+			return "content";
+		}
+
+		@JsonIgnore
+		public boolean isInvisible() {
+			return true;
+		}
+	}
+
+	private void assertContains(String message, String fullstring, String part) {
+		assertNotNull(message, fullstring);
+		assertNotNull(message, part);
+		assertTrue(message, fullstring.contains(part));
+	}
+
+	private void assertDoesNotContains(String message, String fullstring, String part) {
+		assertNotNull(message, part);
+		assertTrue(message, fullstring == null || !fullstring.contains(part));
+	}
+
+	private void assertHasSeveralOf(String message, String fullstring, int number,
+			String part) {
+		assertNotNull(message, fullstring);
+		assertNotNull(message, part);
+		String quotedPart = Pattern.quote(part);
+		String[] fullstringParts = fullstring.split(quotedPart);
+		assertEquals(message, number + 1, fullstringParts.length);
+	}
+}

--- a/src/test/java/org/springframework/hateoas/ResourceLinksVisibleTest.java
+++ b/src/test/java/org/springframework/hateoas/ResourceLinksVisibleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The @JsonView annotation supports filtering class trees in order to provide custom views on specific partial data, cf. eg. https://spring.io/blog/2014/12/02/latest-jackson-integration-improvements-in-spring

The main purpose of this patch is to provide a means of views including the links properties of REST models using Resource(s). See the tests in ResourceLinksVisibleTest for further discussion.

Usage: extend ResourceLinkView to denote your view properties.

(This pull request supersedes pull request #359 and solves issue #351.)
