### PR TITLE
Use system-dependent line separator in tests

### DIFF
--- a/src/test/java/org/springframework/hateoas/support/MappingUtils.java
+++ b/src/test/java/org/springframework/hateoas/support/MappingUtils.java
@@ -50,7 +50,7 @@ public final class MappingUtils {
 				builder.append(scanner.nextLine());
 
 				if (scanner.hasNextLine()) {
-					builder.append("\n");
+					builder.append(System.lineSeparator());
 				}
 			}
 


### PR DESCRIPTION
On windows systems 25 tests breaks currently because of the use of UNIX line separator in MappingUtils class. This PR fixes this issue.