### PR TITLE
Added VndErrorException

### DIFF
--- a/src/main/java/org/springframework/hateoas/VndErrorException.java
+++ b/src/main/java/org/springframework/hateoas/VndErrorException.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpStatusCodeException;
+
+import java.nio.charset.Charset;
+
+/**
+ * A base exception used for propagating the {@link VndErrors} received from remote service call.
+ *
+ * @author Jakub Narloch
+ * @see VndErrors
+ */
+public class VndErrorException extends HttpStatusCodeException {
+
+    /**
+     * The vnd errors.
+     */
+    private final VndErrors vndErrors;
+
+    /**
+     * Creates new instance of {@link VndErrorException} with status code and vnd errors.
+     *
+     * @param statusCode      the status code
+     * @param vndErrors       the vnd errors
+     */
+    public VndErrorException(HttpStatus statusCode, VndErrors vndErrors) {
+        super(statusCode);
+        this.vndErrors = vndErrors;
+    }
+
+    /**
+     * Creates new instance of {@link VndErrorException} with status code and vnd errors.
+     *
+     * @param statusCode      the status code
+     * @param statusText      the status text
+     * @param vndErrors       the vnd errors
+     */
+    public VndErrorException(HttpStatus statusCode, String statusText, VndErrors vndErrors) {
+        super(statusCode, statusText);
+        this.vndErrors = vndErrors;
+    }
+
+    /**
+     * Creates new instance of {@link VndErrorException} with status code, response body and vnd errors.
+     *
+     * @param statusCode      the status code
+     * @param statusText      the status text
+     * @param responseBody    the response body
+     * @param responseCharset the response charset
+     * @param vndErrors       the vnd errors
+     */
+    public VndErrorException(HttpStatus statusCode, String statusText, byte[] responseBody, Charset responseCharset,
+                             VndErrors vndErrors) {
+        super(statusCode, statusText, responseBody, responseCharset);
+        this.vndErrors = vndErrors;
+    }
+
+    /**
+     * Creates new instance of {@link VndErrorException} with status code, http headers, response body and vnd errors.
+     *
+     * @param statusCode      the status code
+     * @param statusText      the status text
+     * @param responseHeaders the response headers
+     * @param responseBody    the response body
+     * @param responseCharset the response charset
+     * @param vndErrors       the vnd errors
+     */
+    public VndErrorException(HttpStatus statusCode, String statusText, HttpHeaders responseHeaders, byte[] responseBody,
+                             Charset responseCharset, VndErrors vndErrors) {
+        super(statusCode, statusText, responseHeaders, responseBody, responseCharset);
+        this.vndErrors = vndErrors;
+    }
+
+    /**
+     * Retrieves the vnd errors.
+     *
+     * @return the vnd errors
+     */
+    public VndErrors getVndErrors() {
+        return vndErrors;
+    }
+}

--- a/src/test/java/org/springframework/hateoas/VndErrorExceptionTest.java
+++ b/src/test/java/org/springframework/hateoas/VndErrorExceptionTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas;
+
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+/**
+ * Tests the {@link VndErrorException}
+ *
+ * @author Jakub Narloch
+ */
+public class VndErrorExceptionTest {
+
+    private static final String LOGREF = "5814b624-a66d-4ef3-9bfa-2b0d2a7baaf9";
+
+    private static final String UNEXPECTED = "Unexpected";
+
+    private VndErrorException exception;
+
+    @Test
+    public void shouldCreateVndErrorWithStatus() {
+
+        exception = new VndErrorException(INTERNAL_SERVER_ERROR, new VndErrors(LOGREF, UNEXPECTED));
+
+        assertThat(exception.getStatusCode(), is(INTERNAL_SERVER_ERROR));
+        assertThat(exception.getVndErrors(), is(notNullValue()));
+        VndErrors.VndError vndError = exception.getVndErrors().iterator().next();
+        assertThat(vndError.getLogref(), is(LOGREF));
+        assertThat(vndError.getMessage(), is(UNEXPECTED));
+    }
+
+    @Test
+    public void shouldCreateVndErrorWithStatusText() {
+
+        exception = new VndErrorException(INTERNAL_SERVER_ERROR, "500", new VndErrors(LOGREF, UNEXPECTED));
+
+        assertThat(exception.getStatusCode(), is(INTERNAL_SERVER_ERROR));
+        assertThat(exception.getStatusText(), is("500"));
+        assertThat(exception.getVndErrors(), is(notNullValue()));
+        VndErrors.VndError vndError = exception.getVndErrors().iterator().next();
+        assertThat(vndError.getLogref(), is(LOGREF));
+        assertThat(vndError.getMessage(), is(UNEXPECTED));
+    }
+
+    @Test
+    public void shouldCreateVndErrorWithStatusTextAndBody() throws Exception {
+
+        exception = new VndErrorException(INTERNAL_SERVER_ERROR, "500", UNEXPECTED.getBytes("UTF-8"),
+                Charset.forName("UTF-8"), new VndErrors(LOGREF, UNEXPECTED));
+
+        assertThat(exception.getStatusCode(), is(INTERNAL_SERVER_ERROR));
+        assertThat(exception.getStatusText(), is("500"));
+        assertThat(exception.getResponseBodyAsString(), is(UNEXPECTED));
+        assertThat(exception.getVndErrors(), is(notNullValue()));
+        VndErrors.VndError vndError = exception.getVndErrors().iterator().next();
+        assertThat(vndError.getLogref(), is(LOGREF));
+        assertThat(vndError.getMessage(), is(UNEXPECTED));
+    }
+}


### PR DESCRIPTION
Hi, 

Some time ago I had created this little thingy for handling the VndErrors in Feign calls over SpringCloud: https://github.com/jmnarloch/feign-vnderror-spring-cloud-starter. I though that I would be better if there would be a unified exception that could be handled by multiple clients: Feign, RestTemplate, HttpClient, OkHttp etc. So I would like to propose adding one.
