### PR TITLE
Support whitespace in Links Header

### DIFF
--- a/src/main/java/org/springframework/hateoas/Links.java
+++ b/src/main/java/org/springframework/hateoas/Links.java
@@ -35,7 +35,7 @@ import org.springframework.util.StringUtils;
  */
 public class Links implements Iterable<Link> {
 
-	private static final Pattern LINK_HEADER_PATTERN = Pattern.compile("(<[^>]*>(;\\w+=\"[^\"]*\")+)");
+	private static final Pattern LINK_HEADER_PATTERN = Pattern.compile("(<[^>]*>(;\\s*\\w+=\"[^\"]*\")+)");
 
 	static final Links NO_LINKS = new Links(Collections.emptyList());
 

--- a/src/test/java/org/springframework/hateoas/LinksUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/LinksUnitTest.java
@@ -34,6 +34,7 @@ public class LinksUnitTest {
 	static final String FIRST = "</something>;rel=\"foo\"";
 	static final String SECOND = "</somethingElse>;rel=\"bar\"";
 	static final String WITH_COMMA = "<http://localhost:8080/test?page=0&filter=foo,bar>;rel=\"foo\"";
+	static final String WITH_WHITESPACE = "</something>; rel=\"foo\"," + SECOND;
 
 	static final String LINKS = StringUtils.collectionToCommaDelimitedString(Arrays.asList(FIRST, SECOND));
 
@@ -92,5 +93,13 @@ public class LinksUnitTest {
 
 		assertThat(twoWithCommaInFirst.getLink("foo")).hasValue(withComma);
 		assertThat(twoWithCommaInFirst.getLink("bar")).hasValue(new Link("/somethingElse", "bar"));
+	}
+
+	/**
+	 * @see https://tools.ietf.org/html/rfc5988#section-5.5
+	 */
+	@Test
+	public void parsesLinksWithWhitespace() {
+		assertThat(Links.valueOf(WITH_WHITESPACE)).isEqualTo(reference);
 	}
 }


### PR DESCRIPTION
The RFC uses [Examples](https://tools.ietf.org/html/rfc5988#section-5.5)
which cannot be parsed correctly