### PR TITLE
Obvious Fix: typo

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -67,7 +67,7 @@ This would render as follows in JSON:
 {
     "firstname" : "Dave",
     "lastname" : "Matthews",
-    _"links" : [
+    "_links" : [
         {
             "rel" : "self",
             "href" : "http://myhost/people"


### PR DESCRIPTION
Typo with the underscore outside of the json string