### PR TITLE
#594 - Protect against Spring 5 non-null inputs

### DIFF
--- a/src/main/java/org/springframework/hateoas/core/AnnotationMappingDiscoverer.java
+++ b/src/main/java/org/springframework/hateoas/core/AnnotationMappingDiscoverer.java
@@ -108,7 +108,11 @@ public class AnnotationMappingDiscoverer implements MappingDiscoverer {
 
 	private String[] getMappingFrom(Annotation annotation) {
 
-		Object value = mappingAttributeName == null ? getValue(annotation) : getValue(annotation, mappingAttributeName);
+		Object value = null;
+
+		if (annotation != null) {
+			value = mappingAttributeName == null ? getValue(annotation) : getValue(annotation, mappingAttributeName);
+		}
 
 		if (value instanceof String) {
 			return new String[] { (String) value };


### PR DESCRIPTION
Spring 5 has adopted a "no nulls" policy that causes certain methods to throw exceptions instead of returning a null. This updates Spring HATEOAS to handle it suitably.