### PR TITLE
[WIP] Convert link with RFC5988 additional attributes

### DIFF
--- a/src/main/java/org/springframework/hateoas/hal/Jackson2HalModule.java
+++ b/src/main/java/org/springframework/hateoas/hal/Jackson2HalModule.java
@@ -573,11 +573,21 @@ public class Jackson2HalModule extends SimpleModule {
 				if (JsonToken.START_ARRAY.equals(jp.nextToken())) {
 					while (!JsonToken.END_ARRAY.equals(jp.nextToken())) {
 						link = jp.readValueAs(Link.class);
-						result.add(new Link(link.getHref(), relation));
+						result.add(new Link(link.getHref(), relation)
+								.withHreflang(link.getHreflang())
+								.withMedia(link.getMedia())
+								.withTitle(link.getTitle())
+								.withType(link.getType())
+								.withDeprecation(link.getDeprecation()));
 					}
 				} else {
 					link = jp.readValueAs(Link.class);
-					result.add(new Link(link.getHref(), relation));
+					result.add(new Link(link.getHref(), relation)
+							.withHreflang(link.getHreflang())
+							.withMedia(link.getMedia())
+							.withTitle(link.getTitle())
+							.withType(link.getType())
+							.withDeprecation(link.getDeprecation()));
 				}
 			}
 

--- a/src/test/java/org/springframework/hateoas/hal/Jackson2HalIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/hal/Jackson2HalIntegrationTest.java
@@ -79,7 +79,7 @@ public class Jackson2HalIntegrationTest extends AbstractJackson2MarshallingInteg
 	static final String LINK_WITH_TITLE = "{\"_links\":{\"ns:foobar\":{\"href\":\"target\",\"title\":\"Foobar's title!\"}}}";
 
 	static final String SINGLE_WITH_ONE_EXTRA_ATTRIBUTES = "{\"_links\":{\"self\":{\"href\":\"localhost\",\"title\":\"the title\"}}}";
-	static final String SINGLE_WITH_ALL_EXTRA_ATTRIBUTES = "{\"_links\":{\"self\":{\"href\":\"localhost\",\"hreflang\":\"en\",\"title\":\"the title\",\"type\":\"the type\",\"deprecation\":\"/customers/deprecated\"}}}";
+	static final String SINGLE_WITH_ALL_EXTRA_ATTRIBUTES = "{\"_links\":{\"self\":{\"href\":\"localhost\",\"hreflang\":\"en\",\"media\":\"the media\",\"title\":\"the title\",\"type\":\"the type\",\"deprecation\":\"/customers/deprecated\"}}}";
 
 	@Before
 	public void setUpModule() {
@@ -119,12 +119,35 @@ public class Jackson2HalIntegrationTest extends AbstractJackson2MarshallingInteg
 	}
 
 	@Test
+	public void deserializeAllExtraRFC5988Attributes() throws Exception {
+
+		ResourceSupport expected = new ResourceSupport();
+		expected.add(new Link("localhost", "self") //
+				.withHreflang("en") //
+				.withTitle("the title") //
+				.withType("the type") //
+				.withMedia("the media") //
+				.withDeprecation("/customers/deprecated"));
+
+		assertThat(read(SINGLE_WITH_ALL_EXTRA_ATTRIBUTES, ResourceSupport.class)).isEqualTo(expected);
+	}
+
+	@Test
 	public void rendersWithOneExtraRFC5988Attribute() throws Exception {
 
 		ResourceSupport resourceSupport = new ResourceSupport();
 		resourceSupport.add(new Link("localhost", "self").withTitle("the title"));
 
 		assertThat(write(resourceSupport)).isEqualTo(SINGLE_WITH_ONE_EXTRA_ATTRIBUTES);
+	}
+
+	@Test
+	public void deserializeOneExtraRFC5988Attribute() throws Exception {
+
+		ResourceSupport expected = new ResourceSupport();
+		expected.add(new Link("localhost", "self").withTitle("the title"));
+
+		assertThat(read(SINGLE_WITH_ONE_EXTRA_ATTRIBUTES, ResourceSupport.class)).isEqualTo(expected);
 	}
 
 	@Test


### PR DESCRIPTION
I noticed that the deserialization in the Jackson2HalModule was not working with the additional RFC5988 attributes added in PR #567 . This adds two tests for converting from Json.

Unfortunately, I am having trouble getting `media` to work. It does not seem to be converted properly using the json parser. I will continue looking into this, but would appreciate one of the maintainers looking it over.

Also, note: I would use one constructor for the link in the deserialization, but it was mentioned in #567 to use Lambok notation. Currently, the constructor containing the attributes is protected and cannot be accessed from the Jackson2HalModule.