### PR TITLE
Make mixins public to make re-use of Jackson2HalModule easier

### DIFF
--- a/src/main/java/org/springframework/hateoas/hal/LinkMixin.java
+++ b/src/main/java/org/springframework/hateoas/hal/LinkMixin.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
  * @author Oliver Gierke
  */
 @JsonIgnoreProperties(value = "rel")
-abstract class LinkMixin extends Link {
+public abstract class LinkMixin extends Link {
 
 	private static final long serialVersionUID = 4720588561299667409L;
 

--- a/src/main/java/org/springframework/hateoas/hal/ResourceSupportMixin.java
+++ b/src/main/java/org/springframework/hateoas/hal/ResourceSupportMixin.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
-abstract class ResourceSupportMixin extends ResourceSupport {
+public abstract class ResourceSupportMixin extends ResourceSupport {
 
 	@Override
 	@XmlElement(name = "link")


### PR DESCRIPTION
I would like to be able to use my own implementation of Jackson2HalModule but re-use the existing mixin classes found in the `org.springframework.hateoas.hal` package. One mixin was already declared public (the `ResourcesMixin` class). This PR just gives the two other mixins the same visibility. 
