### PR TITLE
Use "else if" in HypermediaSupportBeanDefinitionRegistrar.postProcessBeforeInitialization()

### DIFF
--- a/src/main/java/org/springframework/hateoas/config/HypermediaSupportBeanDefinitionRegistrar.java
+++ b/src/main/java/org/springframework/hateoas/config/HypermediaSupportBeanDefinitionRegistrar.java
@@ -249,9 +249,7 @@ class HypermediaSupportBeanDefinitionRegistrar implements ImportBeanDefinitionRe
 
 				RequestMappingHandlerAdapter adapter = (RequestMappingHandlerAdapter) bean;
 				adapter.setMessageConverters(potentiallyRegisterModule(adapter.getMessageConverters()));
-			}
-
-			if (bean instanceof RestTemplate) {
+			} else if (bean instanceof RestTemplate) {
 
 				RestTemplate template = (RestTemplate) bean;
 				template.setMessageConverters(potentiallyRegisterModule(template.getMessageConverters()));


### PR DESCRIPTION
This PR uses `else if` because the conditions are mutually exclusive.