### PR TITLE
Provide link builder DSL to write idiomatic Kotlin code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
 		<slf4j.version>1.7.25</slf4j.version>
 		<spring.version>5.0.11.RELEASE</spring.version>
 		<spring-plugin.version>2.0.0.BUILD-SNAPSHOT</spring-plugin.version>
+		<kotlin.version>1.3.11</kotlin.version>
 	</properties>
 
 	<profiles>
@@ -422,6 +423,26 @@
 
 	<dependencies>
 
+		<!-- Kotlin extension -->
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-stdlib</artifactId>
+			<version>${kotlin.version}</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-reflect</artifactId>
+			<version>${kotlin.version}</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-test</artifactId>
+			<version>${kotlin.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-aop</artifactId>
@@ -662,6 +683,43 @@
 				<configuration>
 					<useSystemClassLoader>false</useSystemClassLoader>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-maven-plugin</artifactId>
+				<version>${kotlin.version}</version>
+				<executions>
+					<execution>
+						<id>compile</id>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+						<configuration>
+							<sourceDirs>
+								<sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+								<sourceDir>${project.basedir}/src/main/java</sourceDir>
+							</sourceDirs>
+						</configuration>
+					</execution>
+					<execution>
+						<id>test-compile</id>
+						<goals>
+							<goal>test-compile</goal>
+						</goals>
+						<configuration>
+							<sourceDirs>
+								<sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+								<sourceDir>${project.basedir}/src/test/java</sourceDir>
+							</sourceDirs>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<version>2.8.2</version>
 			</plugin>
 
 			<plugin>

--- a/src/main/kotlin/org/springframework/hateoas/LinkBuilderDsl.kt
+++ b/src/main/kotlin/org/springframework/hateoas/LinkBuilderDsl.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.hateoas
+
+import org.springframework.hateoas.mvc.ControllerLinkBuilder
+import org.springframework.hateoas.mvc.ControllerLinkBuilder.afford
+import org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo
+import org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn
+import kotlin.reflect.KClass
+
+/**
+ * Creates the [Link] with the given [rel].
+ *
+ * @author Roland Kulcsár
+ */
+infix fun ControllerLinkBuilder.withRel(rel: String): Link = withRel(rel)
+
+/**
+ * Create new [Link] with additional [Affordance]s.
+ *
+ * @author Roland Kulcsár
+ */
+inline infix fun Link.andAffordances(setup: AffordancesBuilderDsl.() -> Unit): Link {
+    val builder = AffordancesBuilderDsl()
+    builder.setup()
+
+    return andAffordances(builder.affordances)
+}
+
+/**
+ * Creates a [ControllerLinkBuilder] pointing to [func] method.
+ *
+ * @author Roland Kulcsár
+ */
+inline fun <reified C> linkTo(func: C.() -> Unit): ControllerLinkBuilder = linkTo(methodOn(C::class.java).apply(func))
+
+/**
+ * Extract a [Link] from the [ControllerLinkBuilder] and look up the related [Affordance]. Should
+ * only be one.
+ *
+ * @author Roland Kulcsár
+ */
+inline fun <reified C> afford(func: C.() -> Unit): Affordance = afford(methodOn(C::class.java).apply(func))
+
+/**
+ * Adds the [links] to the [R] resource.
+ *
+ * @author Roland Kulcsár
+ */
+fun <C, R : ResourceSupport> R.add(controller: Class<C>, links: LinkBuilderDsl<C, R>.(R) -> Unit): R {
+    val builder = LinkBuilderDsl(controller, this)
+    builder.links(this)
+
+    return this
+}
+
+/**
+ * Adds the [links] to the [R] resource.
+ *
+ * @author Roland Kulcsár
+ */
+fun <C : Any, R : ResourceSupport> R.add(controller: KClass<C>, links: LinkBuilderDsl<C, R>.(R) -> Unit): R {
+    return add(controller.java, links)
+}
+
+/**
+ * Provides a link builder Kotlin DSL in order to be able to write idiomatic Kotlin code.
+ *
+ * @author Roland Kulcsár
+ */
+open class LinkBuilderDsl<C, R : ResourceSupport>(val controller: Class<C>, val resource: R) {
+
+    /**
+     * Creates a [ControllerLinkBuilder] pointing to [func] method.
+     */
+    fun <R> linkTo(func: C.() -> R): ControllerLinkBuilder = linkTo(methodOn(controller).run(func))
+
+    /**
+     * Adds link with the given [rel] to [resource].
+     */
+    infix fun ControllerLinkBuilder.withRel(rel: String): Link {
+        val link = withRel(rel)
+        resource.add(link)
+
+        return link
+    }
+}
+
+/**
+ * Provides an affordances builder Kotlin DSL in order to be able to write idiomatic Kotlin code.
+ *
+ * @author Roland Kulcsár
+ */
+open class AffordancesBuilderDsl(val affordances: MutableList<Affordance> = mutableListOf()) {
+
+    inline fun <reified C> afford(func: C.() -> Any) {
+        val affordance = afford(methodOn(C::class.java).func())
+        affordances.add(affordance)
+    }
+}

--- a/src/test/kotlin/org/springframework/hateoas/LinkBuilderDslUnitTest.kt
+++ b/src/test/kotlin/org/springframework/hateoas/LinkBuilderDslUnitTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.hateoas
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.springframework.http.HttpMethod
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+
+/**
+ * Unit tests for [LinkBuilderDsl].
+ *
+ * @author Roland Kulcsár
+ */
+class LinkBuilderDslUnitTest : TestUtils() {
+
+    private val REL_PRODUCTS = "products"
+
+    @Test
+    fun `creates link to controller method`() {
+        val self = linkTo<CustomerController> { findById("15") } withRel Link.REL_SELF
+
+        assertPointsToMockServer(self)
+        assertThat(self.rel).isEqualTo(Link.REL_SELF)
+        assertThat(self.href).endsWith("/customers/15")
+    }
+
+    @Test
+    fun `creates affordance to controller method`() {
+        val delete = afford<CustomerController> { delete("15") }
+
+        assertThat(delete.httpMethod).isEqualTo(HttpMethod.DELETE)
+        assertThat(delete.name).isEqualTo("delete")
+    }
+
+    @Test
+    fun `creates link to controller method with affordances`() {
+        val id = "15"
+        val self = linkTo<CustomerController> { findById(id) } withRel Link.REL_SELF
+        val selfWithAffordances = self andAffordances {
+            afford<CustomerController> { update(id, CustomerDto("John Doe")) }
+            afford<CustomerController> { delete(id) }
+        }
+
+        assertThat(selfWithAffordances.affordances).hasSize(3)
+        assertThat(selfWithAffordances.hashCode()).isNotEqualTo(self.hashCode())
+        assertThat(selfWithAffordances).isNotEqualTo(self)
+    }
+
+    @Test
+    fun `adds links to wrapped domain object`() {
+        val customer = Resource(Customer("15", "John Doe"))
+
+        customer.add(CustomerController::class) {
+            linkTo { findById(it.content.id) } withRel Link.REL_SELF
+            linkTo { findProductsById(it.content.id) } withRel REL_PRODUCTS
+        }
+
+        customer.links.forEach { assertPointsToMockServer(it) }
+        assertThat(customer.hasLink(Link.REL_SELF)).isTrue()
+        assertThat(customer.hasLink(REL_PRODUCTS)).isTrue()
+    }
+
+    @Test
+    fun `adds links to resource`() {
+        val customer = CustomerResource("15", "John Doe")
+
+        customer.add(CustomerController::class) {
+            linkTo { findById(it.id) } withRel Link.REL_SELF
+            linkTo { findProductsById(it.id) } withRel REL_PRODUCTS
+        }
+
+        customer.links.forEach { assertPointsToMockServer(it) }
+        assertThat(customer.hasLink(Link.REL_SELF)).isTrue()
+        assertThat(customer.hasLink(REL_PRODUCTS)).isTrue()
+    }
+
+    data class Customer(val id: String, val name: String)
+    data class CustomerDto(val name: String)
+    open class CustomerResource(val id: String, val name: String) : ResourceSupport()
+    open class ProductResource(val id: String) : ResourceSupport()
+
+    @RequestMapping("/customers")
+    interface CustomerController {
+
+        @GetMapping("/{id}")
+        fun findById(@PathVariable id: String): ResponseEntity<CustomerResource>
+
+        @GetMapping("/{id}/products")
+        fun findProductsById(@PathVariable id: String): PagedResources<ProductResource>
+
+        @PutMapping("/{id}")
+        fun update(@PathVariable id: String, @RequestBody customer: CustomerDto): ResponseEntity<CustomerResource>
+
+        @DeleteMapping("/{id}")
+        fun delete(@PathVariable id: String): ResponseEntity<Unit>
+    }
+}


### PR DESCRIPTION
Hi Spring and Kotlin fans,

I want to share with you my link builder extensions to be able to write idiomatic Kotlin code with Spring HATEOAS.

**Updated at Jan 1 2019**

We have the following resources
```
open class CustomerResource(val id: String) : ResourceSupport()
open class ProductResource(val id: String) : ResourceSupport()
```
and controller
```
@RequestMapping("/customers")
interface CustomerController {

    @GetMapping("/{id}")
    fun findById(@PathVariable id: String): CustomerResource

    @GetMapping("/{id}/products")
    fun findProductsById(@PathVariable id: String): List<ProductResource>

    @PutMapping("/{id}")
    fun update(@PathVariable id: String, @RequestBody customer: CustomerDto): ResponseEntity<CustomerResource>

    @DeleteMapping("/{id}")
    fun delete(@PathVariable id: String): ResponseEntity<Unit>
}
```
**Example 1**
With link builder extensions to create a _self_ link you can simply write that
```
val self = linkTo<CustomerController> { findById("15") } withRel "self"
```
Java equivalent
```
Link self = linkTo(methodOn(CustomerController.class).findById("15")).withRel("self");
```
Kotlin equivalent without extensions
```
val self = linkTo(methodOn(CustomerController::class.java).findById("15")).withRel("self")
```
**Example 2**
With link builder extensions to create and add _self_, _products_ links to  _CustomerResource_ you can simply write that
```
val customer = CustomerResource("15")
customer.add(CustomerController::class) {
    linkTo { findById(it.id) } withRel "self"
    linkTo { findProductsById(it.id) } withRel "products"
}
```
Java equivalent
```
CustomerResource customer = new CustomerResource("15");
customer.add(linkTo(methodOn(CustomerController.class).findById("15")).withRel("self"));
customer.add(linkTo(methodOn(CustomerController.class).findProductsById("15")).withRel("products"));
```
Kotlin equivalent without extensions
```
val customer = CustomerResource("15")
customer.add(linkTo(methodOn(CustomerController::class.java).findById("15")).withRel("self"))
customer.add(linkTo(methodOn(CustomerController::class.java).findProductsById("15")).withRel("products"))
```
**Example 3**
To create and add _self_, _products_ links to a wrapped domain object you can simply write that
```
data class Customer(val id: String)

val customer = Resource(Customer("15"))
customer.add(CustomerController::class) {
    linkTo { findById(it.content.id) } withRel "self"
    linkTo { findProductsById(it.content.id) } withRel "products"
}
```
**Example 4**
Creates affordance to a controller method:

```
val delete = afford<CustomerController> { delete("15") }
```

**Example 5**

Creates link with affordances:

```
val selfWithAffordances = linkTo<CustomerController> { findById(id) } withRel "self" andAffordances {
    afford<CustomerController> { update(id, CustomerDto("John Doe")) }
    afford<CustomerController> { delete(id) }
}
```
**Restrictions:**
You have to make _open_ your resource classes (or use the kotlin allopen plugin) because of cglib proxy issues.