### PR TITLE
Support composed annotations in AnnotationMappingDiscoverer.

### DIFF
--- a/src/main/java/org/springframework/hateoas/core/AnnotationMappingDiscoverer.java
+++ b/src/main/java/org/springframework/hateoas/core/AnnotationMappingDiscoverer.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.hateoas.core;
 
+import static org.springframework.core.annotation.AnnotatedElementUtils.findMergedAnnotation;
 import static org.springframework.core.annotation.AnnotationUtils.*;
 
 import java.lang.annotation.Annotation;
@@ -27,6 +28,7 @@ import org.springframework.util.Assert;
  * {@link MappingDiscoverer} implementation that inspects mappings from a particular annotation.
  * 
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 public class AnnotationMappingDiscoverer implements MappingDiscoverer {
 
@@ -68,7 +70,7 @@ public class AnnotationMappingDiscoverer implements MappingDiscoverer {
 
 		Assert.notNull(type, "Type must not be null!");
 
-		String[] mapping = getMappingFrom(findAnnotation(type, annotationType));
+		String[] mapping = getMappingFrom(findMergedAnnotation(type, annotationType));
 
 		return mapping.length == 0 ? null : mapping[0];
 	}
@@ -94,7 +96,7 @@ public class AnnotationMappingDiscoverer implements MappingDiscoverer {
 		Assert.notNull(type, "Type must not be null!");
 		Assert.notNull(method, "Method must not be null!");
 
-		String[] mapping = getMappingFrom(findAnnotation(method, annotationType));
+		String[] mapping = getMappingFrom(findMergedAnnotation(method, annotationType));
 		String typeMapping = getMapping(type);
 
 		if (mapping == null || mapping.length == 0) {

--- a/src/test/java/org/springframework/hateoas/core/AnnotationMappingDiscovererUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/core/AnnotationMappingDiscovererUnitTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.*;
 import java.lang.reflect.Method;
 
 import org.junit.Test;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
  * 
  * @author Oliver Gierke
  * @author Kevin Conaway
+ * @author Mark Paluch
  */
 public class AnnotationMappingDiscovererUnitTest {
 
@@ -142,7 +144,7 @@ public class AnnotationMappingDiscovererUnitTest {
 	@RequestMapping("/type")
 	interface MyController {
 
-		@RequestMapping("/method")
+		@GetMapping("/method")
 		void method();
 
 		@RequestMapping


### PR DESCRIPTION
We now support composed annotations using `@AliasFor` such as `@GetMapping` that are mixed with `@RequestMapping` on type and method level.

```
@RequestMapping("type")
class MyController {

	@GetMapping("method")
	String method() {
	   ...
	}
}
```