### PR TITLE
Tweak to ControllerLinkBuilder to support X-AppEngine-Https on Google App Engine

### DIFF
--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
@@ -226,10 +226,14 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 		ForwardedHeader forwarded = ForwardedHeader.of(request.getHeader(ForwardedHeader.NAME));
 		String proto = hasText(forwarded.getProto()) ? forwarded.getProto() : request.getHeader("X-Forwarded-Proto");
 		String forwardedSsl = request.getHeader("X-Forwarded-Ssl");
+		// not sure why Google has to do things differently :(
+		String appengineHttps = request.getHeader("X-AppEngine-Https");
 
 		if (hasText(proto)) {
 			builder.scheme(proto);
 		} else if (hasText(forwardedSsl) && forwardedSsl.equalsIgnoreCase("on")) {
+			builder.scheme("https");
+		} else if (hasText(appengineHttps) && appengineHttps.equalsIgnoreCase("on")) {
 			builder.scheme("https");
 		}
 


### PR DESCRIPTION
Currently when running on Google flexible app engine links that should be https are being generated as http because Google doesn't set either the X-Forwarded-Proto or X-Forwarded-Ssl header when terminating SSL in their load balancer.

From https://cloud.google.com/appengine/docs/flexible/nodejs/runtime

"Note that App Engine does not set the X-Forwarded-Proto header to indicate that the original connection was sent over HTTPS as expected by some frameworks. Instead, applications should check that the value of the X-AppEngine-Https is set to "on"."

This fix is related to https://github.com/spring-projects/spring-hateoas/issues/107