### PR TITLE
Remove processing of X-Forwared-Host header

### DIFF
--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
@@ -234,7 +234,6 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 		}
 
 		String host = forwarded.getHost();
-		host = hasText(host) ? host : request.getHeader("X-Forwarded-Host");
 
 		if (!hasText(host)) {
 			return builder;

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
@@ -159,7 +159,7 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		request.addHeader("X-Forwarded-Host", "somethingDifferent");
 
 		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
-		assertThat(link.getHref(), startsWith("http://somethingDifferent"));
+		assertThat(link.getHref(), startsWith("http://somethingDifferent/"));
 	}
 
 	/**
@@ -196,7 +196,7 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		request.addHeader("X-Forwarded-Ssl", "on");
 
 		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
-		assertThat(link.getHref(), startsWith("https://somethingDifferent"));
+		assertThat(link.getHref(), startsWith("https://somethingDifferent/"));
 	}
 
 	/**
@@ -258,7 +258,17 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		assertThat(components.getQuery(), is("foo=bar"));
 	}
 
-	/**
+    @Test
+    public void usesForwardedHostWithoutDefaultPortFromHeader() {
+
+        request.addHeader("X-Forwarded-Host", "somethingDifferent:80");
+
+        Link link = linkTo(PersonControllerImpl.class).withSelfRel();
+        assertThat(link.getHref(), startsWith("http://somethingDifferent/"));
+    }
+
+
+    /**
 	 * @see #90
 	 */
 	@Test
@@ -267,7 +277,7 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		request.addHeader("X-Forwarded-Host", "foobar:8088");
 
 		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
-		assertThat(link.getHref(), startsWith("http://foobar:8088"));
+		assertThat(link.getHref(), startsWith("http://foobar:8088/"));
 	}
 
 	/**
@@ -279,7 +289,7 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		request.addHeader("X-Forwarded-Host", "barfoo:8888, localhost:8088");
 
 		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
-		assertThat(link.getHref(), startsWith("http://barfoo:8888"));
+		assertThat(link.getHref(), startsWith("http://barfoo:8888/"));
 	}
 
 	/**


### PR DESCRIPTION
When the X-Forwarded-Host is sent with the default protocole port e.g.
somethingDifferent:80, the port is added to the link although it was
already processed by ServletUriComponentsBuilder which ignores ports
80/443 for HTTP/HTTPS. The processing of X-Forwarded-Host has been removed;
Now the default port is not set in the link.

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.
