### PR TITLE
Issue #361: Add Support for Resolving Property Values

### DIFF
--- a/src/main/java/org/springframework/hateoas/core/AnnotationMappingDiscoverer.java
+++ b/src/main/java/org/springframework/hateoas/core/AnnotationMappingDiscoverer.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
 import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertyResolver;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -68,7 +69,7 @@ public class AnnotationMappingDiscoverer implements MappingDiscoverer {
 		return getMapping(null, type);
 	}
 	
-	public String getMapping(Environment environment, Class<?> type) {
+	public String getMapping(PropertyResolver resolver, Class<?> type) {
 
 		Assert.notNull(type, "Type must not be null!");
 
@@ -79,7 +80,7 @@ public class AnnotationMappingDiscoverer implements MappingDiscoverer {
 					type.getName()));
 		}
 
-		return mapping.length == 0 ? null : maybeResolveValue(environment, mapping[0]);
+		return mapping.length == 0 ? null : maybeResolveValue(resolver, mapping[0]);
 	}
 
 	/* 
@@ -91,9 +92,9 @@ public class AnnotationMappingDiscoverer implements MappingDiscoverer {
 		return getMapping(method, null);
 	}
 	
-	public String getMapping(Method method, Environment environment) {
+	public String getMapping(Method method, PropertyResolver resolver) {
 		Assert.notNull(method, "Method must not be null!");
-		return getMapping(method.getDeclaringClass(), method, environment);
+		return getMapping(method.getDeclaringClass(), method, resolver);
 	}
 
 	/* 
@@ -105,7 +106,7 @@ public class AnnotationMappingDiscoverer implements MappingDiscoverer {
 		return getMapping(type, method, null);
 	}
 	
-	public String getMapping(Class<?> type, Method method, Environment environment) {
+	public String getMapping(Class<?> type, Method method, PropertyResolver resolver) {
 
 		Assert.notNull(type, "Type must not be null!");
 		Assert.notNull(method, "Method must not be null!");
@@ -124,7 +125,7 @@ public class AnnotationMappingDiscoverer implements MappingDiscoverer {
 		}
 
 		String returnValue = (typeMapping == null || "/".equals(typeMapping) ? mapping[0] : typeMapping + mapping[0]);
-		return maybeResolveValue(environment, returnValue);
+		return maybeResolveValue(resolver, returnValue);
 	}
 
 	private String[] getMappingFrom(Annotation annotation) {
@@ -143,9 +144,9 @@ public class AnnotationMappingDiscoverer implements MappingDiscoverer {
 				"Unsupported type for the mapping attribute! Support String and String[] but got %s!", value.getClass()));
 	}
 	
-	private String maybeResolveValue(Environment environment, String value) {
-		if (environment != null && StringUtils.hasText(value)) {
-			value = environment.resolvePlaceholders(value);
+	private String maybeResolveValue(PropertyResolver resolver, String value) {
+		if (resolver != null && StringUtils.hasText(value)) {
+			value = resolver.resolvePlaceholders(value);
 		}
 		
 		return value;

--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
@@ -22,7 +22,7 @@ import java.net.URI;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertyResolver;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.core.AnnotationMappingDiscoverer;
 import org.springframework.hateoas.core.DummyInvocationUtils;
@@ -78,8 +78,8 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 	 * @param controller the class to discover the annotation on, must not be {@literal null}.
 	 * @return
 	 */
