### PR TITLE
ControllerLinkBuilder and multiple X-Forwarded-* headers values. (issue #509)

### DIFF
--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
@@ -18,6 +18,8 @@ package org.springframework.hateoas.mvc;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Delegate;
 
+import static org.springframework.util.StringUtils.hasText;
+
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.Map;
@@ -51,6 +53,7 @@ import org.springframework.web.util.UriTemplate;
  * @author Greg Turnquist
  * @author Kevin Conaway
  * @author Andrew Naydyonock
+ * @author Oliver Trosien
  */
 public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuilder> {
 
@@ -252,14 +255,23 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 	}
 
 	/**
-	 * Returns a {@link UriComponentsBuilder} obtained from the current servlet mapping with the host tweaked in case the
-	 * request contains an {@code X-Forwarded-Host} header and the scheme tweaked in case the request contains an
-	 * {@code X-Forwarded-Ssl} header
+	 * Returns a {@link UriComponentsBuilder} obtained from the current servlet mapping with tweaked
+	 * scheme tweaked in case the request contains an {@code X-Forwarded-Ssl} header, which is not yet
+	 * supported by the underlying {@link UriComponentsBuilder}.
 	 * 
 	 * @return
 	 */
 	static UriComponentsBuilder getBuilder() {
-		return UriComponentsBuilder.fromHttpRequest(new ServletServerHttpRequest(getCurrentRequest()));
+		
+		HttpServletRequest request = getCurrentRequest();
+		String forwardedSsl = request.getHeader("X-Forwarded-Ssl");
+
+		UriComponentsBuilder builder = UriComponentsBuilder.fromHttpRequest(new ServletServerHttpRequest(request));
+		if (hasText(forwardedSsl) && forwardedSsl.equalsIgnoreCase("on")) {
+			builder.scheme("https");
+		}
+
+		return builder;
 	}
 
 	/**

--- a/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ControllerLinkBuilder.java
@@ -255,7 +255,7 @@ public class ControllerLinkBuilder extends LinkBuilderSupport<ControllerLinkBuil
 	}
 
 	/**
-	 * Returns a {@link UriComponentsBuilder} obtained from the current servlet mapping with tweaked
+	 * Returns a {@link UriComponentsBuilder} obtained from the current servlet mapping with
 	 * scheme tweaked in case the request contains an {@code X-Forwarded-Ssl} header, which is not yet
 	 * supported by the underlying {@link UriComponentsBuilder}.
 	 * 

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -169,7 +168,6 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 	 * @see #112
 	 */
 	@Test
-	@Ignore("X-Forwarded-Ssl Unsupported by UriComponentsBuilder")
 	public void usesForwardedSslIfHeaderIsSet() {
 
 		request.addHeader("X-Forwarded-Ssl", "on");
@@ -182,7 +180,6 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 	 * @see #112
 	 */
 	@Test
-	@Ignore("X-Forwarded-Ssl Unsupported by UriComponentsBuilder")
 	public void usesForwardedSslIfHeaderIsSetOff() {
 
 		request.addHeader("X-Forwarded-Ssl", "off");
@@ -195,7 +192,6 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 	 * @see #112
 	 */
 	@Test
-	@Ignore("X-Forwarded-Ssl Unsupported by UriComponentsBuilder")
 	public void usesForwardedSslAndHostIfHeaderIsSet() {
 
 		request.addHeader("X-Forwarded-Host", "somethingDifferent");

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
@@ -539,9 +539,21 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 	public void supportsTwoProxiesAddingXForwardedPort() {
 		request.addHeader("X-Forwarded-Port", "1443,8443");
 		request.addHeader("X-Forwarded-Host", "proxy1,proxy2");
-	
+
 		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
 		assertThat(link.getHref(), startsWith("http://proxy1:1443"));
+	}
+
+	/**
+	 * @see #509
+	 */
+	@Test
+	public void resolvesAmbiguousXForwardedHeaders() {
+		request.addHeader("X-Forwarded-Proto", "http");
+		request.addHeader("X-Forwarded-Ssl", "on");
+
+		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
+		assertThat(link.getHref(), startsWith("http://"));
 	}
 
 	private static UriComponents toComponents(Link link) {

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.hamcrest.Matchers;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -168,6 +169,7 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 	 * @see #112
 	 */
 	@Test
+	@Ignore("X-Forwarded-Ssl Unsupported by UriComponentsBuilder")
 	public void usesForwardedSslIfHeaderIsSet() {
 
 		request.addHeader("X-Forwarded-Ssl", "on");
@@ -180,6 +182,7 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 	 * @see #112
 	 */
 	@Test
+	@Ignore("X-Forwarded-Ssl Unsupported by UriComponentsBuilder")
 	public void usesForwardedSslIfHeaderIsSetOff() {
 
 		request.addHeader("X-Forwarded-Ssl", "off");
@@ -192,6 +195,7 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 	 * @see #112
 	 */
 	@Test
+	@Ignore("X-Forwarded-Ssl Unsupported by UriComponentsBuilder")
 	public void usesForwardedSslAndHostIfHeaderIsSet() {
 
 		request.addHeader("X-Forwarded-Host", "somethingDifferent");
@@ -530,6 +534,18 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		UriComponents components = toComponents(link);
 
 		assertThat(components.getQueryParams().get("query"), is(nullValue()));
+	}
+
+	/**
+	 * @see #509
+	 */
+	@Test
+	public void supportsTwoProxiesAddingXForwardedPort() {
+		request.addHeader("X-Forwarded-Port", "1443,8443");
+		request.addHeader("X-Forwarded-Host", "proxy1,proxy2");
+	
+		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
+		assertThat(link.getHref(), startsWith("http://proxy1:1443"));
 	}
 
 	private static UriComponents toComponents(Link link) {


### PR DESCRIPTION
Open for discussion: UriComponentsBuilder does not respect X-Forwarded-Ssl, and I didn't see any JIRA issue adding this support. So for now, it's a question if spring-hateoas should just be aligned with the feature set of spring-framework, or add its own customizations. This would basically revert the PR for issue #112. I would vote for aligning it with what UriComponentsBuilder supports, but I'm not to decide.
That's why I put a junit.Ignore on them until this is clarified.