### PR TITLE
#667 - Fix Link to ignore setting "templated" properties

### DIFF
--- a/src/main/java/org/springframework/hateoas/Link.java
+++ b/src/main/java/org/springframework/hateoas/Link.java
@@ -221,6 +221,18 @@ public class Link implements Serializable {
 	}
 
 	/**
+	 * This noop setter is required to deserialize a HAL document that contains a templated URL. It allows
+	 * Jackson to "set" the property, but since it's a virtual property, the injected value (true or false) is
+	 * ignored.
+	 *
+	 * The method is kept private so no one attempts to actually use it.
+	 *
+	 * @param __ - don't care what value is passed in. The true value {@link #isTemplated()} is based upon the {@link UriTemplate}.
+	 */
+	private void setTemplated(boolean __) {
+	}
+
+	/**
 	 * Turns the current template into a {@link Link} by expanding it using the given parameters.
 	 * 
 	 * @param arguments

--- a/src/test/java/org/springframework/hateoas/hal/Jackson2HalIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/hal/Jackson2HalIntegrationTest.java
@@ -17,6 +17,7 @@ package org.springframework.hateoas.hal;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -451,6 +452,23 @@ public class Jackson2HalIntegrationTest extends AbstractJackson2MarshallingInteg
 		resourceSupport.add(new Link("localhost").withSelfRel());
 
 		assertThat(write(resourceSupport)).isEqualTo("{\"_links\":{\"self\":[{\"href\":\"localhost\"}]}}");
+	}
+
+	@Test
+	public void handleTemplatedLinks() throws IOException {
+
+		ResourceSupport original = new ResourceSupport();
+		original.add(new Link("/orders{?id}", "order"));
+
+		String serialized = mapper.writeValueAsString(original);
+
+		String expected = "{\"_links\":{\"order\":{\"href\":\"/orders{?id}\",\"templated\":true}}}";
+
+		assertThat(serialized).isEqualTo(expected);
+
+		ResourceSupport deserialized = mapper.readValue(serialized, ResourceSupport.class);
+
+		assertThat(deserialized).isEqualTo(original);
 	}
 
 	private static void verifyResolvedTitle(String resourceBundleKey) throws Exception {


### PR DESCRIPTION
Deserializing a HAL document with a templated URI will cause Jackson to break due to there being no "templated" property. This PR fixes that by adding a private, no-op `setTemplated` method.