### PR TITLE
Remove list creation in ResourceSupport.getLink()

### DIFF
--- a/src/main/java/org/springframework/hateoas/ResourceSupport.java
+++ b/src/main/java/org/springframework/hateoas/ResourceSupport.java
@@ -123,7 +123,9 @@ public class ResourceSupport implements Identifiable<Link> {
 	 * @return the link with the given rel or {@link Optional#empty()} if none found.
 	 */
 	public Optional<Link> getLink(String rel) {
-		return getLinks(rel).stream().findFirst();
+		return links.stream() //
+				.filter(link -> link.getRel().equals(rel)) //
+				.findFirst();
 	}
 
 	/**


### PR DESCRIPTION
By 4c7227e2743b00f7e2dcca262f8c3daa0b2250eb, `ResourceSupport.getLink()` creates a list.

This PR removes the list creation.