### PR TITLE
#665 - Fix ALPS format

### DIFF
--- a/src/main/java/org/springframework/hateoas/alps/Alps.java
+++ b/src/main/java/org/springframework/hateoas/alps/Alps.java
@@ -24,21 +24,25 @@ import org.springframework.hateoas.alps.Descriptor.DescriptorBuilder;
 import org.springframework.hateoas.alps.Doc.DocBuilder;
 import org.springframework.hateoas.alps.Ext.ExtBuilder;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 /**
  * An ALPS document.
  * 
  * @author Oliver Gierke
+ * @author Greg Turnquist
  * @since 0.15
  * @see http://alps.io
  * @see http://alps.io/spec/#prop-alps
  */
 @Value
 @Builder(builderMethodName = "alps")
+@JsonPropertyOrder({"version", "doc", "descriptor"})
 public class Alps {
 
 	private final String version = "1.0";
 	private final Doc doc;
-	private final List<Descriptor> descriptors;
+	private final List<Descriptor> descriptor;
 
 	/**
 	 * Returns a new {@link DescriptorBuilder}.

--- a/src/main/java/org/springframework/hateoas/alps/Descriptor.java
+++ b/src/main/java/org/springframework/hateoas/alps/Descriptor.java
@@ -20,15 +20,19 @@ import lombok.Value;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 /**
  * A value object for an ALPS descriptor.
  * 
  * @author Oliver Gierke
+ * @author Greg Turnquist
  * @since 0.15
  * @see http://alps.io/spec/#prop-descriptor
  */
 @Value
 @Builder
+@JsonPropertyOrder({"id", "href", "name", "type", "doc", "descriptor", "ext"})
 public class Descriptor {
 
 	private final String id, href, name;
@@ -36,5 +40,5 @@ public class Descriptor {
 	private final Type type;
 	private final Ext ext;
 	private final String rt;
-	private final List<Descriptor> descriptors;
+	private final List<Descriptor> descriptor;
 }

--- a/src/main/java/org/springframework/hateoas/alps/Doc.java
+++ b/src/main/java/org/springframework/hateoas/alps/Doc.java
@@ -21,16 +21,20 @@ import lombok.Value;
 
 import org.springframework.util.Assert;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 /**
  * A value object for an ALPS doc element.
  * 
  * @author Oliver Gierke
+ * @author Greg Turnquist
  * @since 0.15
  * @see http://alps.io/spec/#prop-doc
  */
 @Value
 @Builder
 @AllArgsConstructor
+@JsonPropertyOrder({"format", "href", "value"})
 public class Doc {
 
 	private final String href, value;

--- a/src/main/java/org/springframework/hateoas/alps/Ext.java
+++ b/src/main/java/org/springframework/hateoas/alps/Ext.java
@@ -18,15 +18,19 @@ package org.springframework.hateoas.alps;
 import lombok.Builder;
 import lombok.Value;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 /**
  * A value object for an ALPS ext element.
  * 
  * @author Oliver Gierke
+ * @author Greg Turnquist
  * @since 0.15
  * @see http://alps.io/spec/#prop-ext
  */
 @Value
 @Builder
+@JsonPropertyOrder({"id", "href", "value"})
 public class Ext {
 
 	private final String id;

--- a/src/main/java/org/springframework/hateoas/alps/Format.java
+++ b/src/main/java/org/springframework/hateoas/alps/Format.java
@@ -21,6 +21,7 @@ import java.util.Locale;
  * Enum for all ALPS doc formats.
  * 
  * @author Oliver Gierke
+ * @author Greg Turnquist
  * @since 0.15
  * @see http://alps.io/spec/#prop-format
  */

--- a/src/main/java/org/springframework/hateoas/alps/Type.java
+++ b/src/main/java/org/springframework/hateoas/alps/Type.java
@@ -21,6 +21,7 @@ import java.util.Locale;
  * An enum for ALPS descriptor types
  * 
  * @author Oliver Gierke
+ * @author Greg Turnquist
  * @since 0.15
  * @see http://alps.io/spec/#prop-type
  */

--- a/src/test/java/org/springframework/hateoas/alps/JacksonSerializationTest.java
+++ b/src/test/java/org/springframework/hateoas/alps/JacksonSerializationTest.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
  * Unit tests for serialization of ALPS documents.
  * 
  * @author Oliver Gierke
+ * @author Greg Turnquist
  */
 public class JacksonSerializationTest {
 
@@ -56,10 +57,10 @@ public class JacksonSerializationTest {
 
 		Alps alps = alps().//
 				doc(doc().href("http://example.org/samples/full/doc.html").build()). //
-				descriptors(Arrays.asList(//
+				descriptor(Arrays.asList(//
 						descriptor().id("search").type(Type.SAFE).//
 								doc(new Doc("A search form with two inputs.", Format.TEXT)).//
-								descriptors(Arrays.asList( //
+								descriptor(Arrays.asList( //
 										descriptor().href("#resultType").build(), //
 										descriptor().id("value").name("search").type(Type.SEMANTIC).build())//
 								).build(), //

--- a/src/test/resources/org/springframework/hateoas/alps/reference.json
+++ b/src/test/resources/org/springframework/hateoas/alps/reference.json
@@ -1,15 +1,16 @@
 {
+  "version" : "1.0",
   "doc" : {
     "href" : "http://example.org/samples/full/doc.html"
   },
-  "descriptors" : [ {
+  "descriptor" : [ {
     "id" : "search",
-    "doc" : {
-      "value" : "A search form with two inputs.",
-      "format" : "TEXT"
-    },
     "type" : "SAFE",
-    "descriptors" : [ {
+    "doc" : {
+      "format" : "TEXT",
+      "value" : "A search form with two inputs."
+    },
+    "descriptor" : [ {
       "href" : "#resultType"
     }, {
       "id" : "value",
@@ -18,15 +19,14 @@
     } ]
   }, {
     "id" : "resultType",
+    "type" : "SEMANTIC",
     "doc" : {
       "value" : "results format"
     },
-    "type" : "SEMANTIC",
     "ext" : {
       "id" : "#ext-range",
       "href" : "http://alps.io/ext/range",
       "value" : "summary,detail"
     }
-  } ],
-  "version" : "1.0"
+  } ]
 }


### PR DESCRIPTION
According to the ALPS spec, it's "descriptor" not "descriptors", despite it depicting an array of potentially multiple values. Also fixed the ordering to match as closely as possible all the samples shown in the spec.