### PR TITLE
Fix: JacksonSerializationTest is failing.

### DIFF
--- a/src/test/java/org/springframework/hateoas/alps/JacksonSerializationTest.java
+++ b/src/test/java/org/springframework/hateoas/alps/JacksonSerializationTest.java
@@ -87,7 +87,7 @@ public class JacksonSerializationTest {
 				builder.append(scanner.nextLine());
 
 				if (scanner.hasNextLine()) {
-					builder.append("\n");
+					builder.append("\r\n");
 				}
 			}
 


### PR DESCRIPTION
JacksonSerializationTest is failing due to the differences in line endings.