### PR TITLE
Add extra attributes to Link and use for HAL mediatype

### DIFF
--- a/src/main/java/org/springframework/hateoas/Link.java
+++ b/src/main/java/org/springframework/hateoas/Link.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,13 @@
 package org.springframework.hateoas;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -37,6 +40,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  * Value object for links.
  * 
  * @author Oliver Gierke
+ * @author Greg Turnquist
  */
 @XmlType(name = "link", namespace = Link.ATOM_NAMESPACE)
 @JsonIgnoreProperties("templated")
@@ -55,6 +59,11 @@ public class Link implements Serializable {
 
 	@XmlAttribute private String rel;
 	@XmlAttribute private String href;
+	@XmlAttribute private String hreflang;
+	@XmlAttribute private String media;
+	@XmlAttribute private String title;
+	@XmlAttribute private String type;
+	@XmlAttribute private String deprecation;
 	@XmlTransient @JsonIgnore private UriTemplate template;
 
 	/**
@@ -85,12 +94,33 @@ public class Link implements Serializable {
 	 */
 	public Link(UriTemplate template, String rel) {
 
-		Assert.notNull(template, "UriTempalte must not be null!");
+		Assert.notNull(template, "UriTemplate must not be null!");
 		Assert.hasText(rel, "Rel must not be null or empty!");
 
 		this.template = template;
 		this.href = template.toString();
 		this.rel = rel;
+	}
+
+	/**
+	 * Creates a new {@link Link} to the given URI with the given rel, hreflang, media, title, and type.
+	 *
+	 * @param href must not be {@literal null} or empty.
+	 * @param rel must not be {@literal null} or empty.
+	 * @param hreflang
+	 * @param media
+	 * @param title
+	 * @param type
+	 * @param deprecation
+	 */
+	public Link(String href, String rel, String hreflang, String media, String title, String type, String deprecation) {
+
+		this(href, rel);
+		this.hreflang = hreflang;
+		this.media = media;
+		this.title = title;
+		this.type = type;
+		this.deprecation = deprecation;
 	}
 
 	/**
@@ -119,6 +149,51 @@ public class Link implements Serializable {
 	}
 
 	/**
+	 * Returns the hreflang of the link.
+	 *
+	 * @return
+	 */
+	public String getHreflang() {
+		return hreflang;
+	}
+
+	/**
+	 * Returns the media of the link.
+	 *
+	 * @return
+	 */
+	public String getMedia() {
+		return media;
+	}
+
+	/**
+	 * Returns the title of the link.
+	 *
+	 * @return
+	 */
+	public String getTitle() {
+		return title;
+	}
+
+	/**
+	 * Returns the type of the link
+	 *
+	 * @return
+	 */
+	public String getType() {
+		return type;
+	}
+
+	/**
+	 * Returns link about deprecation of this link.
+	 *
+	 * @return
+	 */
+	public String getDeprecation() {
+		return deprecation;
+	}
+	
+	/**
 	 * Returns a {@link Link} pointing to the same URI but with the given relation.
 	 * 
 	 * @param rel must not be {@literal null} or empty.
@@ -137,6 +212,66 @@ public class Link implements Serializable {
 		return withRel(Link.REL_SELF);
 	}
 
+	/**
+	 * Returns a {@link Link} with the {@code hreflang} attribute filled out.
+	 *
+	 * @param hreflang
+	 * @return
+	 */
+	public Link withHreflang(String hreflang) {
+
+		Assert.hasText(hreflang, "hreflang must not be null or empty!");
+		return new Link(this.href, this.rel, hreflang, this.media, this.title, this.type, this.deprecation);
+	}
+
+	/**
+	 * Returns a {@link Link} with the {@code media} attribute filled out.
+	 *
+	 * @param media
+	 * @return
+	 */
+	public Link withMedia(String media) {
+
+		Assert.hasText(media, "media must not be null or empty!");
+		return new Link(this.href, this.rel, this.hreflang, media, this.title, this.type, this.deprecation);
+	}
+
+	/**
+	 * Returns a {@link Link} with the {@code title} attribute filled out.
+	 *
+	 * @param title
+	 * @return
+	 */
+	public Link withTitle(String title) {
+
+		Assert.hasText(title, "title must not be null or empty!");
+		return new Link(this.href, this.rel, this.hreflang, this.media, title, this.type, this.deprecation);
+	}
+
+	/**
+	 * Returns a {@link Link} with the {@code type} attribute filled out.
+	 *
+	 * @param type
+	 * @return
+	 */
+	public Link withType(String type) {
+
+		Assert.hasText(type, "type must not be null or empty!");
+		return new Link(this.href, this.rel, this.hreflang, this.media, this.title, type, this.deprecation);
+	}
+
+	/**
+	 * Returns a {@link Link} with the {@code deprecation} attribute filled out.
+	 *
+	 * @param deprecation
+	 * @return
+	 */
+	public Link withDeprecation(String deprecation) {
+		
+		Assert.hasText(deprecation, "deprecation must not be null or empty!");
+		return new Link(this.href, this.rel, this.hreflang, this.media, this.title, this.type, deprecation);
+	}
+	
 	/**
 	 * Returns the variable names contained in the template.
 	 * 
@@ -212,7 +347,20 @@ public class Link implements Serializable {
 
 		Link that = (Link) obj;
 
-		return this.href.equals(that.href) && this.rel.equals(that.rel);
+		return
+			this.href.equals(that.href)
+				&&
+				this.rel.equals(that.rel)
+				&&
+				(this.hreflang != null ? this.hreflang.equals(that.hreflang) : this.hreflang == that.hreflang)
+				&&
+				(this.media != null ? this.media.equals(that.media) : this.media == that.media)
+				&&
+				(this.title != null ? this.title.equals(that.title) : this.title == that.title)
+				&&
+				(this.type != null ? this.type.equals(that.type) : this.type == that.type)
+				&&
+				(this.deprecation != null ? this.deprecation.equals(that.deprecation) : this.deprecation == that.deprecation);
 	}
 
 	/* 
@@ -225,6 +373,21 @@ public class Link implements Serializable {
 		int result = 17;
 		result += 31 * href.hashCode();
 		result += 31 * rel.hashCode();
+		if (hreflang != null) {
+			result += 31 * hreflang.hashCode();
+		}
+		if (media != null) {
+			result += 31 * media.hashCode();
+		}
+		if (title != null) {
+			result += 31 * title.hashCode();
+		}
+		if (type != null) {
+			result += 31 * type.hashCode();
+		}
+		if (deprecation != null) {
+			result += 31 * deprecation.hashCode();
+		}
 		return result;
 	}
 
@@ -234,7 +397,29 @@ public class Link implements Serializable {
 	 */
 	@Override
 	public String toString() {
-		return String.format("<%s>;rel=\"%s\"", href, rel);
+		String linkString = String.format("<%s>;rel=\"%s\"", href, rel);
+
+		if (hreflang != null) {
+			linkString += ";hreflang=\"" + hreflang + "\"";
+		}
+
+		if (media != null) {
+			linkString += ";media=\"" + media + "\"";
+		}
+
+		if (title != null) {
+			linkString += ";title=\"" + title + "\"";
+		}
+
+		if (type != null) {
+			linkString += ";type=\"" + type + "\"";
+		}
+
+		if (deprecation != null) {
+			linkString += ";deprecation=\"" + deprecation + "\"";
+		}
+		
+		return linkString;
 	}
 
 	/**
@@ -263,7 +448,34 @@ public class Link implements Serializable {
 				throw new IllegalArgumentException("Link does not provide a rel attribute!");
 			}
 
-			return new Link(matcher.group(1), attributes.get("rel"));
+			Set<String> unrecognizedHeaders = unrecognizedHeaders(attributes);
+			if (!unrecognizedHeaders.isEmpty()) {
+				throw new IllegalArgumentException("Link contains invalid RFC5988 headers! => " + unrecognizedHeaders);
+			}
+
+			Link link = new Link(matcher.group(1), attributes.get("rel"));
+
+			if (attributes.containsKey("hreflang")) {
+				link = link.withHreflang(attributes.get("hreflang"));
+			}
+
+			if (attributes.containsKey("media")) {
+				link = link.withMedia(attributes.get("media"));
+			}
+
+			if (attributes.containsKey("title")) {
+				link = link.withTitle(attributes.get("title"));
+			}
+
+			if (attributes.containsKey("type")) {
+				link = link.withType(attributes.get("type"));
+			}
+
+			if (attributes.containsKey("deprecation")) {
+				link = link.withDeprecation(attributes.get("deprecation"));
+			}
+
+			return link;
 
 		} else {
 			throw new IllegalArgumentException(String.format("Given link header %s is not RFC5988 compliant!", element));
@@ -283,7 +495,7 @@ public class Link implements Serializable {
 		}
 
 		Map<String, String> attributes = new HashMap<String, String>();
-		Pattern keyAndValue = Pattern.compile("(\\w+)=\"(\\p{Lower}[\\p{Lower}\\p{Digit}\\.\\-]*|" + URI_PATTERN + ")\"");
+		Pattern keyAndValue = Pattern.compile("(\\w+)=\"(\\p{Lower}[\\p{Lower}\\p{Digit}\\.\\-\\s]*|" + URI_PATTERN + ")\"");
 		Matcher matcher = keyAndValue.matcher(source);
 
 		while (matcher.find()) {
@@ -291,5 +503,23 @@ public class Link implements Serializable {
 		}
 
 		return attributes;
+	}
+
+	/**
+	 * Scan for any headers not recognized.
+	 *
+	 * @param attributes
+	 * @return
+	 */
+	private static Set<String> unrecognizedHeaders(final Map<String, String> attributes) {
+
+		// Copy the existing keys to avoid damaging the original.
+		Set<String> unrecognizedHeaders = new HashSet<String>();
+		unrecognizedHeaders.addAll(attributes.keySet());
+
+		// Remove all recognized headers
+		unrecognizedHeaders.removeAll(Arrays.asList("href", "rel", "hreflang", "media", "title", "type", "deprecation"));
+
+		return unrecognizedHeaders;
 	}
 }

