### PR TITLE
Handle Optional in IdentifiableResourceAssemblerSupport.unwrapIdentifiables()

### DIFF
--- a/src/main/java/org/springframework/hateoas/mvc/IdentifiableResourceAssemblerSupport.java
+++ b/src/main/java/org/springframework/hateoas/mvc/IdentifiableResourceAssemblerSupport.java
@@ -68,7 +68,7 @@ public abstract class IdentifiableResourceAssemblerSupport<T extends Identifiabl
 		Assert.notNull(id, "Id must not be null!");
 
 		D instance = instantiateResource(entity);
-		instance.add(linkTo(controllerClass, unwrapIdentifyables(parameters)).slash(id).withSelfRel());
+		instance.add(linkTo(controllerClass, unwrapIdentifiables(parameters)).slash(id).withSelfRel());
 		return instance;
 	}
 
@@ -78,10 +78,10 @@ public abstract class IdentifiableResourceAssemblerSupport<T extends Identifiabl
 	 * @param values must not be {@literal null}.
 	 * @return
 	 */
-	private Object[] unwrapIdentifyables(Object[] values) {
+	private Object[] unwrapIdentifiables(Object[] values) {
 
 		return Arrays.stream(values) //
-				.map(element -> element instanceof Identifiable ? ((Identifiable<?>) element).getId() : element) //
+				.map(element -> element instanceof Identifiable ? ((Identifiable<?>) element).getId().get() : element) //
 				.toArray();
 	}
 }

--- a/src/test/java/org/springframework/hateoas/mvc/IdentifiableResourceAssemblerSupportUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/IdentifiableResourceAssemblerSupportUnitTest.java
@@ -16,6 +16,7 @@
 package org.springframework.hateoas.mvc;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.*;
 
 import java.util.Arrays;
@@ -67,18 +68,18 @@ public class IdentifiableResourceAssemblerSupportUnitTest extends TestUtils {
 		Optional<Link> selfLink = resource.getId();
 
 		assertThat(selfLink.map(Link::getHref)) //
-				.hasValueSatisfying(it -> assertThat(it.endsWith("/people/id")));
+				.hasValueSatisfying(it -> assertTrue(it.endsWith("/people/id")));
 	}
 
 	@Test
-	public void unwrapsIdentifyablesForParameters() {
+	public void unwrapsIdentifiablesForParameters() {
 
 		PersonResource resource = new PersonResourceAssembler(ParameterizedController.class).createResource(person, person,
 				"bar");
 		Optional<Link> selfLink = resource.getId();
 
 		assertThat(selfLink.map(Link::getHref)) //
-				.hasValueSatisfying(it -> assertThat(it.endsWith("/people/id")));
+				.hasValueSatisfying(it -> assertTrue(it.endsWith("/people/10/bar/addresses/10")));
 	}
 
 	@Test


### PR DESCRIPTION
This PR also fixes tests having a wrong assertion.