### PR TITLE
URL Cleanup

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.hateoas</groupId>
@@ -7,7 +7,7 @@
 	<version>1.0.0.BUILD-SNAPSHOT</version>
 
 	<name>Spring HATEOAS</name>
-	<url>http://github.com/SpringSource/spring-hateoas</url>
+	<url>https://github.com/SpringSource/spring-hateoas</url>
 	<description>
 		Library to support implementing representations for
 		hyper-text driven REST web services.
@@ -17,7 +17,7 @@
 
 	<organization>
 		<name>Pivotal, Inc.</name>
-		<url>http://www.spring.io</url>
+		<url>https://www.spring.io</url>
 	</organization>
 
 	<developers>
@@ -46,7 +46,7 @@
 	<licenses>
 		<license>
 			<name>Apache License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0</url>
+			<url>https://www.apache.org/licenses/LICENSE-2.0</url>
 			<comments>
 			Copyright 2011-2018 the original author or authors.
 
@@ -54,7 +54,7 @@
 			you may not use this file except in compliance with the License.
 			You may obtain a copy of the License at
 
-			     http://www.apache.org/licenses/LICENSE-2.0
+			     https://www.apache.org/licenses/LICENSE-2.0
 
 			Unless required by applicable law or agreed to in writing, software
 			distributed under the License is distributed on an "AS IS" BASIS,
@@ -675,8 +675,8 @@
 					<additionalparam>-Xdoclint:none</additionalparam>
 					<stylesheetfile>${basedir}/src/main/javadoc/spring-javadoc.css</stylesheetfile>
 					<links>
-						<link>http://static.springframework.org/spring/docs/4.1.x/javadoc-api</link>
-						<link>http://docs.oracle.com/javase/6/docs/api</link>
+						<link>https://docs.spring.io/spring/docs/4.1.x/javadoc-api</link>
+						<link>https://docs.oracle.com/javase/6/docs/api</link>
 					</links>
 				</configuration>
 				<executions>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 with 4 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://static.springframework.org/spring/docs/4.1.x/javadoc-api (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/4.1.x/javadoc-api ([https](https://static.springframework.org/spring/docs/4.1.x/javadoc-api) result 301).
* http://github.com/SpringSource/spring-hateoas with 1 occurrences migrated to:  
  https://github.com/SpringSource/spring-hateoas ([https](https://github.com/SpringSource/spring-hateoas) result 301).
* http://www.spring.io with 1 occurrences migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).
* http://docs.oracle.com/javase/6/docs/api with 1 occurrences migrated to:  
  https://docs.oracle.com/javase/6/docs/api ([https](https://docs.oracle.com/javase/6/docs/api) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences