### PR TITLE
#398 Remove unnecessary URI conversion

### DIFF
--- a/src/main/java/org/springframework/hateoas/core/LinkBuilderSupport.java
+++ b/src/main/java/org/springframework/hateoas/core/LinkBuilderSupport.java
@@ -49,6 +49,11 @@ public abstract class LinkBuilderSupport<T extends LinkBuilder> implements LinkB
 		this.uriComponents = builder.build();
 	}
 
+	public LinkBuilderSupport(UriComponents uriComponents) {
+		Assert.notNull(uriComponents);
+		this.uriComponents = uriComponents;
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.hateoas.LinkBuilder#slash(java.lang.Object)

--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
@@ -60,6 +60,15 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 	}
 
 	/**
+	 * Creates a new {@link ControllerLinkBuilder} using the given {@link UriComponents}.
+	 *
+	 * @param uriComponents must not be {@literal null}.
+	 */
+	ControllerLinkBuilder(UriComponents uriComponents) {
+		super(uriComponents);
+	}
+
+	/**
 	 * Creates a new {@link ControllerLinkBuilder} with a base of the mapping annotated to the given controller class.
 	 * 
 	 * @param controller the class to discover the annotation on, must not be {@literal null}.

--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilderFactory.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilderFactory.java
@@ -137,7 +137,7 @@ public class ControllerLinkBuilderFactory implements MethodLinkBuilderFactory<Co
 		}
 
 		UriComponents components = applyUriComponentsContributer(builder, invocation).buildAndExpand(values);
-		return new ControllerLinkBuilder(UriComponentsBuilder.fromUriString(components.toUriString()));
+		return new ControllerLinkBuilder(components);
 	}
 
 	/* 

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
@@ -81,6 +81,17 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		assertThat(link.getHref(), endsWith("/people/15/addresses/DE"));
 	}
 
+	/**
+	 * @see #398
+	 */
+	@Test
+	public void encodesRequestParameterWithSpecialValue() {
+
+		Link link = linkTo(methodOn(ControllerWithMethods.class).methodWithRequestParam("Spring#\n")).withSelfRel();
+		assertThat(link.getRel(), is(Link.REL_SELF));
+		assertThat(link.getHref(), endsWith("/something/foo?id=Spring%23%0A"));
+	}
+
 	@Test
 	public void createsLinkToSubResource() {
 


### PR DESCRIPTION
@olivergierke I believe this PR should fix #398 

The issue as I see is that `ControllerLinkBuilderFactory` is unnecessarily converting the `UriComponents` into a URI just to coerce it in to a `UriComponentsBuilder`

```java
UriComponents components = applyUriComponentsContributer(builder, invocation).buildAndExpand(values);
return new ControllerLinkBuilder(UriComponentsBuilder.fromUriString(components.toUriString()));
```

`UriComponentsBuilder#fromUriString` is expecting a proper URI to be passed in so any special characters that are in the URI will cause issues.  

The fix in this PR just avoids converting the `UriComponents` instance to URI string just to coerce it back to a `UriComponentsBuilder`.