### PR TITLE
Added X-Forwarded-Path to ControllerLinkBuilder

### DIFF
--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
@@ -43,6 +43,7 @@ import org.springframework.web.util.UriTemplate;
  * @author Oliver Gierke
  * @author Kamill Sokol
  * @author Greg Turnquist
+ * @author Nick Grealy
  */
 public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuilder> {
 
@@ -225,6 +226,12 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 
 		if (hasText(port)) {
 			builder.port(Integer.parseInt(port));
+		}
+
+		String path = request.getHeader("X-Forwarded-Path");
+
+		if (hasText(path)){
+			builder.path(path);
 		}
 
 		return builder;

--- a/src/test/java/org/springframework/hateoas/alps/JacksonSerializationTest.java
+++ b/src/test/java/org/springframework/hateoas/alps/JacksonSerializationTest.java
@@ -70,7 +70,9 @@ public class JacksonSerializationTest {
 								).build())//
 				).build();
 
-		assertThat(mapper.writeValueAsString(alps), is(read(new ClassPathResource("reference.json", getClass()))));
+		assertThat(mapper.writeValueAsString(alps).replaceAll("\r\n", "\n"), is(read(new ClassPathResource("reference" +
+						".json", getClass())
+		)));
 	}
 
 	private static String read(Resource resource) throws IOException {

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
@@ -49,6 +49,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  * @author Kamill Sokol
  * @author Oemer Yildiz
  * @author Greg Turnquist
+ * @author Nick Grealy
  */
 public class ControllerLinkBuilderUnitTest extends TestUtils {
 
@@ -193,6 +194,19 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 
 		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
 		assertThat(link.getHref(), startsWith("https://somethingDifferent"));
+	}
+
+	/**
+	 * @see #143
+	 */
+	@Test
+	public void usesForwardedPathAndHostIfHeaderIsSet() {
+
+		request.addHeader("X-Forwarded-Host", "somethingDifferent");
+		request.addHeader("X-Forwarded-Path", "/foo/bar");
+
+		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
+		assertThat(link.getHref(), startsWith("http://somethingDifferent/foo/bar"));
 	}
 
 	/**


### PR DESCRIPTION
I've added `Added X-Forwarded-Path` handling in the ControllerLinkBuilder, so that context paths can be handled.

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.
