### PR TITLE
#713 - Centralize all Forward header handling.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   matrix:
     - PROFILE=non-existant
     - PROFILE=spring5-next
+    - PROFILE=spring51-next
 addons:
   apt:
     packages:

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,20 @@
 		</profile>
 
 		<profile>
+			<id>spring51-next</id>
+			<properties>
+				<spring.version>5.1.0.BUILD-SNAPSHOT</spring.version>
+				<jackson.version>2.9.2</jackson.version>
+			</properties>
+			<repositories>
+				<repository>
+					<id>spring-libs-snapshot</id>
+					<url>http://repo.spring.io/libs-snapshot</url>
+				</repository>
+			</repositories>
+		</profile>
+
+		<profile>
 
 			<!-- Profile to be run on the CI server, JARs JavaDocs -->
 

--- a/src/test/java/org/springframework/hateoas/TestUtils.java
+++ b/src/test/java/org/springframework/hateoas/TestUtils.java
@@ -17,10 +17,18 @@ package org.springframework.hateoas;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+
 import org.junit.Before;
+import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.filter.ForwardedHeaderFilter;
 
 /**
  * Utility class to ease testing.
@@ -41,6 +49,24 @@ public class TestUtils {
 
 	protected void assertPointsToMockServer(Link link) {
 		assertThat(link.getHref()).startsWith("http://localhost");
+	}
+
+	/**
+	 * Provide a mechanism to simulate inserting a {@link ForwardedHeaderFilter} into the servlet
+	 * filter chain, so {@literal Forwarded} headers are properly inserted into the test web request.
+	 *
+	 * @see https://jira.spring.io/browse/SPR-16668
+	 */
+	protected void adaptRequestFromForwardedHeaders() {
+		
+		MockFilterChain chain = new MockFilterChain();
+		try {
+			new ForwardedHeaderFilter().doFilter(this.request, new MockHttpServletResponse(), chain);
+		} catch (ServletException | IOException e) {
+			throw new RuntimeException(e);
+		}
+		HttpServletRequest adaptedRequest = (HttpServletRequest) chain.getRequest();
+		RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(adaptedRequest));
 	}
 
 	public static void assertEqualAndSameHashCode(Object left, Object right) {


### PR DESCRIPTION
Spring 5.1 is centralizing all Forward header handling. This moves critical bits into one location, making it easy to completely remove once we rebaseline against this version.

Also adds a test profile to ensure Spring 5.1 doesn't break anything.