### PR TITLE
#416 - Alter ResourceAssemblerSupport.toResources to return Resources

### DIFF
--- a/src/main/java/org/springframework/hateoas/mvc/ResourceAssemblerSupport.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ResourceAssemblerSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.List;
 import org.springframework.beans.BeanUtils;
 import org.springframework.hateoas.ResourceAssembler;
 import org.springframework.hateoas.ResourceSupport;
+import org.springframework.hateoas.Resources;
 import org.springframework.util.Assert;
 
 /**
@@ -30,6 +31,7 @@ import org.springframework.util.Assert;
  * sure a self-link is always added.
  * 
  * @author Oliver Gierke
+ * @author Greg Turnquist
  */
 public abstract class ResourceAssemblerSupport<T, D extends ResourceSupport> implements ResourceAssembler<T, D> {
 
@@ -52,22 +54,36 @@ public abstract class ResourceAssemblerSupport<T, D extends ResourceSupport> imp
 	}
 
 	/**
-	 * Converts all given entities into resources.
+	 * Transform a list of {@code T}s into a list of {@link ResourceSupport}s.
+	 *
+	 * @see {@link #toResources(Iterable)} if you need this transformed list rendered as hypermedia
 	 * 
-	 * @see #toResource(Object)
-	 * @param entities must not be {@literal null}.
+	 * @param entities
 	 * @return
 	 */
-	public List<D> toResources(Iterable<? extends T> entities) {
+	public List<D> toList(Iterable<? extends T> entities) {
 
 		Assert.notNull(entities, "Entities must not be null!");
-		List<D> result = new ArrayList<D>();
+		List<D> result = new ArrayList<>();
 
 		for (T entity : entities) {
 			result.add(toResource(entity));
 		}
 
 		return result;
+	}
+
+	/**
+	 * Converts all given entities into resources.
+	 *
+	 * @see #toResource(Object)
+	 * @param entities must not be {@literal null}.
+	 * @return
+	 */
+	public Resources<D> toResources(Iterable<? extends T> entities) {
+
+		Assert.notNull(entities, "Entities must not be null!");
+		return new Resources<D>(toList(entities));
 	}
 
 	/**

--- a/src/test/java/org/springframework/hateoas/mvc/IdentifiableResourceAssemblerSupportUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/IdentifiableResourceAssemblerSupportUnitTest.java
@@ -94,7 +94,7 @@ public class IdentifiableResourceAssemblerSupportUnitTest extends TestUtils {
 		Person second = new Person();
 		second.id = 2L;
 
-		List<PersonResource> result = assembler.toList(Arrays.asList(first, second));
+		List<PersonResource> result = assembler.build(Arrays.asList(first, second)).toListOfResources();
 
 		LinkBuilder builder = linkTo(PersonController.class);
 
@@ -119,7 +119,7 @@ public class IdentifiableResourceAssemblerSupportUnitTest extends TestUtils {
 		Person second = new Person();
 		second.id = 2L;
 
-		Resources<PersonResource> result = assembler.toResources(Arrays.asList(first, second));
+		Resources<PersonResource> result = assembler.build(Arrays.asList(first, second)).toResources();
 
 		LinkBuilder builder = linkTo(PersonController.class);
 

--- a/src/test/java/org/springframework/hateoas/mvc/IdentifiableResourceAssemblerSupportUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/IdentifiableResourceAssemblerSupportUnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.hateoas.Identifiable;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.LinkBuilder;
 import org.springframework.hateoas.ResourceSupport;
+import org.springframework.hateoas.Resources;
 import org.springframework.hateoas.TestUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -35,6 +36,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
  * Unit tests for {@link IdentifiableResourceAssemblerSupport}.
  * 
  * @author Oliver Gierke
+ * @author Greg Turnquist
  */
 public class IdentifiableResourceAssemblerSupportUnitTest extends TestUtils {
 
@@ -81,6 +83,34 @@ public class IdentifiableResourceAssemblerSupportUnitTest extends TestUtils {
 				.hasValueSatisfying(it -> assertThat(it.endsWith("/people/id")));
 	}
 
+	/**
+	 * @see #416
+	 */
+	@Test
+	public void convertsEntitiesToListOfResources() {
+
+		Person first = new Person();
+		first.id = 1L;
+		Person second = new Person();
+		second.id = 2L;
+
+		List<PersonResource> result = assembler.toList(Arrays.asList(first, second));
+
+		LinkBuilder builder = linkTo(PersonController.class);
+
+		PersonResource firstResource = new PersonResource();
+		firstResource.add(builder.slash(1L).withSelfRel());
+
+		PersonResource secondResource = new PersonResource();
+		secondResource.add(builder.slash(1L).withSelfRel());
+
+		assertThat(result).hasSize(2);
+		assertThat(result).contains(firstResource, secondResource);
+	}
+
+	/**
+	 * @see #416
+	 */
 	@Test
 	public void convertsEntitiesToResources() {
 
@@ -89,7 +119,7 @@ public class IdentifiableResourceAssemblerSupportUnitTest extends TestUtils {
 		Person second = new Person();
 		second.id = 2L;
 
-		List<PersonResource> result = assembler.toResources(Arrays.asList(first, second));
+		Resources<PersonResource> result = assembler.toResources(Arrays.asList(first, second));
 
 		LinkBuilder builder = linkTo(PersonController.class);
 


### PR DESCRIPTION
To avoid confusion about what to return on a Spring MVC endpoint, change toResources to not return `List<D>`, but instead `Resources<D>`. This clearly ensures when used to construct Spring MVC endpoints, will return a type Spring HATEOAS will properly marshal.

Related issues: #493
Related pull requests: #572