### PR TITLE
Changed linkTo so that it can be invoked outside of a HttpRequest.

### DIFF
--- a/src/main/java/org/springframework/hateoas/MethodLinkBuilderFactory.java
+++ b/src/main/java/org/springframework/hateoas/MethodLinkBuilderFactory.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Method;
 
 import org.springframework.hateoas.core.DummyInvocationUtils;
 import org.springframework.hateoas.mvc.ControllerLinkBuilder;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * Extension of {@link LinkBuilderFactory} for implementations that also support creating {@link LinkBuilder}s by
@@ -59,4 +60,16 @@ public interface MethodLinkBuilderFactory<T extends LinkBuilder> extends LinkBui
 	 * @return
 	 */
 	T linkTo(Object methodInvocationResult);
+
+	/**
+	 * Returns a {@link LinkBuilder} pointing to the URI mapped to the method the result is handed into this method. Use
+	 * {@link DummyInvocationUtils#methodOn(Class, Object...)} to obtain a dummy instance of a controller to record a
+	 * dummy method invocation on. See {@link ControllerLinkBuilder#linkTo(Object)} for an example.
+	 *
+	 * @see ControllerLinkBuilder#linkTo(Object)
+	 * @param builder must not be {@literal null}.
+	 * @param methodInvocationResult must not be {@literal null}.
+	 * @return
+	 */
+	T linkTo(UriComponentsBuilder builder, Object methodInvocationResult);
 }

--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
@@ -139,6 +139,18 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 	}
 
 	/**
+	 * Creates a {@link ControllerLinkBuilder} pointing to a controller method. Hand in a dummy method invocation result
+	 * you can create via {@link #methodOn(Class, Object...)} or {@link DummyInvocationUtils#methodOn(Class, Object...)}.
+	 *
+	 * @param builder
+	 * @param invocationValue
+	 * @return
+	 */
+	public static ControllerLinkBuilder linkTo(UriComponentsBuilder builder, Object invocationValue) {
+		return FACTORY.linkTo(builder, invocationValue);
+	}
+
+	/**
 	 * Wrapper for {@link DummyInvocationUtils#methodOn(Class, Object...)} to be available in case you work with static
 	 * imports of {@link ControllerLinkBuilder}.
 	 * 
@@ -185,8 +197,13 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 	 * @return
 	 */
 	static UriComponentsBuilder getBuilder() {
-
-		HttpServletRequest request = getCurrentRequest();
+		HttpServletRequest request;
+		try {
+			request = getCurrentRequest();
+		} catch (IllegalStateException e){
+			// not in the context of a Http Request, so return blank UriComponentsBuilder...
+			return UriComponentsBuilder.fromPath("");
+		}
 		ServletUriComponentsBuilder builder = ServletUriComponentsBuilder.fromServletMapping(request);
 
 		ForwardedHeader forwarded = ForwardedHeader.of(request.getHeader(ForwardedHeader.NAME));

--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilderFactory.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilderFactory.java
@@ -103,12 +103,21 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 		return ControllerLinkBuilder.linkTo(controller, method, parameters);
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.hateoas.MethodLinkBuilderFactory#linkTo(java.lang.Object)
 	 */
 	@Override
 	public ControllerLinkBuilder linkTo(Object invocationValue) {
+		return linkTo(ControllerLinkBuilder.getBuilder(), invocationValue);
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.hateoas.MethodLinkBuilderFactory#linkTo(UriComponentsBuilder builder, java.lang.Object)
+	 */
+	@Override
+	public ControllerLinkBuilder linkTo(UriComponentsBuilder builder, Object invocationValue) {
 
 		Assert.isInstanceOf(LastInvocationAware.class, invocationValue);
 		LastInvocationAware invocations = (LastInvocationAware) invocationValue;
@@ -118,7 +127,7 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 		Method method = invocation.getMethod();
 
 		String mapping = DISCOVERER.getMapping(invocation.getTargetType(), method);
-		UriComponentsBuilder builder = ControllerLinkBuilder.getBuilder().path(mapping);
+		builder.path(mapping);
 
 		UriTemplate template = new UriTemplate(mapping);
 		Map<String, Object> values = new HashMap<String, Object>();

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderOutsideSpringMvcUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderOutsideSpringMvcUnitTest.java
@@ -3,10 +3,13 @@ package org.springframework.hateoas.mvc;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.*;
+import static org.springframework.web.util.UriComponentsBuilder.*;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.hateoas.Link;
 import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * Test cases for {@link ControllerLinkBuilder} that are NOT inside an existing Spring MVC request
@@ -24,18 +27,28 @@ public class ControllerLinkBuilderOutsideSpringMvcUnitTest {
 	}
 
 	/**
-	 * @see #342
+	 * Calling linkTo outside of a HTTP request should not throw an exception.
+	 * @see #408
 	 */
-	@Test(expected = IllegalStateException.class)
-	public void createsLinkToMethodOnParameterizedControllerRoot() {
+	@Test
+	public void callingLinkToOutsideOfHttpRequestShouldNotThrowException() {
+		Link link = linkTo(methodOn(ControllerLinkBuilderUnitTest.PersonsAddressesController.class, 15)
+				.getAddressesForCountry("DE")).withSelfRel();
+		assertThat(link.getHref(), is("/people/15/addresses/DE"));
+	}
 
-		try {
-			linkTo(methodOn(ControllerLinkBuilderUnitTest.PersonsAddressesController.class, 15)
-					.getAddressesForCountry("DE")).withSelfRel();
-		} catch (IllegalStateException e) {
-			assertThat(e.getMessage(), equalTo("Could not find current request via RequestContextHolder. Is this being called from a Spring MVC handler?"));
-			throw e;
-		}
+	/**
+	 * Calling linkTo outside of a HTTP request, should allow passing in a custom builder.
+	 * @see #408
+	 */
+	@Test
+	public void linkToShouldTakeAUriCompoentsBuilder() {
+		Link link = linkTo(fromUriString("https://myproxy.net:1234/somepath"), methodOn
+				(ControllerLinkBuilderUnitTest
+				.PersonsAddressesController
+				.class, 15)
+				.getAddressesForCountry("DE")).withSelfRel();
+		assertThat(link.getHref(), is("https://myproxy.net:1234/somepath/people/15/addresses/DE"));
 	}
 
 }

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
@@ -447,14 +447,11 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 	@Test
 	public void mentionsRequiredUsageWithinWebRequestInException() {
 
-		exception.expect(IllegalStateException.class);
-		exception.expectMessage("request");
-		exception.expectMessage("Spring MVC");
-
 		RequestContextHolder.setRequestAttributes(null);
 
-		linkTo(methodOn(ControllerLinkBuilderUnitTest.PersonsAddressesController.class, 15).getAddressesForCountry("DE"))
+		Link link = linkTo(methodOn(PersonsAddressesController.class, 15).getAddressesForCountry("DE"))
 				.withSelfRel();
+		assertThat(link.getHref(), endsWith("/people/15/addresses/DE"));
 	}
 
 	private static UriComponents toComponents(Link link) {


### PR DESCRIPTION
Changed linkTo so that it can be invoked outside of a HttpRequest -
issue #408.
Added a linkTo method, which takes an explicit UriComponentBuilder.

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.