-	public static ControllerLinkBuilder linkTo(Environment environment, Class<?> controller) {
-		return linkTo(environment, controller, new Object[0]);
+	public static ControllerLinkBuilder linkTo(PropertyResolver resolver, Class<?> controller) {
+		return linkTo(resolver, controller, new Object[0]);
 	}
 
 	/**
@@ -106,12 +106,12 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 	 * @param parameters
 	 * @return
 	 */
-	public static ControllerLinkBuilder linkTo(Environment env, Class<?> controller, Object... parameters) {
+	public static ControllerLinkBuilder linkTo(PropertyResolver resolver, Class<?> controller, Object... parameters) {
 
 		Assert.notNull(controller);
 
 		ControllerLinkBuilder builder = new ControllerLinkBuilder(getBuilder());
-		String mapping = ((AnnotationMappingDiscoverer)DISCOVERER).getMapping(env, controller);
+		String mapping = ((AnnotationMappingDiscoverer)DISCOVERER).getMapping(resolver, controller);
 
 		UriComponents uriComponents = UriComponentsBuilder.fromUriString(mapping == null ? "/" : mapping).build();
 		UriComponents expandedComponents = uriComponents.expand(parameters);
@@ -128,17 +128,17 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 	
 	/**
 	 * Similar to {@link org.springframework.hateoas.MethodLinkBuilderFactory#linkTo(Method, Object...)}
-	 * but takes an optional {@link Environment} parameter. If it is non-null, it will attempt to resolve
+	 * but takes an optional {@link PropertyResolver} parameter. If it is non-null, it will attempt to resolve
 	 * any placeholders in requestMappings that were found.
 	 *
-	 * @param env
+	 * @param resolver
 	 * @param method
 	 * @param parameters
 	 * @see org.springframework.hateoas.MethodLinkBuilderFactory#linkTo(Method, Object...)
 	 * @return
 	 */
-	public static ControllerLinkBuilder linkTo(Environment env, Method method, Object... parameters) {
-		return linkTo(env, method.getDeclaringClass(), method, parameters);
+	public static ControllerLinkBuilder linkTo(PropertyResolver resolver, Method method, Object... parameters) {
+		return linkTo(resolver, method.getDeclaringClass(), method, parameters);
 	}
 
 	/*
@@ -150,22 +150,22 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 	
 	/**
 	 * Similar to {@link org.springframework.hateoas.MethodLinkBuilderFactory#linkTo(Class<?>, Method, Object...)}
-	 * but takes an optional {@link Environment} parameter. If it is non-null, it will attempt to resolve
+	 * but takes an optional {@link PropertyResolver} parameter. If it is non-null, it will attempt to resolve
 	 * any placeholders in requestMappings that were found.
 	 * 
-	 * @param env
+	 * @param resolver
 	 * @param controller
 	 * @param method
 	 * @param parameters
 	 * @see org.springframework.hateoas.MethodLinkBuilderFactory#linkTo(Class<?>, Method, Object...)
 	 * @return
 	 */
-	public static ControllerLinkBuilder linkTo(Environment env, Class<?> controller, Method method, Object... parameters) {
+	public static ControllerLinkBuilder linkTo(PropertyResolver resolver, Class<?> controller, Method method, Object... parameters) {
 
 		Assert.notNull(controller, "Controller type must not be null!");
 		Assert.notNull(method, "Method must not be null!");
 
-		UriTemplate template = new UriTemplate(((AnnotationMappingDiscoverer)DISCOVERER).getMapping(controller, method, env));
+		UriTemplate template = new UriTemplate(((AnnotationMappingDiscoverer)DISCOVERER).getMapping(controller, method, resolver));
 		URI uri = template.expand(parameters);
 
 		return new ControllerLinkBuilder(getBuilder()).slash(uri);
@@ -212,19 +212,19 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 	 * Link link = linkTo(methodOn(CustomerController.class).showAddresses(2L)).withRel("addresses");
 	 * </pre>
 	 * 
-	 * If the {@link Environment} parameter is non-null, it will attempt to resolve any placeholders
+	 * If the {@link PropertyResolver} parameter is non-null, it will attempt to resolve any placeholders
 	 * found in the mapping 
 	 * 
 	 * The resulting {@link Link} instance will point to {@code /customers/2/addresses} and have a rel of
 	 * {@code addresses}. For more details on the method invocation constraints, see
 	 * {@link DummyInvocationUtils#methodOn(Class, Object...)}.
 	 * 
-	 * @param environment
+	 * @param resolver
 	 * @param invocationValue
 	 * @return
 	 */
-	public static ControllerLinkBuilder linkTo(Environment environment, Object invocationValue) {
-		return FACTORY.linkTo(environment, invocationValue);
+	public static ControllerLinkBuilder linkTo(PropertyResolver resolver, Object invocationValue) {
+		return FACTORY.linkTo(resolver, invocationValue);
 	}
 
 	/**

--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
@@ -22,6 +22,7 @@ import java.net.URI;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.springframework.core.env.Environment;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.core.AnnotationMappingDiscoverer;
 import org.springframework.hateoas.core.DummyInvocationUtils;
@@ -43,6 +44,7 @@ import org.springframework.web.util.UriTemplate;
  * @author Oliver Gierke
  * @author Kamill Sokol
  * @author Greg Turnquist
+ * @author Josh Ghiloni
  */
 public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuilder> {
 
@@ -66,7 +68,18 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 	 * @return
 	 */
 	public static ControllerLinkBuilder linkTo(Class<?> controller) {
-		return linkTo(controller, new Object[0]);
+		return linkTo(null, controller, new Object[0]);
+	}
+
+	/**
+	 * Creates a new {@link ControllerLinkBuilder} with a base of the mapping annotated to the given controller class.
+	 * 
+	 * @param env If not {@literal null}, it will attempt to resolve placeholders in mappings
+	 * @param controller the class to discover the annotation on, must not be {@literal null}.
+	 * @return
+	 */
+	public static ControllerLinkBuilder linkTo(Environment environment, Class<?> controller) {
+		return linkTo(environment, controller, new Object[0]);
 	}
 
 	/**
@@ -79,11 +92,26 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 	 * @return
 	 */
 	public static ControllerLinkBuilder linkTo(Class<?> controller, Object... parameters) {
+		return linkTo(null, controller, parameters);
+	}
+	
+	/**
+	 * Creates a new {@link ControllerLinkBuilder} with a base of the mapping annotated to the given controller class. The
+	 * additional parameters are used to fill up potentially available path variables in the class scop request mapping.
+	 * 
+	 * If the env parameter is non-null, it will attempt to resolve any placeholders found in mappings
+	 * 
+	 * @param env
+	 * @param controller
+	 * @param parameters
+	 * @return
+	 */
+	public static ControllerLinkBuilder linkTo(Environment env, Class<?> controller, Object... parameters) {
 
 		Assert.notNull(controller);
 
 		ControllerLinkBuilder builder = new ControllerLinkBuilder(getBuilder());
-		String mapping = DISCOVERER.getMapping(controller);
+		String mapping = ((AnnotationMappingDiscoverer)DISCOVERER).getMapping(env, controller);
 
 		UriComponents uriComponents = UriComponentsBuilder.fromUriString(mapping == null ? "/" : mapping).build();
 		UriComponents expandedComponents = uriComponents.expand(parameters);
@@ -95,18 +123,49 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 	 * @see org.springframework.hateoas.MethodLinkBuilderFactory#linkTo(Method, Object...)
 	 */
 	public static ControllerLinkBuilder linkTo(Method method, Object... parameters) {
-		return linkTo(method.getDeclaringClass(), method, parameters);
+		return linkTo(null, method.getDeclaringClass(), method, parameters);
+	}
+	
+	/**
+	 * Similar to {@link org.springframework.hateoas.MethodLinkBuilderFactory#linkTo(Method, Object...)}
+	 * but takes an optional {@link Environment} parameter. If it is non-null, it will attempt to resolve
+	 * any placeholders in requestMappings that were found.
+	 *
+	 * @param env
+	 * @param method
+	 * @param parameters
+	 * @see org.springframework.hateoas.MethodLinkBuilderFactory#linkTo(Method, Object...)
+	 * @return
+	 */
+	public static ControllerLinkBuilder linkTo(Environment env, Method method, Object... parameters) {
+		return linkTo(env, method.getDeclaringClass(), method, parameters);
 	}
 
 	/*
 	 * @see org.springframework.hateoas.MethodLinkBuilderFactory#linkTo(Class<?>, Method, Object...)
 	 */
 	public static ControllerLinkBuilder linkTo(Class<?> controller, Method method, Object... parameters) {
+		return linkTo(null, controller, method, parameters);
+	}
+	
+	/**
+	 * Similar to {@link org.springframework.hateoas.MethodLinkBuilderFactory#linkTo(Class<?>, Method, Object...)}
+	 * but takes an optional {@link Environment} parameter. If it is non-null, it will attempt to resolve
+	 * any placeholders in requestMappings that were found.
+	 * 
+	 * @param env
+	 * @param controller
+	 * @param method
+	 * @param parameters
+	 * @see org.springframework.hateoas.MethodLinkBuilderFactory#linkTo(Class<?>, Method, Object...)
+	 * @return
+	 */
+	public static ControllerLinkBuilder linkTo(Environment env, Class<?> controller, Method method, Object... parameters) {
 
 		Assert.notNull(controller, "Controller type must not be null!");
 		Assert.notNull(method, "Method must not be null!");
 
-		UriTemplate template = new UriTemplate(DISCOVERER.getMapping(controller, method));
+		UriTemplate template = new UriTemplate(((AnnotationMappingDiscoverer)DISCOVERER).getMapping(controller, method, env));
 		URI uri = template.expand(parameters);
 
 		return new ControllerLinkBuilder(getBuilder()).slash(uri);
@@ -135,7 +194,37 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 	 * @return
 	 */
 	public static ControllerLinkBuilder linkTo(Object invocationValue) {
-		return FACTORY.linkTo(invocationValue);
+		return FACTORY.linkTo(null, invocationValue);
+	}
+	
+	/**
+	 * Creates a {@link ControllerLinkBuilder} pointing to a controller method. Hand in a dummy method invocation result
+	 * you can create via {@link #methodOn(Class, Object...)} or {@link DummyInvocationUtils#methodOn(Class, Object...)}.
+	 * 
+	 * <pre>
+	 * @RequestMapping("/customers")
+	 * class CustomerController {
+	 * 
+	 *   @RequestMapping("/{id}/addresses")
+	 *   HttpEntity&lt;Addresses&gt; showAddresses(@PathVariable Long id) { … } 
+	 * }
+	 * 
+	 * Link link = linkTo(methodOn(CustomerController.class).showAddresses(2L)).withRel("addresses");
+	 * </pre>
+	 * 
+	 * If the {@link Environment} parameter is non-null, it will attempt to resolve any placeholders
+	 * found in the mapping 
+	 * 
+	 * The resulting {@link Link} instance will point to {@code /customers/2/addresses} and have a rel of
+	 * {@code addresses}. For more details on the method invocation constraints, see
+	 * {@link DummyInvocationUtils#methodOn(Class, Object...)}.
+	 * 
+	 * @param environment
+	 * @param invocationValue
+	 * @return
+	 */
+	public static ControllerLinkBuilder linkTo(Environment environment, Object invocationValue) {
+		return FACTORY.linkTo(environment, invocationValue);
 	}
 
 	/**

--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilderFactory.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilderFactory.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.core.MethodParameter;
-import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertyResolver;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.MethodLinkBuilderFactory;
 import org.springframework.hateoas.core.AnnotationAttribute;
@@ -86,8 +86,8 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 		return ControllerLinkBuilder.linkTo(controller);
 	}
 	
-	public ControllerLinkBuilder linkTo(Environment env, Class<?> controller) {
-		return ControllerLinkBuilder.linkTo(env, controller);
+	public ControllerLinkBuilder linkTo(PropertyResolver resolver, Class<?> controller) {
+		return ControllerLinkBuilder.linkTo(resolver, controller);
 	}
 
 	/*
@@ -99,8 +99,8 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 		return ControllerLinkBuilder.linkTo(controller, parameters);
 	}
 	
-	public ControllerLinkBuilder linkTo(Environment env, Class<?> controller, Object... parameters) {
-		return ControllerLinkBuilder.linkTo(env, controller, parameters);
+	public ControllerLinkBuilder linkTo(PropertyResolver resolver, Class<?> controller, Object... parameters) {
+		return ControllerLinkBuilder.linkTo(resolver, controller, parameters);
 	}
 
 	/* 
@@ -112,8 +112,8 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 		return ControllerLinkBuilder.linkTo(controller, method, parameters);
 	}
 	
-	public ControllerLinkBuilder linkTo(Environment env, Class<?> controller, Method method, Object... parameters) {
-		return ControllerLinkBuilder.linkTo(env, controller, method, parameters);
+	public ControllerLinkBuilder linkTo(PropertyResolver resolver, Class<?> controller, Method method, Object... parameters) {
+		return ControllerLinkBuilder.linkTo(resolver, controller, method, parameters);
 	}
 
 	/* 
@@ -125,7 +125,7 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 		return linkTo(null, invocationValue);
 	}
 	
-	public ControllerLinkBuilder linkTo(Environment env, Object invocationValue) {
+	public ControllerLinkBuilder linkTo(PropertyResolver resolver, Object invocationValue) {
 
 		Assert.isInstanceOf(LastInvocationAware.class, invocationValue);
 		LastInvocationAware invocations = (LastInvocationAware) invocationValue;
@@ -134,7 +134,7 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 		Iterator<Object> classMappingParameters = invocations.getObjectParameters();
 		Method method = invocation.getMethod();
 
-		String mapping = ((AnnotationMappingDiscoverer)DISCOVERER).getMapping(invocation.getTargetType(), method, env);
+		String mapping = ((AnnotationMappingDiscoverer)DISCOVERER).getMapping(invocation.getTargetType(), method, resolver);
 		UriComponentsBuilder builder = ControllerLinkBuilder.getBuilder().path(mapping);
 
 		UriTemplate template = new UriTemplate(mapping);
@@ -166,8 +166,8 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 		return ControllerLinkBuilder.linkTo(method, parameters);
 	}
 	
-	public ControllerLinkBuilder linkTo(Environment env, Method method, Object... parameters) {
-		return ControllerLinkBuilder.linkTo(env, method, parameters);
+	public ControllerLinkBuilder linkTo(PropertyResolver resolver, Method method, Object... parameters) {
+		return ControllerLinkBuilder.linkTo(resolver, method, parameters);
 	}
 
 	/**

--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilderFactory.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilderFactory.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.core.MethodParameter;
+import org.springframework.core.env.Environment;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.MethodLinkBuilderFactory;
 import org.springframework.hateoas.core.AnnotationAttribute;
@@ -84,6 +85,10 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 	public ControllerLinkBuilder linkTo(Class<?> controller) {
 		return ControllerLinkBuilder.linkTo(controller);
 	}
+	
+	public ControllerLinkBuilder linkTo(Environment env, Class<?> controller) {
+		return ControllerLinkBuilder.linkTo(env, controller);
+	}
 
 	/*
 	 * (non-Javadoc)
@@ -92,6 +97,10 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 	@Override
 	public ControllerLinkBuilder linkTo(Class<?> controller, Object... parameters) {
 		return ControllerLinkBuilder.linkTo(controller, parameters);
+	}
+	
+	public ControllerLinkBuilder linkTo(Environment env, Class<?> controller, Object... parameters) {
+		return ControllerLinkBuilder.linkTo(env, controller, parameters);
 	}
 
 	/* 
@@ -102,6 +111,10 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 	public ControllerLinkBuilder linkTo(Class<?> controller, Method method, Object... parameters) {
 		return ControllerLinkBuilder.linkTo(controller, method, parameters);
 	}
+	
+	public ControllerLinkBuilder linkTo(Environment env, Class<?> controller, Method method, Object... parameters) {
+		return ControllerLinkBuilder.linkTo(env, controller, method, parameters);
+	}
 
 	/* 
 	 * (non-Javadoc)
@@ -109,6 +122,10 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 	 */
 	@Override
 	public ControllerLinkBuilder linkTo(Object invocationValue) {
+		return linkTo(null, invocationValue);
+	}
+	
+	public ControllerLinkBuilder linkTo(Environment env, Object invocationValue) {
 
 		Assert.isInstanceOf(LastInvocationAware.class, invocationValue);
 		LastInvocationAware invocations = (LastInvocationAware) invocationValue;
@@ -117,7 +134,7 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 		Iterator<Object> classMappingParameters = invocations.getObjectParameters();
 		Method method = invocation.getMethod();
 
-		String mapping = DISCOVERER.getMapping(invocation.getTargetType(), method);
+		String mapping = ((AnnotationMappingDiscoverer)DISCOVERER).getMapping(invocation.getTargetType(), method, env);
 		UriComponentsBuilder builder = ControllerLinkBuilder.getBuilder().path(mapping);
 
 		UriTemplate template = new UriTemplate(mapping);
@@ -147,6 +164,10 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 	@Override
 	public ControllerLinkBuilder linkTo(Method method, Object... parameters) {
 		return ControllerLinkBuilder.linkTo(method, parameters);
+	}
+	
+	public ControllerLinkBuilder linkTo(Environment env, Method method, Object... parameters) {
+		return ControllerLinkBuilder.linkTo(env, method, parameters);
 	}
 
 	/**


### PR DESCRIPTION
Add Support for Resolving Property Values in @RequestMapping(value)

Creates extra methods in `AnnotationMappingDiscoverer`, `ControllerLinkBuilder`, and `ControllerLinkBuilderFactory` to take an `Environment` object that can be used resolve placeholders. Accepts null `Environment`s to allow for backward compatibility.
