### PR TITLE
Clean up JavaDocs by removing references to downstream methods.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,11 +25,21 @@
 			<id>ogierke</id>
 			<name>Oliver Gierke</name>
 			<email>ogierke(at)pivotal.io</email>
-			<organization>Pivotal, Inc.</organization>
+			<organization>Pivotal Software, Inc.</organization>
 			<roles>
 				<role>Project lead</role>
 			</roles>
 			<timezone>+1</timezone>
+		</developer>
+		<developer>
+			<id>gturnquist</id>
+			<name>Greg Turnquist</name>
+			<email>gturnquist(at)pivotal.io</email>
+			<organization>Pivotal Software, Inc.</organization>
+			<roles>
+				<role>Contributor</role>
+			</roles>
+			<timezone>-6</timezone>
 		</developer>
 	</developers>
 

--- a/src/main/java/org/springframework/hateoas/PagedResources.java
+++ b/src/main/java/org/springframework/hateoas/PagedResources.java
@@ -102,7 +102,6 @@ public class PagedResources<T> extends Resources<T> {
 	/**
 	 * Returns the Link pointing to the next page (if set).
 	 * 
-	 * @see #addPaginationLinks(Link)
 	 * @return
 	 */
 	@JsonIgnore
@@ -113,7 +112,6 @@ public class PagedResources<T> extends Resources<T> {
 	/**
 	 * Returns the Link pointing to the previous page (if set).
 	 * 
-	 * @see #addPaginationLinks(Link)
 	 * @return
 	 */
 	@JsonIgnore


### PR DESCRIPTION
Putting in links to downstream methods (Spring Data Commons `PagedResourcesAssembler.addPaginationLinks`) is not advisable.

Resolves #501