### PR TITLE
559: fix multiple encodings of params

### DIFF
--- a/src/main/java/org/springframework/hateoas/Link.java
+++ b/src/main/java/org/springframework/hateoas/Link.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 import lombok.experimental.Wither;
 
 import java.io.Serializable;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -131,7 +132,7 @@ public class Link implements Serializable {
 
 	/**
 	 * Returns safe copy of {@link Affordance}s.
-	 * 
+	 *
 	 * @return
 	 */
 	public List<Affordance> getAffordances() {
@@ -166,7 +167,7 @@ public class Link implements Serializable {
 
 	/**
 	 * Create new {@link Link} with additional {@link Affordance}s.
-	 * 
+	 *
 	 * @param affordances must not be {@literal null}.
 	 * @return
 	 */
@@ -181,7 +182,7 @@ public class Link implements Serializable {
 
 	/**
 	 * Creats a new {@link Link} with the given {@link Affordance}s.
-	 * 
+	 *
 	 * @param affordances must not be {@literal null}.
 	 * @return
 	 */
@@ -227,7 +228,12 @@ public class Link implements Serializable {
 	 * @return
 	 */
 	public Link expand(Object... arguments) {
-		return new Link(getUriTemplate().expand(arguments).toString(), getRel());
+
+		URI uri = (arguments == null || arguments.length == 0) ?
+				getUriTemplate().checkParams(arguments) :
+				getUriTemplate().expand(arguments);
+
+		return new Link(uri.toString(), getRel());
 	}
 
 	/**
@@ -242,7 +248,7 @@ public class Link implements Serializable {
 
 	/**
 	 * Returns whether the current {@link Link} has the given link relation.
-	 * 
+	 *
 	 * @param rel must not be {@literal null} or empty.
 	 * @return
 	 */

--- a/src/main/java/org/springframework/hateoas/Link.java
+++ b/src/main/java/org/springframework/hateoas/Link.java
@@ -230,7 +230,7 @@ public class Link implements Serializable {
 	public Link expand(Object... arguments) {
 
 		URI uri = (arguments == null || arguments.length == 0) ?
-				getUriTemplate().checkParams(arguments) :
+				getUriTemplate().checkRequiredParams() :
 				getUriTemplate().expand(arguments);
 
 		return new Link(uri.toString(), getRel());

--- a/src/main/java/org/springframework/hateoas/UriTemplate.java
+++ b/src/main/java/org/springframework/hateoas/UriTemplate.java
@@ -204,22 +204,16 @@ public class UriTemplate implements Iterable<TemplateVariable>, Serializable {
 	}
 
 	/**
-	 * Expands the {@link UriTemplate} using the given parameters. The values will be applied in the order of the
-	 * variables discovered.
+	 * Checks the {@link UriTemplate} for unset but required params.
 	 *
-	 * @param parameters
 	 * @return
-	 * @see #expand(Map)
 	 */
-	public URI checkParams(Object... parameters) {
-		org.springframework.web.util.UriTemplate baseTemplate = new org.springframework.web.util.UriTemplate(baseUri);
-		UriComponentsBuilder builder = UriComponentsBuilder.fromUri(baseTemplate.expand(parameters));
-		Iterator<Object> iterator = Arrays.asList(parameters).iterator();
-
+	public URI checkRequiredParams() {
 		for (TemplateVariable variable : getOptionalVariables()) {
-
-			Object value = iterator.hasNext() ? iterator.next() : null;
-			appendToBuilder(builder, variable, value);
+			if (variable.isRequired()) {
+				throw new IllegalArgumentException(
+					String.format("Template variable %s is required but no value was given!", variable.getName()));
+			}
 		}
 
 		return URI.create(baseUri);

--- a/src/main/java/org/springframework/hateoas/UriTemplate.java
+++ b/src/main/java/org/springframework/hateoas/UriTemplate.java
@@ -204,6 +204,28 @@ public class UriTemplate implements Iterable<TemplateVariable>, Serializable {
 	}
 
 	/**
+	 * Expands the {@link UriTemplate} using the given parameters. The values will be applied in the order of the
+	 * variables discovered.
+	 *
+	 * @param parameters
+	 * @return
+	 * @see #expand(Map)
+	 */
+	public URI checkParams(Object... parameters) {
+		org.springframework.web.util.UriTemplate baseTemplate = new org.springframework.web.util.UriTemplate(baseUri);
+		UriComponentsBuilder builder = UriComponentsBuilder.fromUri(baseTemplate.expand(parameters));
+		Iterator<Object> iterator = Arrays.asList(parameters).iterator();
+
+		for (TemplateVariable variable : getOptionalVariables()) {
+
+			Object value = iterator.hasNext() ? iterator.next() : null;
+			appendToBuilder(builder, variable, value);
+		}
+
+		return URI.create(baseUri);
+	}
+
+	/**
 	 * Expands the {@link UriTemplate} using the given parameters.
 	 * 
 	 * @param parameters must not be {@literal null}.

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
@@ -231,6 +231,42 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		assertThat(queryParams.get("offset"), contains("10"));
 	}
 
+	@Test
+	public void linksToMethodWithPathVariableAndRequestParamsWithNull() {
+
+		Link link = linkTo(methodOn(ControllerWithMethods.class).methodForNextPage("1", null, 5)).withSelfRel();
+
+		UriComponents components = toComponents(link);
+		assertThat(components.getPath()).isEqualTo("/something/1/foo");
+
+		MultiValueMap<String, String> queryParams = components.getQueryParams();
+		assertThat(queryParams.get("limit"), contains("5"));
+	}
+
+	@Test
+	public void linksToMethodWithPathVariableWithBlankAndRequestParamsWithNull() {
+
+		Link link = linkTo(methodOn(ControllerWithMethods.class).methodForNextPage("with blank", null, 5)).withSelfRel();
+
+		UriComponents components = toComponents(link);
+		assertThat(components.getPath()).isEqualTo("/something/with%20blank/foo");
+
+		MultiValueMap<String, String> queryParams = components.getQueryParams();
+		assertThat(queryParams.get("limit"), contains("5"));
+	}
+
+	@Test
+	public void linksToMethodWithRequestParam() {
+
+		Link link = linkTo(methodOn(ControllerWithMethods.class).methodForNextPage("with blank", null, 5)).withSelfRel();
+
+		UriComponents components = toComponents(link);
+		assertThat(components.getPath()).isEqualTo("/something/with%20blank/foo");
+
+		MultiValueMap<String, String> queryParams = components.getQueryParams();
+		assertThat(queryParams.get("limit"), contains("5"));
+	}
+
 	/**
 	 * @see #26, #39
 	 */
@@ -384,27 +420,6 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		assertThat(link.getHref()).endsWith("/something/with%20blank/foo");
 	}
 
-	@Test
-	public void uriComponentsToMethodWithPathVariableContainingBlankAnsOptionalQueryParams() {
-
-		Link link = linkTo(methodOn(ControllerWithMethods.class).methodForNextPage("with blank", 0, 10)).withSelfRel();
-
-		UriComponents components = toComponents(link);
-		assertThat(components.toUriString(), containsString("/something/with%20blank/foo"));
-		assertThat(components.toUriString(), containsString("offset=0"));
-		assertThat(components.toUriString(), containsString("limit=10"));
-	}
-
-	@Test
-	public void uriComponentsToMethodWithPathVariableContainingBlankAnsOptionalQueryParamNull() {
-
-		Link link = linkTo(methodOn(ControllerWithMethods.class).methodForNextPage("with blank", null, 10)).withSelfRel();
-
-		UriComponents components = toComponents(link);
-		assertThat(components.toUriString(), containsString("/something/with%20blank/foo"));
-		assertThat(components.toUriString(), containsString("limit=10"));
-	}
-
 	/**
 	 * @see #192
 	 */
@@ -493,6 +508,15 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 
 		assertThat(link.getRel()).isEqualTo(Link.REL_SELF);
 		assertThat(link.getHref()).endsWith("/something/foo?id=Spring%23%0A");
+	}
+
+	@Test
+	public void encodesAndExpandsPathvariableWithSpecialValueAndRequestParameterWithNull() {
+
+		Link link = linkTo(methodOn(ControllerWithMethods.class).methodForNextPage("Spring#\n", null, 10)).withSelfRel().expand();
+
+		assertThat(link.getRel()).isEqualTo(Link.REL_SELF);
+		assertThat(link.getHref()).endsWith("/something/Spring%23%0A/foo?limit=10");
 	}
 
 	/**
@@ -609,18 +633,6 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 
 		Link link = linkTo(methodOn(ControllerWithMethods.class).methodWithAlternatePathVariable("bar")).withSelfRel();
 		assertThat(link.getHref()).isEqualTo("http://localhost/something/bar/foo");
-	}
-
-	@Test
-	public void uriComponentsToMethodWithPathVariableAndRequestParamsContainingNull()
-	{
-		Link link = linkTo(methodOn(ControllerWithMethods.class).methodForNextPage("1", null, 10)).withSelfRel();
-
-		UriComponents components = toComponents(link);
-		assertThat(components.getPath(), is(equalTo("/something/1/foo")));
-
-		MultiValueMap<String, String> queryParams = components.getQueryParams();
-		assertThat(queryParams.get("limit"), contains("10"));
 	}
 
 	private static UriComponents toComponents(Link link) {

--- a/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mvc/ControllerLinkBuilderUnitTest.java
@@ -384,6 +384,27 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		assertThat(link.getHref()).endsWith("/something/with%20blank/foo");
 	}
 
+	@Test
+	public void uriComponentsToMethodWithPathVariableContainingBlankAnsOptionalQueryParams() {
+
+		Link link = linkTo(methodOn(ControllerWithMethods.class).methodForNextPage("with blank", 0, 10)).withSelfRel();
+
+		UriComponents components = toComponents(link);
+		assertThat(components.toUriString(), containsString("/something/with%20blank/foo"));
+		assertThat(components.toUriString(), containsString("offset=0"));
+		assertThat(components.toUriString(), containsString("limit=10"));
+	}
+
+	@Test
+	public void uriComponentsToMethodWithPathVariableContainingBlankAnsOptionalQueryParamNull() {
+
+		Link link = linkTo(methodOn(ControllerWithMethods.class).methodForNextPage("with blank", null, 10)).withSelfRel();
+
+		UriComponents components = toComponents(link);
+		assertThat(components.toUriString(), containsString("/something/with%20blank/foo"));
+		assertThat(components.toUriString(), containsString("limit=10"));
+	}
+
 	/**
 	 * @see #192
 	 */
@@ -588,6 +609,18 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 
 		Link link = linkTo(methodOn(ControllerWithMethods.class).methodWithAlternatePathVariable("bar")).withSelfRel();
 		assertThat(link.getHref()).isEqualTo("http://localhost/something/bar/foo");
+	}
+
+	@Test
+	public void uriComponentsToMethodWithPathVariableAndRequestParamsContainingNull()
+	{
+		Link link = linkTo(methodOn(ControllerWithMethods.class).methodForNextPage("1", null, 10)).withSelfRel();
+
+		UriComponents components = toComponents(link);
+		assertThat(components.getPath(), is(equalTo("/something/1/foo")));
+
+		MultiValueMap<String, String> queryParams = components.getQueryParams();
+		assertThat(queryParams.get("limit"), contains("10"));
 	}
 
 	private static UriComponents toComponents(Link link) {


### PR DESCRIPTION
In order to #559 I got multiple encodings using the ControllerLinkBuilder. I added corresponding tests and fixed the issue. The ControllerLinkBuilder#bindRequestParameters method already encodes the params in the template url. Any further expand of the url will encode the % sign in %25. So no additional encoding should be done.
The Link#expand method is not only used to expand parameters in the template but also to check for missing required parameters.
I added another checkParams method to the UriTemplate class to only check the params but not encoding them.