### PR TITLE
Added support for X-Forwarded-Path header

### DIFF
--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
@@ -261,6 +261,12 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 			builder.port(Integer.parseInt(port));
 		}
 
+		String path = request.getHeader("X-Forwarded-Path");
+
+		if (hasText(path)) {
+			builder.path(path);
+		}
+
 		return builder;
 	}
 

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
@@ -336,6 +336,17 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		assertThat(link.getHref(), startsWith("http://foobarhost/"));
 	}
 
+	@Test
+	public void usesForwardedHostAndPathFromHeaderAndPortFromAnotherHeader() {
+
+		request.addHeader("X-Forwarded-Host", "foobarhost");
+		request.addHeader("X-Forwarded-Path", "/foo");
+		request.addHeader("X-Forwarded-Port", "1234");
+
+		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
+		assertThat(link.getHref(), startsWith("http://foobarhost:1234/foo"));
+	}
+
 	/**
 	 * @see #114
 	 */


### PR DESCRIPTION
Some proxies use URL rewriting, which means that requested URI and forwarded URI do not match.  In such cases, URLs generated by ControllerLinkBuilder are incorrect.

The following issue suggest usage of a X-Forwarded-Path header which would hold the base path of the service.
https://github.com/18F/api.data.gov/issues/260

The path method of the builder was used with the X-Forwarded-Path header value.