--- a/src/main/java/org/springframework/hateoas/Link.java
+++ b/src/main/java/org/springframework/hateoas/Link.java
@@ -15,14 +15,18 @@
  */
 package org.springframework.hateoas;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Wither;
+
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -44,6 +48,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  */
 @XmlType(name = "link", namespace = Link.ATOM_NAMESPACE)
 @JsonIgnoreProperties("templated")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+@Getter
+@EqualsAndHashCode(of = {"rel", "href", "hreflang", "media", "title", "deprecation"})
 public class Link implements Serializable {
 
 	private static final long serialVersionUID = -9037755944661782121L;
@@ -57,13 +65,13 @@ public class Link implements Serializable {
 	public static final String REL_NEXT = "next";
 	public static final String REL_LAST = "last";
 
-	@XmlAttribute private String rel;
-	@XmlAttribute private String href;
-	@XmlAttribute private String hreflang;
-	@XmlAttribute private String media;
-	@XmlAttribute private String title;
-	@XmlAttribute private String type;
-	@XmlAttribute private String deprecation;
+	@XmlAttribute @Wither private String rel;
+	@XmlAttribute @Wither private String href;
+	@XmlAttribute @Wither private String hreflang;
+	@XmlAttribute @Wither private String media;
+	@XmlAttribute @Wither private String title;
+	@XmlAttribute @Wither private String type;
+	@XmlAttribute @Wither private String deprecation;
 	@XmlTransient @JsonIgnore private UriTemplate template;
 
 	/**
@@ -103,107 +111,6 @@ public class Link implements Serializable {
 	}
 
 	/**
-	 * Creates a new {@link Link} to the given URI with the given rel, hreflang, media, title, and type.
-	 *
-	 * @param href must not be {@literal null} or empty.
-	 * @param rel must not be {@literal null} or empty.
-	 * @param hreflang
-	 * @param media
-	 * @param title
-	 * @param type
-	 * @param deprecation
-	 */
-	public Link(String href, String rel, String hreflang, String media, String title, String type, String deprecation) {
-
-		this(href, rel);
-		this.hreflang = hreflang;
-		this.media = media;
-		this.title = title;
-		this.type = type;
-		this.deprecation = deprecation;
-	}
-
-	/**
-	 * Empty constructor required by the marshalling framework.
-	 */
-	protected Link() {
-
-	}
-
-	/**
-	 * Returns the actual URI the link is pointing to.
-	 * 
-	 * @return
-	 */
-	public String getHref() {
-		return href;
-	}
-
-	/**
-	 * Returns the rel of the link.
-	 * 
-	 * @return
-	 */
-	public String getRel() {
-		return rel;
-	}
-
-	/**
-	 * Returns the hreflang of the link.
-	 *
-	 * @return
-	 */
-	public String getHreflang() {
-		return hreflang;
-	}
-
-	/**
-	 * Returns the media of the link.
-	 *
-	 * @return
-	 */
-	public String getMedia() {
-		return media;
-	}
-
-	/**
-	 * Returns the title of the link.
-	 *
-	 * @return
-	 */
-	public String getTitle() {
-		return title;
-	}
-
-	/**
-	 * Returns the type of the link
-	 *
-	 * @return
-	 */
-	public String getType() {
-		return type;
-	}
-
-	/**
-	 * Returns link about deprecation of this link.
-	 *
-	 * @return
-	 */
-	public String getDeprecation() {
-		return deprecation;
-	}
-	
-	/**
-	 * Returns a {@link Link} pointing to the same URI but with the given relation.
-	 * 
-	 * @param rel must not be {@literal null} or empty.
-	 * @return
-	 */
-	public Link withRel(String rel) {
-		return new Link(href, rel);
-	}
-
-	/**
 	 * Returns a {@link Link} pointing to the same URI but with the {@code self} relation.
 	 * 
 	 * @return
@@ -212,66 +119,6 @@ public class Link implements Serializable {
 		return withRel(Link.REL_SELF);
 	}
 
-	/**
-	 * Returns a {@link Link} with the {@code hreflang} attribute filled out.
-	 *
-	 * @param hreflang
-	 * @return
-	 */
-	public Link withHreflang(String hreflang) {
-
-		Assert.hasText(hreflang, "hreflang must not be null or empty!");
-		return new Link(this.href, this.rel, hreflang, this.media, this.title, this.type, this.deprecation);
-	}
-
-	/**
-	 * Returns a {@link Link} with the {@code media} attribute filled out.
-	 *
-	 * @param media
-	 * @return
-	 */
-	public Link withMedia(String media) {
-
-		Assert.hasText(media, "media must not be null or empty!");
-		return new Link(this.href, this.rel, this.hreflang, media, this.title, this.type, this.deprecation);
-	}
-
-	/**
-	 * Returns a {@link Link} with the {@code title} attribute filled out.
-	 *
-	 * @param title
-	 * @return
-	 */
-	public Link withTitle(String title) {
-
-		Assert.hasText(title, "title must not be null or empty!");
-		return new Link(this.href, this.rel, this.hreflang, this.media, title, this.type, this.deprecation);
-	}
-
-	/**
-	 * Returns a {@link Link} with the {@code type} attribute filled out.
-	 *
-	 * @param type
-	 * @return
-	 */
-	public Link withType(String type) {
-
-		Assert.hasText(type, "type must not be null or empty!");
-		return new Link(this.href, this.rel, this.hreflang, this.media, this.title, type, this.deprecation);
-	}
-
-	/**
-	 * Returns a {@link Link} with the {@code deprecation} attribute filled out.
-	 *
-	 * @param deprecation
-	 * @return
-	 */
-	public Link withDeprecation(String deprecation) {
-		
-		Assert.hasText(deprecation, "deprecation must not be null or empty!");
-		return new Link(this.href, this.rel, this.hreflang, this.media, this.title, this.type, deprecation);
-	}
-	
 	/**
 	 * Returns the variable names contained in the template.
 	 * 
@@ -330,68 +177,7 @@ public class Link implements Serializable {
 		return template;
 	}
 
-	/* 
-	 * (non-Javadoc)
-	 * @see java.lang.Object#equals(java.lang.Object)
-	 */
-	@Override
-	public boolean equals(Object obj) {
-
-		if (this == obj) {
-			return true;
-		}
-
-		if (!(obj instanceof Link)) {
-			return false;
-		}
-
-		Link that = (Link) obj;
-
-		return
-			this.href.equals(that.href)
-				&&
-				this.rel.equals(that.rel)
-				&&
-				(this.hreflang != null ? this.hreflang.equals(that.hreflang) : this.hreflang == that.hreflang)
-				&&
-				(this.media != null ? this.media.equals(that.media) : this.media == that.media)
-				&&
-				(this.title != null ? this.title.equals(that.title) : this.title == that.title)
-				&&
-				(this.type != null ? this.type.equals(that.type) : this.type == that.type)
-				&&
-				(this.deprecation != null ? this.deprecation.equals(that.deprecation) : this.deprecation == that.deprecation);
-	}
-
-	/* 
-	 * (non-Javadoc)
-	 * @see java.lang.Object#hashCode()
-	 */
-	@Override
-	public int hashCode() {
-
-		int result = 17;
-		result += 31 * href.hashCode();
-		result += 31 * rel.hashCode();
-		if (hreflang != null) {
-			result += 31 * hreflang.hashCode();
-		}
-		if (media != null) {
-			result += 31 * media.hashCode();
-		}
-		if (title != null) {
-			result += 31 * title.hashCode();
-		}
-		if (type != null) {
-			result += 31 * type.hashCode();
-		}
-		if (deprecation != null) {
-			result += 31 * deprecation.hashCode();
-		}
-		return result;
-	}
-
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see java.lang.Object#toString()
 	 */
@@ -448,11 +234,6 @@ public class Link implements Serializable {
 				throw new IllegalArgumentException("Link does not provide a rel attribute!");
 			}
 
-			Set<String> unrecognizedHeaders = unrecognizedHeaders(attributes);
-			if (!unrecognizedHeaders.isEmpty()) {
-				throw new IllegalArgumentException("Link contains invalid RFC5988 headers! => " + unrecognizedHeaders);
-			}
-
 			Link link = new Link(matcher.group(1), attributes.get("rel"));
 
 			if (attributes.containsKey("hreflang")) {
@@ -503,23 +284,5 @@ public class Link implements Serializable {
 		}
 
 		return attributes;
-	}
-
-	/**
-	 * Scan for any headers not recognized.
-	 *
-	 * @param attributes
-	 * @return
-	 */
-	private static Set<String> unrecognizedHeaders(final Map<String, String> attributes) {
-
-		// Copy the existing keys to avoid damaging the original.
-		Set<String> unrecognizedHeaders = new HashSet<String>();
-		unrecognizedHeaders.addAll(attributes.keySet());
-
-		// Remove all recognized headers
-		unrecognizedHeaders.removeAll(Arrays.asList("href", "rel", "hreflang", "media", "title", "type", "deprecation"));
-
-		return unrecognizedHeaders;
 	}
 }

--- a/src/main/java/org/springframework/hateoas/Links.java
+++ b/src/main/java/org/springframework/hateoas/Links.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,10 +29,11 @@ import org.springframework.util.StringUtils;
  * Value object to represent a list of {@link Link}s.
  * 
  * @author Oliver Gierke
+ * @author Greg Turnquist
  */
 public class Links implements Iterable<Link> {
 
-	private static final Pattern LINK_HEADER_PATTERN = Pattern.compile("(<[^>]*>;rel=\"[^\"]*\")");
+	private static final Pattern LINK_HEADER_PATTERN = Pattern.compile("(<[^>]*>(;\\w+=\"[^\"]*\")+)");
 
 	static final Links NO_LINKS = new Links(Collections.<Link> emptyList());
 

--- a/src/main/java/org/springframework/hateoas/hal/LinkMixin.java
+++ b/src/main/java/org/springframework/hateoas/hal/LinkMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,13 +28,46 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
  * 
  * @author Alexander Baetz
  * @author Oliver Gierke
+ * @author Greg Turnquist
  */
-@JsonIgnoreProperties(value = "rel")
+@JsonIgnoreProperties({"rel", "media"})
 abstract class LinkMixin extends Link {
 
 	private static final long serialVersionUID = 4720588561299667409L;
 
-	/* 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.hateoas.Link#getHreflang()
+	 */
+	@Override
+	@JsonInclude(Include.NON_NULL)
+	public abstract String getHreflang();
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.hateoas.Link#getTitle()
+	 */
+	@Override
+	@JsonInclude(Include.NON_NULL)
+	public abstract String getTitle();
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.hateoas.Link#getType()
+	 */
+	@Override
+	@JsonInclude(Include.NON_NULL)
+	public abstract String getType();
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.hateoas.Link#getDeprecation()
+	 */
+	@Override
+	@JsonInclude(Include.NON_NULL)
+	public abstract String getDeprecation();
+	
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.hateoas.Link#isTemplate()
 	 */

--- a/src/test/java/org/springframework/hateoas/AbstractJackson2MarshallingIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/AbstractJackson2MarshallingIntegrationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.hateoas;
 
 import java.io.StringWriter;
@@ -5,6 +20,7 @@ import java.io.Writer;
 
 import org.junit.Before;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -12,6 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * 
  * @author Oliver Gierke
  * @author Jon Brisbin
+ * @author Greg Turnquist
  */
 public abstract class AbstractJackson2MarshallingIntegrationTest {
 
@@ -20,6 +37,7 @@ public abstract class AbstractJackson2MarshallingIntegrationTest {
 	@Before
 	public void setUp() {
 		mapper = new ObjectMapper();
+		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 	}
 
 	protected String write(Object object) throws Exception {

--- a/src/test/java/org/springframework/hateoas/LinkUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/LinkUnitTest.java
@@ -125,24 +125,25 @@ public class LinkUnitTest {
 	/**
 	 * @see #100
 	 */
-	@Test(expected = IllegalArgumentException.class)
-	public void rejectsUnrecognizedAttributes() {
-		try {
-			Link.valueOf("</something>;rel=\"foo\";unknown=\"should fail\"");
-		} catch (IllegalArgumentException e) {
-			assertThat(e.getMessage(), is("Link contains invalid RFC5988 headers! => [unknown]"));
-			throw e;
-		}
+	@Test
+	public void ignoresUnrecognizedAttributes() {
+		Link link = Link.valueOf("</something>;rel=\"foo\";unknown=\"should fail\"");
+
+		assertThat(link.getHref(), is("/something"));
+		assertThat(link.getRel(), is("foo"));
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void rejectsMissingRelAttribute() {
-		Link.valueOf("</something>);title=\"title\"");
+		Link.valueOf("</something>;title=\"title\"");
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void rejectsLinkWithoutAttributesAtAll() {
-		Link.valueOf("</something>);title=\"title\"");
+
+		Link link = Link.valueOf("</something>");
+
+		System.out.println(link);
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/src/test/java/org/springframework/hateoas/LinkUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/LinkUnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.junit.Test;
  * Unit tests for {@link Link}.
  * 
  * @author Oliver Gierke
+ * @author Greg Turnquist
  */
 public class LinkUnitTest {
 
@@ -103,11 +104,35 @@ public class LinkUnitTest {
 		assertThat(Link.valueOf(""), is(nullValue()));
 	}
 
+	/**
+	 * @see #54
+	 * @see #100
+	 */
 	@Test
 	public void parsesRFC5988HeaderIntoLink() {
 
 		assertThat(Link.valueOf("</something>;rel=\"foo\""), is(new Link("/something", "foo")));
 		assertThat(Link.valueOf("</something>;rel=\"foo\";title=\"Some title\""), is(new Link("/something", "foo")));
+		assertThat(Link.valueOf("</customer/1>;rel=\"self\";hreflang=\"en\";media=\"pdf\";title=\"pdf customer copy\";type=\"portable document\";deprecation=\"http://example.com/customers/deprecated\""),
+			is(new Link("/customer/1")
+				.withHreflang("en")
+				.withMedia("pdf")
+				.withTitle("pdf customer copy")
+				.withType("portable document")
+				.withDeprecation("http://example.com/customers/deprecated")));
+	}
+
+	/**
+	 * @see #100
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void rejectsUnrecognizedAttributes() {
+		try {
+			Link.valueOf("</something>;rel=\"foo\";unknown=\"should fail\"");
+		} catch (IllegalArgumentException e) {
+			assertThat(e.getMessage(), is("Link contains invalid RFC5988 headers! => [unknown]"));
+			throw e;
+		}
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/src/test/java/org/springframework/hateoas/LinksUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/LinksUnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.util.StringUtils;
  * Unit test for {@link Links}.
  * 
  * @author Oliver Gierke
+ * @author Greg Turnquist
  */
 public class LinksUnitTest {
 
@@ -36,18 +37,27 @@ public class LinksUnitTest {
 
 	static final String LINKS = StringUtils.collectionToCommaDelimitedString(Arrays.asList(FIRST, SECOND));
 
-	static final Links reference = new Links(new Link("/something", "foo"), new Link("/somethingElse", "bar"));
+	static final String THIRD = "</something>;rel=\"foo\";hreflang=\"en\"";
+	static final String FOURTH = "</somethingElse>;rel=\"bar\";hreflang=\"de\"";
 
+	static final String LINKS2 = StringUtils.collectionToCommaDelimitedString(Arrays.asList(THIRD, FOURTH));
+
+	static final Links reference = new Links(new Link("/something", "foo"), new Link("/somethingElse", "bar"));
+	static final Links reference2 = new Links(new Link("/something", "foo").withHreflang("en"), new Link("/somethingElse", "bar").withHreflang("de"));
+	
 	@Test
 	public void parsesLinkHeaderLinks() {
 
 		assertThat(Links.valueOf(LINKS), is(reference));
+		assertThat(Links.valueOf(LINKS2), is(reference2));
 		assertThat(reference.toString(), is(LINKS));
+		assertThat(reference2.toString(), is(LINKS2));
 	}
 
 	@Test
 	public void skipsEmptyLinkElements() {
 		assertThat(Links.valueOf(LINKS + ",,,"), is(reference));
+		assertThat(Links.valueOf(LINKS2 + ",,,"), is(reference2));
 	}
 
 	@Test
@@ -57,9 +67,14 @@ public class LinksUnitTest {
 		assertThat(Links.valueOf(""), is(Links.NO_LINKS));
 	}
 
+	/**
+	 * @see #54
+	 * @see #100
+	 */
 	@Test
 	public void getSingleLinkByRel() {
 		assertThat(reference.getLink("bar"), is(new Link("/somethingElse", "bar")));
+		assertThat(reference2.getLink("bar"), is(new Link("/somethingElse", "bar").withHreflang("de")));
 	}
 
 	/**

--- a/src/test/java/org/springframework/hateoas/hal/DefaultCurieProviderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/hal/DefaultCurieProviderUnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
  * Unit tests for {@link DefaultCurieProvider}.
  * 
  * @author Oliver Gierke
+ * @author Greg Turnquist
  */
 public class DefaultCurieProviderUnitTest {
 
@@ -80,6 +81,19 @@ public class DefaultCurieProviderUnitTest {
 	@Test
 	public void doesNotPrefixQualifiedRels() {
 		assertThat(provider.getNamespacedRelFrom(new Link("http://amazon.com", "custom:rel")), is("custom:rel"));
+	}
+
+	/**
+	 * @see #100
+	 */
+	@Test
+	public void prefixesNormalRelsThatHaveExtraRFC5988Attributes() {
+		assertThat(provider.getNamespacedRelFrom(new Link("http://amazon.com", "custom:rel")
+			.withHreflang("en")
+			.withTitle("the title")
+			.withMedia("the media")
+			.withType("the type")
+			.withDeprecation("http://example.com/custom/deprecated")), is("custom:rel"));
 	}
 
 	/**

--- a/src/test/java/org/springframework/hateoas/hal/Jackson2HalIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/hal/Jackson2HalIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import java.util.Locale;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.context.support.MessageSourceAccessor;
@@ -51,6 +52,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * 
  * @author Alexander Baetz
  * @author Oliver Gierke
+ * @author Greg Turnquist
  */
 public class Jackson2HalIntegrationTest extends AbstractJackson2MarshallingIntegrationTest {
 
@@ -77,6 +79,9 @@ public class Jackson2HalIntegrationTest extends AbstractJackson2MarshallingInteg
 
 	static final String LINK_WITH_TITLE = "{\"_links\":{\"ns:foobar\":{\"href\":\"target\",\"title\":\"Foobar's title!\"}}}";
 
+	static final String SINGLE_WITH_ONE_EXTRA_ATTRIBUTES = "{\"_links\":{\"self\":{\"href\":\"localhost\",\"title\":\"the title\"}}}";
+	static final String SINGLE_WITH_ALL_EXTRA_ATTRIBUTES = "{\"_links\":{\"self\":{\"href\":\"localhost\",\"hreflang\":\"en\",\"title\":\"the title\",\"type\":\"the type\",\"deprecation\":\"/customers/deprecated\"}}}";
+	
 	@Before
 	public void setUpModule() {
 
@@ -94,6 +99,33 @@ public class Jackson2HalIntegrationTest extends AbstractJackson2MarshallingInteg
 		resourceSupport.add(new Link("localhost"));
 
 		assertThat(write(resourceSupport), is(SINGLE_LINK_REFERENCE));
+	}
+
+	/**
+	 * @see #100
+	 */
+	@Test
+	public void rendersAllExtraRFC5988Attributes() throws Exception {
+
+		ResourceSupport resourceSupport = new ResourceSupport();
+		resourceSupport.add(new Link("localhost", "self")
+			.withHreflang("en")
+			.withTitle("the title")
+			.withType("the type")
+			.withMedia("the media")
+			.withDeprecation("/customers/deprecated"));
+
+		assertThat(write(resourceSupport), is(SINGLE_WITH_ALL_EXTRA_ATTRIBUTES));
+	}
+
+	@Test
+	public void rendersWithOneExtraRFC5988Attribute() throws Exception {
+
+		ResourceSupport resourceSupport = new ResourceSupport();
+		resourceSupport.add(new Link("localhost", "self")
+			.withTitle("the title"));
+
+		assertThat(write(resourceSupport), is(SINGLE_WITH_ONE_EXTRA_ATTRIBUTES));
 	}
 
 	@Test


### PR DESCRIPTION
Adds many additional attributes defined in RFC5988 and verifies they work properly in the neutral representation of Link while also being rendered properly in the HAL module.

Related tickets: #100, #417, #235
Previous pull requests: #240, #238, #223, #79