### PR TITLE
#617 - Use SynthesizingMethodParameter to support AliasFor attributes

### DIFF
--- a/src/main/java/org/springframework/hateoas/mvc/AnnotatedParametersParameterAccessor.java
+++ b/src/main/java/org/springframework/hateoas/mvc/AnnotatedParametersParameterAccessor.java
@@ -24,7 +24,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.core.DefaultParameterNameDiscoverer;
 import org.springframework.core.MethodParameter;
+import org.springframework.core.annotation.SynthesizingMethodParameter;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.format.support.DefaultFormattingConversionService;
@@ -47,6 +49,7 @@ class AnnotatedParametersParameterAccessor {
 
 	private static final Map<Method, MethodParameters> METHOD_PARAMETERS_CACHE = new ConcurrentReferenceHashMap<Method, MethodParameters>(
 			16, ReferenceType.WEAK);
+	private static final DefaultParameterNameDiscoverer DISCOVERER = new DefaultParameterNameDiscoverer();
 
 	private final @NonNull AnnotationAttribute attribute;
 
@@ -70,7 +73,9 @@ class AnnotatedParametersParameterAccessor {
 			Object verifiedValue = verifyParameterValue(parameter, value);
 
 			if (verifiedValue != null) {
-				result.add(createParameter(parameter, verifiedValue, attribute));
+				SynthesizingMethodParameter synthesizingMethodParameter = new SynthesizingMethodParameter(invocation.getMethod(), parameter.getParameterIndex());
+				synthesizingMethodParameter.initParameterNameDiscovery(DISCOVERER);
+				result.add(createParameter(synthesizingMethodParameter, verifiedValue, attribute));
 			}
 		}
 

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
@@ -554,6 +554,16 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		assertThat(linkTo(PersonControllerImpl.class).withSelfRel().getHref(), endsWith("/ctx/people"));
 	}
 
+	/**
+	 * @see #617
+	 */
+	@Test
+	public void alternativePathVariableParameter() {
+
+		Link link = linkTo(methodOn(ControllerWithMethods.class).methodWithAlternatePathVariable("bar")).withSelfRel();
+		assertThat(link.getHref(), is("http://localhost/something/bar/foo"));
+	}
+
 	private static UriComponents toComponents(Link link) {
 		return UriComponentsBuilder.fromUriString(link.expand().getHref()).build();
 	}
@@ -618,6 +628,11 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		@RequestMapping(value = "/{id}/foo")
 		HttpEntity<Void> methodWithMultiValueRequestParams(@PathVariable String id, @RequestParam List<Integer> items,
 				@RequestParam Integer limit) {
+			return null;
+		}
+
+		@RequestMapping(value = "/{id}/foo")
+		HttpEntity<Void> methodWithAlternatePathVariable(@PathVariable(name = "id") String otherId) {
 			return null;
 		}
 

--- a/src/test/java/org/springframework/hateoas/mvc/DummyInvocationUtilsUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/DummyInvocationUtilsUnitTest.java
@@ -15,7 +15,11 @@
  */
 package org.springframework.hateoas.mvc;
 
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+
 import org.junit.Test;
+import org.springframework.hateoas.Link;
 import org.springframework.hateoas.TestUtils;
 import org.springframework.hateoas.core.DummyInvocationUtils;
 import org.springframework.http.HttpEntity;
@@ -30,10 +34,17 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class DummyInvocationUtilsUnitTest extends TestUtils {
 
 	@Test
-	public void test() {
+	public void pathVariableWithDefaultParameter() {
 
-		ControllerLinkBuilder.linkTo(DummyInvocationUtils.methodOn(SampleController.class).someMethod(1L));
+		Link link = ControllerLinkBuilder.linkTo(DummyInvocationUtils.methodOn(SampleController.class).someMethod(1L)).withSelfRel();
+		assertThat(link.getHref(), is("http://localhost/sample/1/foo"));
+	}
 
+	@Test
+	public void pathVariableWithNameParameter() {
+
+		Link link = ControllerLinkBuilder.linkTo(DummyInvocationUtils.methodOn(SampleController.class).someOtherMethod(2L)).withSelfRel();
+		assertThat(link.getHref(), is("http://localhost/sample/2/bar"));
 	}
 
 	@RequestMapping("/sample")
@@ -41,6 +52,11 @@ public class DummyInvocationUtilsUnitTest extends TestUtils {
 
 		@RequestMapping("/{id}/foo")
 		HttpEntity<Void> someMethod(@PathVariable("id") Long id) {
+			return new ResponseEntity<Void>(HttpStatus.OK);
+		}
+
+		@RequestMapping("/{otherName}/bar")
+		HttpEntity<Void> someOtherMethod(@PathVariable(name = "otherName") Long id) {
 			return new ResponseEntity<Void>(HttpStatus.OK);
 		}
 	}


### PR DESCRIPTION
When parsing the controller method parameters, use `SynthesizingMethodParameter` in order to leverage Spring's `@AliasFor` annotations that bridge attributes together. That way, fetching a parameter's annotation supports aliased attributes.