### PR TITLE
Fixes #483 - The asterisk in URI Template donates a composite value

### DIFF
--- a/src/main/java/org/springframework/hateoas/TemplateVariable.java
+++ b/src/main/java/org/springframework/hateoas/TemplateVariable.java
@@ -23,6 +23,8 @@ import lombok.Value;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -150,7 +152,8 @@ public final class TemplateVariable implements Serializable {
 		REQUEST_PARAM("?", true), //
 		REQUEST_PARAM_CONTINUED("&", true), //
 		SEGMENT("/", true), //
-		FRAGMENT("#", true);
+		FRAGMENT("#", true),
+		COMPOSITE_PARAM("*", true);
 
 		private static final List<VariableType> COMBINABLE_TYPES = Arrays.asList(REQUEST_PARAM, REQUEST_PARAM_CONTINUED);
 

--- a/src/test/java/org/springframework/hateoas/UriTemplateUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/UriTemplateUnitTest.java
@@ -261,6 +261,66 @@ public class UriTemplateUnitTest {
 		assertThat(template.toString(), is("/{?q}"));
 	}
 
+	/**
+	 * @see #483
+	 */
+	@Test
+	public void compositveValuesAreRecognisedAsVariableType() {
+		UriTemplate template = new UriTemplate("/foo{&bar,foobar*}");
+
+		assertVariables(template,
+				new TemplateVariable("bar", VariableType.REQUEST_PARAM_CONTINUED),
+				new TemplateVariable("foobar", VariableType.COMPOSITE_PARAM));
+	}
+
+	/**
+	 * @see #483
+	 */
+	@Test
+	public void expandsCompositeValueAsAssociativeArray() {
+		UriTemplate template = new UriTemplate("/foo{&bar,foobar*}");
+
+		String expandedTemplate = template.expand(new HashMap<String, Object>(){{
+			put("bar", "barExpanded");
+			put("foobar", new HashMap<String, String>(){{
+				put("city", "Clarksville");
+				put("state", "TN");
+			}});
+		}}).toString();
+
+		assertThat(expandedTemplate, is("/foo?bar=barExpanded&city=Clarksville&state=TN"));
+	}
+
+	/**
+	 * @see #483
+	 */
+	@Test
+	public void expandsCompositeValueAsList() {
+		UriTemplate template = new UriTemplate("/foo{&bar,foobar*}");
+
+		String expandedTemplate = template.expand(new HashMap<String, Object>(){{
+			put("bar", "barExpanded");
+			put("foobar", Arrays.asList("foo1", "foo2"));
+		}}).toString();
+
+		assertThat(expandedTemplate, is("/foo?bar=barExpanded&foobar=foo1&foobar=foo2"));
+	}
+
+	/**
+	 * @see #483
+	 */
+	@Test
+	public void handlesCompositeValueAsSingleValue() {
+		UriTemplate template = new UriTemplate("/foo{&bar,foobar*}");
+
+		String expandedTemplate = template.expand(new HashMap<String, Object>(){{
+			put("bar", "barExpanded");
+			put("foobar", "singleValue");
+		}}).toString();
+
+		assertThat(expandedTemplate, is("/foo?bar=barExpanded&foobar=singleValue"));
+	}
+
 	private static void assertVariables(UriTemplate template, TemplateVariable... variables) {
 		assertVariables(template, Arrays.asList(variables));
 	}


### PR DESCRIPTION
The URITemplate needs to handle composite values which are indicated with an asterisk.  A composite field can be expanded to a list or an associative array. https://tools.ietf.org/html/rfc6570#section-2.4.2
