### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -24,4 +24,4 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
 Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
 
-This Code of Conduct is adapted from the http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].
+This Code of Conduct is adapted from the https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].

--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@ image:https://badges.gitter.im/spring-projects/spring-hateoas.png[link=https://g
 
 = Spring HATEOAS
 
-This project provides some APIs to ease creating REST representations that follow the http://en.wikipedia.org/wiki/HATEOAS[HATEOAS] principle when working with Spring and especially Spring MVC. The core problem it tries to address is link creation and representation assembly.
+This project provides some APIs to ease creating REST representations that follow the https://en.wikipedia.org/wiki/HATEOAS[HATEOAS] principle when working with Spring and especially Spring MVC. The core problem it tries to address is link creation and representation assembly.
 
 == Project Status
 
@@ -75,6 +75,6 @@ git config core.commentchar "/"
 
 == Resources
 
-* Reference documentation - http://docs.spring.io/spring-hateoas/docs/current/reference/html/[html], http://docs.spring.io/spring-hateoas/docs/current/reference/pdf/spring-hateoas-reference.pdf[pdf]
+* Reference documentation - https://docs.spring.io/spring-hateoas/docs/current/reference/html/[html], https://docs.spring.io/spring-hateoas/docs/current/reference/pdf/spring-hateoas-reference.pdf[pdf]
 * https://docs.spring.io/spring-hateoas/docs/current-SNAPSHOT/[JavaDoc]
 * https://spring.io/guides/gs/rest-hateoas/[Getting started guide]

--- a/src/docs/resources/org/springframework/hateoas/docs/mediatype/collectionjson/spec-part1.json
+++ b/src/docs/resources/org/springframework/hateoas/docs/mediatype/collectionjson/spec-part1.json
@@ -1,6 +1,6 @@
 {
   "collection": {
     "version": "1.0",
-    "href": "http://example.org/friends/"
+    "href": "https://example.org/friends/"
   }
 }

--- a/src/docs/resources/org/springframework/hateoas/docs/mediatype/collectionjson/spec-part2.json
+++ b/src/docs/resources/org/springframework/hateoas/docs/mediatype/collectionjson/spec-part2.json
@@ -1,16 +1,16 @@
 {
   "collection": {
     "version": "1.0",
-    "href": "http://example.org/friends/",
+    "href": "https://example.org/friends/",
     "links": [
       {
         "rel": "feed",
-        "href": "http://example.org/friends/rss"
+        "href": "https://example.org/friends/rss"
       }
     ],
     "items": [
       {
-        "href": "http://example.org/friends/jdoe",
+        "href": "https://example.org/friends/jdoe",
         "data": [
           {
             "name": "fullname",
@@ -26,19 +26,19 @@
         "links": [
           {
             "rel": "blog",
-            "href": "http://examples.org/blogs/jdoe",
+            "href": "https://examples.org/blogs/jdoe",
             "prompt": "Blog"
           },
           {
             "rel": "avatar",
-            "href": "http://examples.org/images/jdoe",
+            "href": "https://examples.org/images/jdoe",
             "prompt": "Avatar",
             "render": "image"
           }
         ]
       },
       {
-        "href": "http://example.org/friends/msmith",
+        "href": "https://example.org/friends/msmith",
         "data": [
           {
             "name": "fullname",
@@ -54,19 +54,19 @@
         "links": [
           {
             "rel": "blog",
-            "href": "http://examples.org/blogs/msmith",
+            "href": "https://examples.org/blogs/msmith",
             "prompt": "Blog"
           },
           {
             "rel": "avatar",
-            "href": "http://examples.org/images/msmith",
+            "href": "https://examples.org/images/msmith",
             "prompt": "Avatar",
             "render": "image"
           }
         ]
       },
       {
-        "href": "http://example.org/friends/rwilliams",
+        "href": "https://example.org/friends/rwilliams",
         "data": [
           {
             "name": "fullname",
@@ -82,12 +82,12 @@
         "links": [
           {
             "rel": "blog",
-            "href": "http://examples.org/blogs/rwilliams",
+            "href": "https://examples.org/blogs/rwilliams",
             "prompt": "Blog"
           },
           {
             "rel": "avatar",
-            "href": "http://examples.org/images/rwilliams",
+            "href": "https://examples.org/images/rwilliams",
             "prompt": "Avatar",
             "render": "image"
           }
@@ -97,7 +97,7 @@
     "queries": [
       {
         "rel": "search",
-        "href": "http://example.org/friends/search",
+        "href": "https://example.org/friends/search",
         "prompt": "Search",
         "data": [
           {

--- a/src/docs/resources/org/springframework/hateoas/docs/mediatype/collectionjson/spec-part3.json
+++ b/src/docs/resources/org/springframework/hateoas/docs/mediatype/collectionjson/spec-part3.json
@@ -1,24 +1,24 @@
 {
   "collection": {
     "version": "1.0",
-    "href": "http://example.org/friends/", // <1>
+    "href": "https://example.org/friends/", // <1>
     "links": [   // <2>
       {
         "rel": "feed",
-        "href": "http://example.org/friends/rss"
+        "href": "https://example.org/friends/rss"
       },
       {
         "rel": "queries",
-        "href": "http://example.org/friends/?queries"
+        "href": "https://example.org/friends/?queries"
       },
       {
         "rel": "template",
-        "href": "http://example.org/friends/?template"
+        "href": "https://example.org/friends/?template"
       }
     ],
     "items": [  // <3>
       {
-        "href": "http://example.org/friends/jdoe",
+        "href": "https://example.org/friends/jdoe",
         "data": [  // <4>
           {
             "name": "fullname",
@@ -34,12 +34,12 @@
         "links": [ // <5>
           {
             "rel": "blog",
-            "href": "http://examples.org/blogs/jdoe",
+            "href": "https://examples.org/blogs/jdoe",
             "prompt": "Blog"
           },
           {
             "rel": "avatar",
-            "href": "http://examples.org/images/jdoe",
+            "href": "https://examples.org/images/jdoe",
             "prompt": "Avatar",
             "render": "image"
           }

--- a/src/docs/resources/org/springframework/hateoas/docs/mediatype/collectionjson/spec-part4.json
+++ b/src/docs/resources/org/springframework/hateoas/docs/mediatype/collectionjson/spec-part4.json
@@ -1,11 +1,11 @@
 {
   "collection": {
     "version": "1.0",
-    "href": "http://example.org/friends/",
+    "href": "https://example.org/friends/",
     "queries": [
       {
         "rel": "search",
-        "href": "http://example.org/friends/search",
+        "href": "https://example.org/friends/search",
         "prompt": "Search",
         "data": [
           {

--- a/src/docs/resources/org/springframework/hateoas/docs/mediatype/collectionjson/spec-part5.json
+++ b/src/docs/resources/org/springframework/hateoas/docs/mediatype/collectionjson/spec-part5.json
@@ -1,7 +1,7 @@
 {
   "collection": {
     "version": "1.0",
-    "href": "http://example.org/friends/",
+    "href": "https://example.org/friends/",
     "template": {
       "data": [
         {

--- a/src/docs/resources/org/springframework/hateoas/docs/mediatype/collectionjson/spec-part6.json
+++ b/src/docs/resources/org/springframework/hateoas/docs/mediatype/collectionjson/spec-part6.json
@@ -1,7 +1,7 @@
 {
   "collection": {
     "version": "1.0",
-    "href": "http://example.org/friends/",
+    "href": "https://example.org/friends/",
     "error": {
       "title": "Server Error",
       "code": "X1C2",

--- a/src/docs/resources/org/springframework/hateoas/docs/mediatype/collectionjson/spec-part7.json
+++ b/src/docs/resources/org/springframework/hateoas/docs/mediatype/collectionjson/spec-part7.json
@@ -11,11 +11,11 @@
       },
       {
         "name": "blog",
-        "value": "http://example.org/blogs/wchandry"
+        "value": "https://example.org/blogs/wchandry"
       },
       {
         "name": "avatar",
-        "value": "http://example.org/images/wchandry"
+        "value": "https://example.org/images/wchandry"
       }
     ]
   }

--- a/src/docs/resources/org/springframework/hateoas/docs/mediatype/hal/hal-multiple-entry-link-relation.json
+++ b/src/docs/resources/org/springframework/hateoas/docs/mediatype/hal/hal-multiple-entry-link-relation.json
@@ -1,8 +1,8 @@
 {
   "_links": {
     "item": [
-      { "href": "http://myhost/cart/42" },
-      { "href": "http://myhost/inventory/12" }
+      { "href": "https://myhost/cart/42" },
+      { "href": "https://myhost/inventory/12" }
     ]
   },
   "customer": "Dave Matthews"

--- a/src/docs/resources/org/springframework/hateoas/docs/mediatype/hal/hal-single-entry-link-relation-array.json
+++ b/src/docs/resources/org/springframework/hateoas/docs/mediatype/hal/hal-single-entry-link-relation-array.json
@@ -1,6 +1,6 @@
 {
   "_links": {
-    "item": [{ "href": "http://myhost/inventory/12" }]
+    "item": [{ "href": "https://myhost/inventory/12" }]
   },
   "customer": "Dave Matthews"
 }

--- a/src/docs/resources/org/springframework/hateoas/docs/mediatype/hal/hal-single-entry-link-relation-object.json
+++ b/src/docs/resources/org/springframework/hateoas/docs/mediatype/hal/hal-single-entry-link-relation-object.json
@@ -1,6 +1,6 @@
 {
   "_links": {
-    "item": { "href": "http://myhost/inventory/12" }
+    "item": { "href": "https://myhost/inventory/12" }
   },
   "customer": "Dave Matthews"
 }

--- a/src/docs/resources/org/springframework/hateoas/docs/mediatype/hal/hal-with-curies.json
+++ b/src/docs/resources/org/springframework/hateoas/docs/mediatype/hal/hal-with-curies.json
@@ -1,15 +1,15 @@
 {
   "_links": {
     "self": {
-      "href": "http://myhost/person/1"
+      "href": "https://myhost/person/1"
     },
     "curies": {
       "name": "ex",
-      "href": "http://example.com/rels/{rel}",
+      "href": "https://example.com/rels/{rel}",
       "templated": true
     },
     "ex:orders": {
-      "href": "http://myhost/person/1/orders"
+      "href": "https://myhost/person/1/orders"
     }
   },
   "firstname": "Dave",

--- a/src/main/asciidoc/fundamentals.adoc
+++ b/src/main/asciidoc/fundamentals.adoc
@@ -145,7 +145,7 @@ The model type can now be used like this:
 PersonModel model = new PersonModel();
 model.firstname = "Dave";
 model.lastname = "Matthews";
-model.add(new Link("http://myhost/people/42"));
+model.add(new Link("https://myhost/people/42"));
 ----
 ====
 
@@ -158,7 +158,7 @@ If you returned such an instance from a Spring MVC or WebFlux controller and the
 {
   "_links" : {
     "self" : {
-      "href" : "http://myhost/people/42"
+      "href" : "https://myhost/people/42"
     }
   },
   "firstname" : "Dave",

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -5,7 +5,7 @@ Oliver Gierke; Greg Turnquist; Jay Bryant
 :toc: left
 :hide-uri-scheme:
 
-This project provides some APIs to ease creating REST representations that follow the http://en.wikipedia.org/wiki/HATEOAS[HATEOAS] principle when working with Spring and especially Spring MVC. The core problem it tries to address is link creation and representation assembly.
+This project provides some APIs to ease creating REST representations that follow the https://en.wikipedia.org/wiki/HATEOAS[HATEOAS] principle when working with Spring and especially Spring MVC. The core problem it tries to address is link creation and representation assembly.
 
 (C) 2012-2019 The original authors.
 
@@ -27,7 +27,7 @@ This section describes how to configure Spring HATEOAS.
 [[configuration.at-enable]]
 === Using `@EnableHypermediaSupport`
 
-To let the `RepresentationModel` subtypes be rendered according to the specification of various hypermedia representations types, you can activate support for a particular hypermedia representation format through `@EnableHypermediaSupport`. The annotation takes a `HypermediaType` enumeration as its argument. Currently, we support http://tools.ietf.org/html/draft-kelly-json-hal[HAL] as well as a default rendering. Using the annotation triggers the following:
+To let the `RepresentationModel` subtypes be rendered according to the specification of various hypermedia representations types, you can activate support for a particular hypermedia representation format through `@EnableHypermediaSupport`. The annotation takes a `HypermediaType` enumeration as its argument. Currently, we support https://tools.ietf.org/html/draft-kelly-json-hal[HAL] as well as a default rendering. Using the annotation triggers the following:
 
 * It registers necessary Jackson modules to render `EntityModel` and `CollectionModel` in the hypermedia specific format.
 * If JSONPath is on the classpath, it automatically registers a `LinkDiscoverer` instance to look up links by their `rel` in plain JSON representations (see <<client.link-discoverer>>).

--- a/src/main/asciidoc/mediatypes.adoc
+++ b/src/main/asciidoc/mediatypes.adoc
@@ -95,7 +95,7 @@ extensively to avoid surprises.
 [[mediatypes.hal.curie-provider]]
 === [[spis.curie-provider]] Using the `CurieProvider` API
 
-The http://tools.ietf.org/html/rfc5988=section-4[Web Linking RFC] describes registered and extension link relation types. Registered rels are well-known strings registered with the http://www.iana.org/assignments/link-relations/link-relations.xhtml[IANA registry of link relation types]. Extension `rel` URIs can be used by applications that do not wish to register a relation type. Each one is a URI that uniquely identifies the relation type. The `rel` URI can be serialized as a compact URI or http://www.w3.org/TR/curie[Curie]. For example, a curie of `ex:persons` stands for the link relation type `http://example.com/rels/persons` if `ex` is defined as `http://example.com/rels/{rel}`. If curies are used, the base URI must be present in the response scope.
+The https://tools.ietf.org/html/rfc5988=section-4[Web Linking RFC] describes registered and extension link relation types. Registered rels are well-known strings registered with the https://www.iana.org/assignments/link-relations/link-relations.xhtml[IANA registry of link relation types]. Extension `rel` URIs can be used by applications that do not wish to register a relation type. Each one is a URI that uniquely identifies the relation type. The `rel` URI can be serialized as a compact URI or https://www.w3.org/TR/curie[Curie]. For example, a curie of `ex:persons` stands for the link relation type `https://example.com/rels/persons` if `ex` is defined as `https://example.com/rels/{rel}`. If curies are used, the base URI must be present in the response scope.
 
 The `rel` values created by the default `RelProvider` are extension relation types and, as a result, must be URIs, which can cause a lot of overhead. The `CurieProvider` API takes care of that: It lets you define a base URI as a URI template and a prefix that stands for that base URI. If a `CurieProvider` is present, the `RelProvider` prepends all `rel` values with the curie prefix. Furthermore a `curies` link is automatically added to the HAL resource.
 
@@ -111,7 +111,7 @@ public class Config {
 
   @Bean
   public CurieProvider curieProvider() {
-    return new DefaultCurieProvider("ex", new UriTemplate("http://www.example.com/rels/{rel}"));
+    return new DefaultCurieProvider("ex", new UriTemplate("https://www.example.com/rels/{rel}"));
   }
 }
 ----
@@ -230,7 +230,7 @@ Spring HATEOAS more specifically will:
 [[mediatypes.uber]]
 == UBER - Uniform Basis for Exchanging Representations
 
-http://uberhypermedia.org/[UBER, window="_blank"] is an experimental JSON spec
+https://rawgit.com/uber-hypermedia/specification/master/uber-hypermedia.html[UBER, window="_blank"] is an experimental JSON spec
 
 [quote, Mike Amundsen, UBER spec]
 ____

--- a/src/main/java/org/springframework/hateoas/IanaLinkRelations.java
+++ b/src/main/java/org/springframework/hateoas/IanaLinkRelations.java
@@ -48,28 +48,28 @@ public class IanaLinkRelations {
 	/**
 	 * Refers to a substitute for this context
 	 *
-	 * @see {@link http://www.w3.org/TR/html5/links.html#link-type-alternate}
+	 * @see {@link https://www.w3.org/TR/html5/links.html#link-type-alternate}
 	 */
 	public static final LinkRelation ALTERNATE = LinkRelation.of("alternate");
 
 	/**
 	 * Refers to an appendix.
 	 *
-	 * @see {@link http://www.w3.org/TR/1999/REC-html401-19991224}
+	 * @see {@link https://www.w3.org/TR/1999/REC-html401-19991224}
 	 */
 	public static final LinkRelation APPENDIX = LinkRelation.of("appendix");
 
 	/**
 	 * Refers to a collection of records, documents, or other materials of historical interest.
 	 *
-	 * @see {@link http://www.w3.org/TR/2011/WD-html5-20110113/links.html#rel-archives}
+	 * @see {@link https://www.w3.org/TR/2011/WD-html5-20110113/links.html#rel-archives}
 	 */
 	public static final LinkRelation ARCHIVES = LinkRelation.of("archives");
 
 	/**
 	 * Refers to the context's author.
 	 *
-	 * @see {@link http://www.w3.org/TR/html5/links.html#link-type-author}
+	 * @see {@link https://www.w3.org/TR/html5/links.html#link-type-author}
 	 */
 	public static final LinkRelation AUTHOR = LinkRelation.of("author");
 
@@ -83,7 +83,7 @@ public class IanaLinkRelations {
 	/**
 	 * Gives a permanent link to use for bookmarking purposes.
 	 *
-	 * @see {@link http://www.w3.org/TR/html5/links.html#link-type-bookmark}
+	 * @see {@link https://www.w3.org/TR/html5/links.html#link-type-bookmark}
 	 */
 	public static final LinkRelation BOOKMARK = LinkRelation.of("bookmark");
 
@@ -97,7 +97,7 @@ public class IanaLinkRelations {
 	/**
 	 * Refers to a chapter in a collection of resources.
 	 *
-	 * @see {@link http://www.w3.org/TR/1999/REC-html401-19991224}
+	 * @see {@link https://www.w3.org/TR/1999/REC-html401-19991224}
 	 */
 	public static final LinkRelation CHAPTER = LinkRelation.of("chapter");
 
@@ -118,7 +118,7 @@ public class IanaLinkRelations {
 	/**
 	 * Refers to a table of contents.
 	 *
-	 * @see {@link http://www.w3.org/TR/1999/REC-html401-19991224}
+	 * @see {@link https://www.w3.org/TR/1999/REC-html401-19991224}
 	 */
 	public static final LinkRelation CONTENTS = LinkRelation.of("contents");
 
@@ -134,7 +134,7 @@ public class IanaLinkRelations {
 	/**
 	 * Refers to a copyright statement that applies to the link's context.
 	 *
-	 * @see {@link http://www.w3.org/TR/1999/REC-html401-19991224}
+	 * @see {@link https://www.w3.org/TR/1999/REC-html401-19991224}
 	 */
 	public static final LinkRelation COPYRIGHT = LinkRelation.of("copyright");
 
@@ -155,7 +155,7 @@ public class IanaLinkRelations {
 	/**
 	 * Refers to a resource providing information about the link's context.
 	 *
-	 * @see {@link http://www.w3.org/TR/powder-dr/#assoc-linking}
+	 * @see {@link https://www.w3.org/TR/powder-dr/#assoc-linking}
 	 */
 	public static final LinkRelation DESCRIBED_BY = LinkRelation.of("describedBy");
 
@@ -229,14 +229,14 @@ public class IanaLinkRelations {
 	/**
 	 * Refers to a glossary of terms.
 	 *
-	 * @see {@link http://www.w3.org/TR/1999/REC-html401-19991224}
+	 * @see {@link https://www.w3.org/TR/1999/REC-html401-19991224}
 	 */
 	public static final LinkRelation GLOSSARY = LinkRelation.of("glossary");
 
 	/**
 	 * Refers to context-sensitive help.
 	 *
-	 * @see {@link http://www.w3.org/TR/html5/links.html#link-type-help}
+	 * @see {@link https://www.w3.org/TR/html5/links.html#link-type-help}
 	 */
 	public static final LinkRelation HELP = LinkRelation.of("help");
 
@@ -250,21 +250,21 @@ public class IanaLinkRelations {
 	/**
 	 * Refers to a hub that enables registration for notification of updates to the context.
 	 *
-	 * @see {@link http://pubsubhubbub.googlecode.com}
+	 * @see {@link https://pubsubhubbub.googlecode.com}
 	 */
 	public static final LinkRelation HUB = LinkRelation.of("hub");
 
 	/**
 	 * Refers to an icon representing the link's context.
 	 *
-	 * @see {@link http://www.w3.org/TR/html5/links.html#link-type-icon}
+	 * @see {@link https://www.w3.org/TR/html5/links.html#link-type-icon}
 	 */
 	public static final LinkRelation ICON = LinkRelation.of("icon");
 
 	/**
 	 * Refers to an index.
 	 *
-	 * @see {@link http://www.w3.org/TR/1999/REC-html401-19991224}
+	 * @see {@link https://www.w3.org/TR/1999/REC-html401-19991224}
 	 */
 	public static final LinkRelation INDEX = LinkRelation.of("index");
 
@@ -459,7 +459,7 @@ public class IanaLinkRelations {
 	/**
 	 * Indicates that the link's context is a part of a series, and that the next in the series is the link target.
 	 *
-	 * @see {@link http://www.w3.org/TR/html5/links.html#link-type-next}
+	 * @see {@link https://www.w3.org/TR/html5/links.html#link-type-next}
 	 */
 	public static final LinkRelation NEXT = LinkRelation.of("next");
 
@@ -473,14 +473,14 @@ public class IanaLinkRelations {
 	/**
 	 * Indicates that the context‚Äôs original author or publisher does not endorse the link target.
 	 *
-	 * @see {@link http://www.w3.org/TR/html5/links.html#link-type-nofollow}
+	 * @see {@link https://www.w3.org/TR/html5/links.html#link-type-nofollow}
 	 */
 	public static final LinkRelation NOFOLLOW = LinkRelation.of("nofollow");
 
 	/**
 	 * Indicates that no referrer information is to be leaked when following the link.
 	 *
-	 * @see {@link http://www.w3.org/TR/html5/links.html#link-type-noreferrer}
+	 * @see {@link https://www.w3.org/TR/html5/links.html#link-type-noreferrer}
 	 */
 	public static final LinkRelation NOREFERRER = LinkRelation.of("noreferrer");
 
@@ -501,7 +501,7 @@ public class IanaLinkRelations {
 	/**
 	 * Gives the address of the pingback resource for the link context.
 	 *
-	 * @see {@link http://www.hixie.ch/specs/pingback/pingback}
+	 * @see {@link https://www.hixie.ch/specs/pingback/pingback}
 	 */
 	public static final LinkRelation PINGBACK = LinkRelation.of("pingback");
 
@@ -526,7 +526,7 @@ public class IanaLinkRelations {
 	 * the link context, and that the user agent ought to fetch, such that the user agent can deliver a faster response
 	 * once the resource is requested in the future.
 	 *
-	 * @see {@link http://www.w3.org/TR/resource-hints/}
+	 * @see {@link https://www.w3.org/TR/resource-hints/}
 	 */
 	public static final LinkRelation PREFETCH = LinkRelation.of("prefetch");
 
@@ -534,7 +534,7 @@ public class IanaLinkRelations {
 	 * Refers to a resource that should be loaded early in the processing of the link's context, without blocking
 	 * rendering.
 	 *
-	 * @see {@link http://www.w3.org/TR/preload/}
+	 * @see {@link https://www.w3.org/TR/preload/}
 	 */
 	public static final LinkRelation PRELOAD = LinkRelation.of("preload");
 
@@ -550,7 +550,7 @@ public class IanaLinkRelations {
 	/**
 	 * Indicates that the link's context is a part of a series, and that the previous in the series is the link target.
 	 *
-	 * @see {@link http://www.w3.org/TR/html5/links.html#link-type-prev}
+	 * @see {@link https://www.w3.org/TR/html5/links.html#link-type-prev}
 	 */
 	public static final LinkRelation PREV = LinkRelation.of("prev");
 
@@ -564,7 +564,7 @@ public class IanaLinkRelations {
 	/**
 	 * Refers to the previous resource in an ordered series of resources. Synonym for "prev".
 	 *
-	 * @see {@link http://www.w3.org/TR/1999/REC-html401-19991224}
+	 * @see {@link https://www.w3.org/TR/1999/REC-html401-19991224}
 	 */
 	public static final LinkRelation PREVIOUS = LinkRelation.of("previous");
 
@@ -623,7 +623,7 @@ public class IanaLinkRelations {
 	/**
 	 * Refers to a section in a collection of resources.
 	 *
-	 * @see {@link http://www.w3.org/TR/1999/REC-html401-19991224}
+	 * @see {@link https://www.w3.org/TR/1999/REC-html401-19991224}
 	 */
 	public static final LinkRelation SECTION = LinkRelation.of("section");
 
@@ -644,21 +644,21 @@ public class IanaLinkRelations {
 	/**
 	 * Refers to the first resource in a collection of resources.
 	 *
-	 * @see {@link http://www.w3.org/TR/1999/REC-html401-19991224}
+	 * @see {@link https://www.w3.org/TR/1999/REC-html401-19991224}
 	 */
 	public static final LinkRelation START = LinkRelation.of("start");
 
 	/**
 	 * Refers to a stylesheet.
 	 *
-	 * @see {@link http://www.w3.org/TR/html5/links.html#link-type-stylesheet}
+	 * @see {@link https://www.w3.org/TR/html5/links.html#link-type-stylesheet}
 	 */
 	public static final LinkRelation STYLESHEET = LinkRelation.of("stylesheet");
 
 	/**
 	 * Refers to a resource serving as a subsection in a collection of resources.
 	 *
-	 * @see {@link http://www.w3.org/TR/1999/REC-html401-19991224}
+	 * @see {@link https://www.w3.org/TR/1999/REC-html401-19991224}
 	 */
 	public static final LinkRelation SUBSECTION = LinkRelation.of("subsection");
 
@@ -672,7 +672,7 @@ public class IanaLinkRelations {
 	/**
 	 * Gives a tag (identified by the given address) that applies to the current document.
 	 *
-	 * @see {@link http://www.w3.org/TR/html5/links.html#link-type-tag}
+	 * @see {@link https://www.w3.org/TR/html5/links.html#link-type-tag}
 	 */
 	public static final LinkRelation TAG = LinkRelation.of("tag");
 
@@ -730,7 +730,7 @@ public class IanaLinkRelations {
 	 * Identifies a target URI that supports the Webmention protcol. This allows clients that mention a resource in some
 	 * form of publishing process to contact that endpoint and inform it that this resource has been mentioned.
 	 *
-	 * @see {@link http://www.w3.org/TR/webmention/}
+	 * @see {@link https://www.w3.org/TR/webmention/}
 	 */
 	public static final LinkRelation WEBMENTION = LinkRelation.of("webmention");
 

--- a/src/main/java/org/springframework/hateoas/IanaRels.java
+++ b/src/main/java/org/springframework/hateoas/IanaRels.java
@@ -20,7 +20,7 @@ import lombok.experimental.UtilityClass;
 /**
  * Static class to find out whether a relation type is defined by the IANA.
  *
- * @see http://www.iana.org/assignments/link-relations/link-relations.xhtml
+ * @see https://www.iana.org/assignments/link-relations/link-relations.xhtml
  * @author Oliver Gierke
  * @author Roland Kulcsár
  * @author Greg Turnquist

--- a/src/main/java/org/springframework/hateoas/QueryParameter.java
+++ b/src/main/java/org/springframework/hateoas/QueryParameter.java
@@ -19,7 +19,7 @@ import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
 /**
- * Representation of a web request's query parameter (http://example.com?name=foo) => {"name", "foo", true}.
+ * Representation of a web request's query parameter (https://example.com?name=foo) => {"name", "foo", true}.
  *
  * @author Greg Turnquist
  */

--- a/src/main/java/org/springframework/hateoas/UriTemplate.java
+++ b/src/main/java/org/springframework/hateoas/UriTemplate.java
@@ -38,7 +38,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  *
  * @author Oliver Gierke
  * @author JamesE Richardson
- * @see http://tools.ietf.org/html/rfc6570
+ * @see https://tools.ietf.org/html/rfc6570
  * @since 0.9
  */
 public class UriTemplate implements Iterable<TemplateVariable>, Serializable {

--- a/src/main/java/org/springframework/hateoas/config/EnableHypermediaSupport.java
+++ b/src/main/java/org/springframework/hateoas/config/EnableHypermediaSupport.java
@@ -61,7 +61,7 @@ public @interface EnableHypermediaSupport {
 		 * HAL - Hypermedia Application Language.
 		 *
 		 * @see http://stateless.co/hal_specification.html
-		 * @see http://tools.ietf.org/html/draft-kelly-json-hal-05
+		 * @see https://tools.ietf.org/html/draft-kelly-json-hal-05
 		 */
 		HAL(MediaTypes.HAL_JSON, MediaTypes.HAL_JSON_UTF8),
 
@@ -82,7 +82,7 @@ public @interface EnableHypermediaSupport {
 		/**
 		 * UBER Hypermedia
 		 *
-		 * @see http://uberhypermedia.org/
+		 * @see https://rawgit.com/uber-hypermedia/specification/master/uber-hypermedia.html
 		 */
 		UBER(MediaTypes.UBER_JSON);
 

--- a/src/main/java/org/springframework/hateoas/mediatype/hal/CurieProvider.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/hal/CurieProvider.java
@@ -24,7 +24,7 @@ import org.springframework.hateoas.Links;
 /**
  * API to provide HAL curie information for links.
  *
- * @see {@link http://tools.ietf.org/html/draft-kelly-json-hal#section-8.2}
+ * @see {@link https://tools.ietf.org/html/draft-kelly-json-hal#section-8.2}
  * @author Oliver Gierke
  * @author Jeff Stano
  * @since 0.9

--- a/src/main/java/org/springframework/hateoas/mediatype/hal/HalConfiguration.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/hal/HalConfiguration.java
@@ -76,7 +76,7 @@ public class HalConfiguration {
 	/**
 	 * Configures how to render a single link for the given link relation pattern, i.e. this can be either a fixed link
 	 * relation (like {@code search}), take wildcards to e.g. match links of a given curie (like {@code acme:*}) or even
-	 * complete URIs (like {@code http://api.acme.com/foo/**}).
+	 * complete URIs (like {@code https://api.acme.com/foo/**}).
 	 *
 	 * @param pattern must not be {@literal null}.
 	 * @param renderSingleLinks must not be {@literal null}.

--- a/src/main/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsProperty.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsProperty.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
  * Describe a parameter for the associated state transition in a HAL-FORMS document. A {@link HalFormsTemplate} may
  * contain a list of {@link HalFormsProperty}s
  *
- * @see http://mamund.site44.com/misc/hal-forms/
+ * @see https://mamund.site44.com/misc/hal-forms/
  */
 @JsonInclude(Include.NON_DEFAULT)
 @Value

--- a/src/main/java/org/springframework/hateoas/server/core/EvoInflectorLinkRelationProvider.java
+++ b/src/main/java/org/springframework/hateoas/server/core/EvoInflectorLinkRelationProvider.java
@@ -23,7 +23,7 @@ import org.springframework.hateoas.server.LinkRelationProvider;
  * {@link LinkRelationProvider} implementation using the Evo Inflector implementation of an algorithmic approach to
  * English plurals.
  *
- * @see http://www.csse.monash.edu.au/~damian/papers/HTML/Plurals.html
+ * @see http://users.monash.edu/~damian/papers/HTML/Plurals.html
  * @author Oliver Gierke
  */
 public class EvoInflectorLinkRelationProvider extends DefaultLinkRelationProvider {

--- a/src/main/resources/license.txt
+++ b/src/main/resources/license.txt
@@ -207,7 +207,7 @@ similar licenses that require the source code and/or modifications to
 source code to be made available (as would be noted above), you may obtain a 
 copy of the source code corresponding to the binaries for such open source 
 components and modifications thereto, if any, (the "Source Files"), by 
-downloading the Source Files from http://www.springsource.org/download, 
+downloading the Source Files from https://www.springsource.org/download, 
 or by sending a request, with your name and address to: VMware, Inc., 3401 Hillview 
 Avenue, Palo Alto, CA 94304, United States of America or email info@vmware.com.  All 
 such requests should clearly specify:  OPEN SOURCE FILES REQUEST, Attention General 

--- a/src/test/java/org/springframework/hateoas/LinkUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/LinkUnitTest.java
@@ -131,7 +131,7 @@ public class LinkUnitTest {
 					+ "media=\"pdf\";" //
 					+ "title=\"pdf customer copy\";" //
 					+ "type=\"portable document\";" //
-					+ "deprecation=\"http://example.com/customers/deprecated\";" //
+					+ "deprecation=\"https://example.com/customers/deprecated\";" //
 					+ "profile=\"my-profile\";" //
 					+ "name=\"my-name\";")) //
 					.isEqualTo(new Link("/customer/1") //
@@ -139,7 +139,7 @@ public class LinkUnitTest {
 							.withMedia("pdf") //
 							.withTitle("pdf customer copy") //
 							.withType("portable document") //
-							.withDeprecation("http://example.com/customers/deprecated") //
+							.withDeprecation("https://example.com/customers/deprecated") //
 							.withProfile("my-profile") //
 							.withName("my-name"));
 		});
@@ -213,7 +213,7 @@ public class LinkUnitTest {
 	@Test
 	public void serializesCorrectly() throws IOException {
 
-		Link link = new Link("http://foobar{?foo,bar}");
+		Link link = new Link("https://foobar{?foo,bar}");
 
 		ObjectOutputStream stream = new ObjectOutputStream(new ByteArrayOutputStream());
 		stream.writeObject(link);
@@ -246,8 +246,8 @@ public class LinkUnitTest {
 	@Test
 	public void parsesUriLinkRelations() {
 
-		assertThat(Link.valueOf("<http://localhost>; rel=\"http://acme.com/rels/foo-bar\"").getRel()) //
-				.isEqualTo(LinkRelation.of("http://acme.com/rels/foo-bar"));
+		assertThat(Link.valueOf("<http://localhost>; rel=\"https://acme.com/rels/foo-bar\"").getRel()) //
+				.isEqualTo(LinkRelation.of("https://acme.com/rels/foo-bar"));
 	}
 
 	/**

--- a/src/test/java/org/springframework/hateoas/client/TraversonTest.java
+++ b/src/test/java/org/springframework/hateoas/client/TraversonTest.java
@@ -153,7 +153,7 @@ public class TraversonTest {
 	@Test
 	public void sendsConfiguredHeadersForJsonPathExpression() {
 
-		String expectedHeader = "<http://www.example.com>;rel=\"home\"";
+		String expectedHeader = "<https://www.example.com>;rel=\"home\"";
 
 		HttpHeaders headers = new HttpHeaders();
 		headers.add("Link", expectedHeader);
@@ -172,7 +172,7 @@ public class TraversonTest {
 	@Test
 	public void sendsConfiguredHeadersForToEntity() {
 
-		String expectedHeader = "<http://www.example.com>;rel=\"home\"";
+		String expectedHeader = "<https://www.example.com>;rel=\"home\"";
 
 		HttpHeaders headers = new HttpHeaders();
 		headers.add("Link", expectedHeader);

--- a/src/test/java/org/springframework/hateoas/mediatype/alps/AlpsLinkDiscoverUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/alps/AlpsLinkDiscoverUnitTest.java
@@ -42,7 +42,7 @@ public class AlpsLinkDiscoverUnitTest extends LinkDiscovererUnitTest {
 	@Test
 	public void discoversFullyQualifiedRel() {
 
-		Optional<Link> link = getDiscoverer().findLinkWithRel("http://foo.com/bar", getInputString());
+		Optional<Link> link = getDiscoverer().findLinkWithRel("http://www.foo.com/bar", getInputString());
 
 		assertThat(link) //
 				.map(Link::getHref) //

--- a/src/test/java/org/springframework/hateoas/mediatype/alps/JacksonSerializationTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/alps/JacksonSerializationTest.java
@@ -60,7 +60,7 @@ public class JacksonSerializationTest {
 	public void writesSampleDocument() throws Exception {
 
 		Alps alps = alps().//
-				doc(doc().href("http://example.org/samples/full/doc.html").build()). //
+				doc(doc().href("https://example.org/samples/full/doc.html").build()). //
 				descriptor(Arrays.asList(//
 						descriptor().id("search").type(Type.SAFE).//
 								doc(new Doc("A search form with two inputs.", Format.TEXT)).//

--- a/src/test/java/org/springframework/hateoas/mediatype/collectionjson/CollectionJsonLinkDiscovererUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/collectionjson/CollectionJsonLinkDiscovererUnitTest.java
@@ -52,7 +52,7 @@ public class CollectionJsonLinkDiscovererUnitTest {
 
 		assertThat(link) //
 				.map(Link::getHref) //
-				.hasValue("http://example.org/friends/");
+				.hasValue("https://example.org/friends/");
 	}
 
 	@Test
@@ -62,20 +62,20 @@ public class CollectionJsonLinkDiscovererUnitTest {
 
 		assertThat(this.discoverer.findLinkWithRel("self", specBasedJson)) //
 				.map(Link::getHref) //
-				.hasValue("http://example.org/friends/");
+				.hasValue("https://example.org/friends/");
 
 		assertThat(this.discoverer.findLinkWithRel("feed", specBasedJson)) //
 				.map(Link::getHref) //
-				.hasValue("http://example.org/friends/rss");
+				.hasValue("https://example.org/friends/rss");
 
 		assertThat(this.discoverer.findLinksWithRel("blog", specBasedJson)) //
 				.extracting("href") //
-				.containsExactlyInAnyOrder("http://examples.org/blogs/jdoe", "http://examples.org/blogs/msmith",
-						"http://examples.org/blogs/rwilliams");
+				.containsExactlyInAnyOrder("https://examples.org/blogs/jdoe", "https://examples.org/blogs/msmith",
+						"https://examples.org/blogs/rwilliams");
 
 		assertThat(this.discoverer.findLinksWithRel("avatar", specBasedJson)) //
 				.extracting("href") //
-				.containsExactlyInAnyOrder("http://examples.org/images/jdoe", "http://examples.org/images/msmith",
-						"http://examples.org/images/rwilliams");
+				.containsExactlyInAnyOrder("https://examples.org/images/jdoe", "https://examples.org/images/msmith",
+						"https://examples.org/images/rwilliams");
 	}
 }

--- a/src/test/java/org/springframework/hateoas/mediatype/collectionjson/CollectionJsonSpecTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/collectionjson/CollectionJsonSpecTest.java
@@ -70,7 +70,7 @@ public class CollectionJsonSpecTest {
 		RepresentationModel<?> resource = mapper.readValue(specBasedJson, RepresentationModel.class);
 
 		assertThat(resource.getLinks()).hasSize(1);
-		assertThat(resource.getRequiredLink(IanaLinkRelations.SELF)).isEqualTo(new Link("http://example.org/friends/"));
+		assertThat(resource.getRequiredLink(IanaLinkRelations.SELF)).isEqualTo(new Link("https://example.org/friends/"));
 	}
 
 	/**
@@ -87,8 +87,8 @@ public class CollectionJsonSpecTest {
 						mapper.getTypeFactory().constructParametricType(EntityModel.class, Friend.class)));
 
 		assertThat(resources.getLinks()).hasSize(2);
-		assertThat(resources.getRequiredLink(IanaLinkRelations.SELF)).isEqualTo(new Link("http://example.org/friends/"));
-		assertThat(resources.getRequiredLink("feed")).isEqualTo(new Link("http://example.org/friends/rss", "feed"));
+		assertThat(resources.getRequiredLink(IanaLinkRelations.SELF)).isEqualTo(new Link("https://example.org/friends/"));
+		assertThat(resources.getRequiredLink("feed")).isEqualTo(new Link("https://example.org/friends/rss", "feed"));
 		assertThat(resources.getContent()).hasSize(3);
 
 		List<EntityModel<Friend>> friends = new ArrayList<>(resources.getContent());
@@ -96,27 +96,27 @@ public class CollectionJsonSpecTest {
 		assertThat(friends.get(0).getContent().getEmail()).isEqualTo("jdoe@example.org");
 		assertThat(friends.get(0).getContent().getFullname()).isEqualTo("J. Doe");
 		assertThat(friends.get(0).getRequiredLink(IanaLinkRelations.SELF))
-				.isEqualTo(new Link("http://example.org/friends/jdoe"));
-		assertThat(friends.get(0).getRequiredLink("blog")).isEqualTo(new Link("http://examples.org/blogs/jdoe", "blog"));
+				.isEqualTo(new Link("https://example.org/friends/jdoe"));
+		assertThat(friends.get(0).getRequiredLink("blog")).isEqualTo(new Link("https://examples.org/blogs/jdoe", "blog"));
 		assertThat(friends.get(0).getRequiredLink("avatar"))
-				.isEqualTo(new Link("http://examples.org/images/jdoe", "avatar"));
+				.isEqualTo(new Link("https://examples.org/images/jdoe", "avatar"));
 
 		assertThat(friends.get(1).getContent().getEmail()).isEqualTo("msmith@example.org");
 		assertThat(friends.get(1).getContent().getFullname()).isEqualTo("M. Smith");
 		assertThat(friends.get(1).getRequiredLink(IanaLinkRelations.SELF.value()))
-				.isEqualTo(new Link("http://example.org/friends/msmith"));
-		assertThat(friends.get(1).getRequiredLink("blog")).isEqualTo(new Link("http://examples.org/blogs/msmith", "blog"));
+				.isEqualTo(new Link("https://example.org/friends/msmith"));
+		assertThat(friends.get(1).getRequiredLink("blog")).isEqualTo(new Link("https://examples.org/blogs/msmith", "blog"));
 		assertThat(friends.get(1).getRequiredLink("avatar"))
-				.isEqualTo(new Link("http://examples.org/images/msmith", "avatar"));
+				.isEqualTo(new Link("https://examples.org/images/msmith", "avatar"));
 
 		assertThat(friends.get(2).getContent().getEmail()).isEqualTo("rwilliams@example.org");
 		assertThat(friends.get(2).getContent().getFullname()).isEqualTo("R. Williams");
 		assertThat(friends.get(2).getRequiredLink(IanaLinkRelations.SELF.value()))
-				.isEqualTo(new Link("http://example.org/friends/rwilliams"));
+				.isEqualTo(new Link("https://example.org/friends/rwilliams"));
 		assertThat(friends.get(2).getRequiredLink("blog"))
-				.isEqualTo(new Link("http://examples.org/blogs/rwilliams", "blog"));
+				.isEqualTo(new Link("https://examples.org/blogs/rwilliams", "blog"));
 		assertThat(friends.get(2).getRequiredLink("avatar"))
-				.isEqualTo(new Link("http://examples.org/images/rwilliams", "avatar"));
+				.isEqualTo(new Link("https://examples.org/images/rwilliams", "avatar"));
 	}
 
 	/**
@@ -132,14 +132,14 @@ public class CollectionJsonSpecTest {
 				mapper.getTypeFactory().constructParametricType(EntityModel.class, Friend.class));
 
 		assertThat(resource.getLinks()).hasSize(6);
-		assertThat(resource.getRequiredLink(IanaLinkRelations.SELF)).isEqualTo(new Link("http://example.org/friends/jdoe"));
-		assertThat(resource.getRequiredLink("feed")).isEqualTo(new Link("http://example.org/friends/rss", "feed"));
+		assertThat(resource.getRequiredLink(IanaLinkRelations.SELF)).isEqualTo(new Link("https://example.org/friends/jdoe"));
+		assertThat(resource.getRequiredLink("feed")).isEqualTo(new Link("https://example.org/friends/rss", "feed"));
 		assertThat(resource.getRequiredLink("queries"))
-				.isEqualTo(new Link("http://example.org/friends/?queries", "queries"));
+				.isEqualTo(new Link("https://example.org/friends/?queries", "queries"));
 		assertThat(resource.getRequiredLink("template"))
-				.isEqualTo(new Link("http://example.org/friends/?template", "template"));
-		assertThat(resource.getRequiredLink("blog")).isEqualTo(new Link("http://examples.org/blogs/jdoe", "blog"));
-		assertThat(resource.getRequiredLink("avatar")).isEqualTo(new Link("http://examples.org/images/jdoe", "avatar"));
+				.isEqualTo(new Link("https://example.org/friends/?template", "template"));
+		assertThat(resource.getRequiredLink("blog")).isEqualTo(new Link("https://examples.org/blogs/jdoe", "blog"));
+		assertThat(resource.getRequiredLink("avatar")).isEqualTo(new Link("https://examples.org/images/jdoe", "avatar"));
 
 		assertThat(resource.getContent().getEmail()).isEqualTo("jdoe@example.org");
 		assertThat(resource.getContent().getFullname()).isEqualTo("J. Doe");
@@ -160,7 +160,7 @@ public class CollectionJsonSpecTest {
 
 		assertThat(resources.getContent()).hasSize(0);
 		assertThat(resources.getRequiredLink(IanaLinkRelations.SELF.value()))
-				.isEqualTo(new Link("http://example.org/friends/"));
+				.isEqualTo(new Link("https://example.org/friends/"));
 	}
 
 	/**
@@ -178,7 +178,7 @@ public class CollectionJsonSpecTest {
 
 		assertThat(resources.getContent()).hasSize(0);
 		assertThat(resources.getRequiredLink(IanaLinkRelations.SELF.value()))
-				.isEqualTo(new Link("http://example.org/friends/"));
+				.isEqualTo(new Link("https://example.org/friends/"));
 	}
 
 	/**
@@ -196,7 +196,7 @@ public class CollectionJsonSpecTest {
 
 		assertThat(resources.getContent()).hasSize(0);
 		assertThat(resources.getRequiredLink(IanaLinkRelations.SELF.value()))
-				.isEqualTo(new Link("http://example.org/friends/"));
+				.isEqualTo(new Link("https://example.org/friends/"));
 	}
 
 	/**

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/DefaultCurieProviderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/DefaultCurieProviderUnitTest.java
@@ -74,21 +74,21 @@ public class DefaultCurieProviderUnitTest {
 	@Test
 	public void doesNotPrefixIanaRels() {
 
-		assertThat(provider.getNamespacedRelFrom(new Link("http://amazon.com"))) //
+		assertThat(provider.getNamespacedRelFrom(new Link("https://amazon.com"))) //
 				.isEqualTo(HalLinkRelation.of(IanaLinkRelations.SELF));
 	}
 
 	@Test
 	public void prefixesNormalRels() {
 
-		assertThat(provider.getNamespacedRelFrom(new Link("http://amazon.com", "book"))) //
+		assertThat(provider.getNamespacedRelFrom(new Link("https://amazon.com", "book"))) //
 				.isEqualTo(HalLinkRelation.curied("acme", "book"));
 	}
 
 	@Test
 	public void doesNotPrefixQualifiedRels() {
 
-		assertThat(provider.getNamespacedRelFrom(new Link("http://amazon.com", "custom:rel")))
+		assertThat(provider.getNamespacedRelFrom(new Link("https://amazon.com", "custom:rel")))
 				.isEqualTo(HalLinkRelation.curied("custom", "rel"));
 	}
 
@@ -98,12 +98,12 @@ public class DefaultCurieProviderUnitTest {
 	@Test
 	public void prefixesNormalRelsThatHaveExtraRFC5988Attributes() {
 
-		Link link = new Link("http://amazon.com", "custom:rel") //
+		Link link = new Link("https://amazon.com", "custom:rel") //
 				.withHreflang("en") //
 				.withTitle("the title") //
 				.withMedia("the media") //
 				.withType("the type") //
-				.withDeprecation("http://example.com/custom/deprecated");
+				.withDeprecation("https://example.com/custom/deprecated");
 
 		assertThat(provider.getNamespacedRelFrom(link)) //
 				.isEqualTo(HalLinkRelation.curied("custom", "rel"));

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/HalConfigurationUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/HalConfigurationUnitTest.java
@@ -54,16 +54,16 @@ public class HalConfigurationUnitTest {
 	@Test // #811
 	public void registersWildcardedArrayLinksPatternForUri() {
 
-		HalConfiguration configuration = new HalConfiguration().withRenderSingleLinksFor("http://somehost/foo/**",
+		HalConfiguration configuration = new HalConfiguration().withRenderSingleLinksFor("https://somehost/foo/**",
 				RenderSingleLinks.AS_ARRAY);
 
-		assertThat(configuration.getSingleLinkRenderModeFor(LinkRelation.of("http://somehost/foo")))
+		assertThat(configuration.getSingleLinkRenderModeFor(LinkRelation.of("https://somehost/foo")))
 				.isEqualTo(RenderSingleLinks.AS_ARRAY);
-		assertThat(configuration.getSingleLinkRenderModeFor(LinkRelation.of("http://somehost/foo/bar")))
+		assertThat(configuration.getSingleLinkRenderModeFor(LinkRelation.of("https://somehost/foo/bar")))
 				.isEqualTo(RenderSingleLinks.AS_ARRAY);
-		assertThat(configuration.getSingleLinkRenderModeFor(LinkRelation.of("http://somehost/foo/bar/foobar")))
+		assertThat(configuration.getSingleLinkRenderModeFor(LinkRelation.of("https://somehost/foo/bar/foobar")))
 				.isEqualTo(RenderSingleLinks.AS_ARRAY);
-		assertThat(configuration.getSingleLinkRenderModeFor(LinkRelation.of("http://somehost/bar")))
+		assertThat(configuration.getSingleLinkRenderModeFor(LinkRelation.of("https://somehost/bar")))
 				.isEqualTo(RenderSingleLinks.AS_SINGLE);
 	}
 }

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/HalLinkDiscovererUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/HalLinkDiscovererUnitTest.java
@@ -45,7 +45,7 @@ public class HalLinkDiscovererUnitTest extends LinkDiscovererUnitTest {
 	@Test
 	public void discoversFullyQualifiedRel() {
 
-		assertThat(getDiscoverer().findLinkWithRel("http://foo.com/bar", getInputString())) //
+		assertThat(getDiscoverer().findLinkWithRel("http://www.foo.com/bar", getInputString())) //
 				.map(Link::getHref) //
 				.hasValue("fullRelHref");
 	}
@@ -64,7 +64,7 @@ public class HalLinkDiscovererUnitTest extends LinkDiscovererUnitTest {
 				+ "media=\"pdf\";" //
 				+ "title=\"pdf customer copy\";" //
 				+ "type=\"portable document\";" //
-				+ "deprecation=\"http://example.com/customers/deprecated\";" //
+				+ "deprecation=\"https://example.com/customers/deprecated\";" //
 				+ "profile=\"my-profile\"" //
 				+ "name=\"my-name\"");
 

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsLinkDiscovererUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsLinkDiscovererUnitTest.java
@@ -42,7 +42,7 @@ public class HalFormsLinkDiscovererUnitTest extends LinkDiscovererUnitTest {
 	 */
 	@Test
 	public void discoversFullyQualifiedRel() {
-		assertThat(getDiscoverer().findLinkWithRel("http://foo.com/bar", getInputString())).isNotNull();
+		assertThat(getDiscoverer().findLinkWithRel("http://www.foo.com/bar", getInputString())).isNotNull();
 	}
 
 	/**
@@ -59,7 +59,7 @@ public class HalFormsLinkDiscovererUnitTest extends LinkDiscovererUnitTest {
 				+ "media=\"pdf\";" //
 				+ "title=\"pdf customer copy\";" //
 				+ "type=\"portable document\";" //
-				+ "deprecation=\"http://example.com/customers/deprecated\";" //
+				+ "deprecation=\"https://example.com/customers/deprecated\";" //
 				+ "profile=\"my-profile\"" //
 				+ "name=\"my-name\"");
 

--- a/src/test/java/org/springframework/hateoas/mediatype/uber/Jackson2UberIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/uber/Jackson2UberIntegrationTest.java
@@ -221,7 +221,7 @@ public class Jackson2UberIntegrationTest extends AbstractJackson2MarshallingInte
 	public void renderResourceWithMultipleRels() throws Exception {
 
 		EntityModel<String> data4 = new EntityModel<>("third", new Link("localhost"),
-				new Link("localhost").withRel("http://example.org/rels/todo"), new Link("second").withRel("second"),
+				new Link("localhost").withRel("https://example.org/rels/todo"), new Link("second").withRel("second"),
 				new Link("third").withRel("third"));
 
 		assertThat(write(data4)).isEqualTo(MappingUtils.read(new ClassPathResource("resource4.json", getClass())));
@@ -257,7 +257,7 @@ public class Jackson2UberIntegrationTest extends AbstractJackson2MarshallingInte
 		assertThat(actual3).isEqualTo(expected3);
 
 		EntityModel<String> expected4 = new EntityModel<>("third", new Link("localhost"),
-				new Link("localhost").withRel("http://example.org/rels/todo"), new Link("second").withRel("second"),
+				new Link("localhost").withRel("https://example.org/rels/todo"), new Link("second").withRel("second"),
 				new Link("third").withRel("third"));
 		EntityModel<String> actual4 = mapper
 				.readValue(MappingUtils.read(new ClassPathResource("resource4.json", getClass())), resourceStringType);

--- a/src/test/java/org/springframework/hateoas/mediatype/uber/UberLinkDiscovererUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/uber/UberLinkDiscovererUnitTest.java
@@ -50,7 +50,7 @@ public class UberLinkDiscovererUnitTest extends LinkDiscovererUnitTest {
 	 */
 	@Test
 	public void discoversFullyQualifiedRel() {
-		assertThat(getDiscoverer().findLinkWithRel("http://foo.com/bar", this.sample)).isNotNull();
+		assertThat(getDiscoverer().findLinkWithRel("http://www.foo.com/bar", this.sample)).isNotNull();
 	}
 
 	@Override

--- a/src/test/java/org/springframework/hateoas/server/mvc/ControllerLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/server/mvc/ControllerLinkBuilderUnitTest.java
@@ -156,7 +156,7 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		adaptRequestFromForwardedHeaders();
 
 		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
-		assertThat(link.getHref(), startsWith("http://somethingDifferent"));
+		assertThat(link.getHref(), startsWith("https://somethingDifferent"));
 	}
 
 	/**
@@ -272,7 +272,7 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		adaptRequestFromForwardedHeaders();
 
 		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
-		assertThat(link.getHref(), startsWith("http://foobar:8088"));
+		assertThat(link.getHref(), startsWith("https://foobar:8088"));
 	}
 
 	/**
@@ -286,7 +286,7 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		adaptRequestFromForwardedHeaders();
 
 		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
-		assertThat(link.getHref(), startsWith("http://barfoo:8888"));
+		assertThat(link.getHref(), startsWith("https://barfoo:8888"));
 	}
 
 	/**
@@ -342,7 +342,7 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 
 		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
 
-		assertThat(link.getHref(), startsWith("http://foobarhost:9090/"));
+		assertThat(link.getHref(), startsWith("https://foobarhost:9090/"));
 	}
 
 	/**
@@ -357,7 +357,7 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 		adaptRequestFromForwardedHeaders();
 
 		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
-		assertThat(link.getHref(), startsWith("http://foobarhost/"));
+		assertThat(link.getHref(), startsWith("https://foobarhost/"));
 	}
 
 	/**
@@ -546,7 +546,7 @@ public class ControllerLinkBuilderUnitTest extends TestUtils {
 
 		adaptRequestFromForwardedHeaders();
 
-		assertThat(linkTo(PersonControllerImpl.class).withSelfRel().getHref(), startsWith("http://proxy1:1443"));
+		assertThat(linkTo(PersonControllerImpl.class).withSelfRel().getHref(), startsWith("https://proxy1:1443"));
 	}
 
 	/**

--- a/src/test/java/org/springframework/hateoas/server/mvc/WebMvcLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/server/mvc/WebMvcLinkBuilderUnitTest.java
@@ -155,7 +155,7 @@ public class WebMvcLinkBuilderUnitTest extends TestUtils {
 		adaptRequestFromForwardedHeaders();
 
 		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
-		assertThat(link.getHref(), startsWith("http://somethingDifferent"));
+		assertThat(link.getHref(), startsWith("https://somethingDifferent"));
 	}
 
 	/**
@@ -271,7 +271,7 @@ public class WebMvcLinkBuilderUnitTest extends TestUtils {
 		adaptRequestFromForwardedHeaders();
 
 		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
-		assertThat(link.getHref(), startsWith("http://foobar:8088"));
+		assertThat(link.getHref(), startsWith("https://foobar:8088"));
 	}
 
 	/**
@@ -285,7 +285,7 @@ public class WebMvcLinkBuilderUnitTest extends TestUtils {
 		adaptRequestFromForwardedHeaders();
 
 		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
-		assertThat(link.getHref(), startsWith("http://barfoo:8888"));
+		assertThat(link.getHref(), startsWith("https://barfoo:8888"));
 	}
 
 	/**
@@ -341,7 +341,7 @@ public class WebMvcLinkBuilderUnitTest extends TestUtils {
 
 		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
 
-		assertThat(link.getHref(), startsWith("http://foobarhost:9090/"));
+		assertThat(link.getHref(), startsWith("https://foobarhost:9090/"));
 	}
 
 	/**
@@ -356,7 +356,7 @@ public class WebMvcLinkBuilderUnitTest extends TestUtils {
 		adaptRequestFromForwardedHeaders();
 
 		Link link = linkTo(PersonControllerImpl.class).withSelfRel();
-		assertThat(link.getHref(), startsWith("http://foobarhost/"));
+		assertThat(link.getHref(), startsWith("https://foobarhost/"));
 	}
 
 	/**
@@ -545,7 +545,7 @@ public class WebMvcLinkBuilderUnitTest extends TestUtils {
 
 		adaptRequestFromForwardedHeaders();
 
-		assertThat(linkTo(PersonControllerImpl.class).withSelfRel().getHref(), startsWith("http://proxy1:1443"));
+		assertThat(linkTo(PersonControllerImpl.class).withSelfRel().getHref(), startsWith("https://proxy1:1443"));
 	}
 
 	/**

--- a/src/test/java/org/springframework/hateoas/server/reactive/HypermediaWebFilterTest.java
+++ b/src/test/java/org/springframework/hateoas/server/reactive/HypermediaWebFilterTest.java
@@ -65,7 +65,7 @@ public class HypermediaWebFilterTest {
 	@Test
 	public void webFilterShouldEmbedExchangeIntoContext() {
 
-		this.testClient.get().uri("http://example.com/api") //
+		this.testClient.get().uri("https://example.com/api") //
 				.accept(MediaTypes.HAL_JSON) //
 				.exchange() //
 				.expectStatus().isOk() //
@@ -76,7 +76,7 @@ public class HypermediaWebFilterTest {
 				.expectNextMatches(resourceSupport -> {
 
 					assertThat(resourceSupport.getLinks())//
-							.containsExactly(new Link("http://example.com/api", IanaLinkRelations.SELF));
+							.containsExactly(new Link("https://example.com/api", IanaLinkRelations.SELF));
 
 					return true;
 				}).verifyComplete();

--- a/src/test/resources/org/springframework/hateoas/mediatype/alps/link-discoverer.json
+++ b/src/test/resources/org/springframework/hateoas/mediatype/alps/link-discoverer.json
@@ -1,7 +1,7 @@
 {
   "version" : "1.0",
   "doc" : {
-    "href" : "http://example.org/samples/full/doc.html"
+    "href" : "https://example.org/samples/full/doc.html"
   },
   "descriptors" : [ {
     "id" : "sfirst descriptor",
@@ -17,7 +17,7 @@
     "href" : "selfHref"
   }, {
     "id" : "fully qualified descriptor",
-    "name" : "http://foo.com/bar",
+    "name" : "http://www.foo.com/bar",
     "href" : "fullRelHref"
   } ]
 }

--- a/src/test/resources/org/springframework/hateoas/mediatype/alps/reference.json
+++ b/src/test/resources/org/springframework/hateoas/mediatype/alps/reference.json
@@ -1,7 +1,7 @@
 {
   "version" : "1.0",
   "doc" : {
-    "href" : "http://example.org/samples/full/doc.html"
+    "href" : "https://example.org/samples/full/doc.html"
   },
   "descriptor" : [ {
     "id" : "search",

--- a/src/test/resources/org/springframework/hateoas/mediatype/collectionjson/spec-part1.json
+++ b/src/test/resources/org/springframework/hateoas/mediatype/collectionjson/spec-part1.json
@@ -1,6 +1,6 @@
 {
   "collection": {
     "version": "1.0",
-    "href": "http://example.org/friends/"
+    "href": "https://example.org/friends/"
   }
 }

--- a/src/test/resources/org/springframework/hateoas/mediatype/collectionjson/spec-part2.json
+++ b/src/test/resources/org/springframework/hateoas/mediatype/collectionjson/spec-part2.json
@@ -1,16 +1,16 @@
 {
   "collection": {
     "version": "1.0",
-    "href": "http://example.org/friends/",
+    "href": "https://example.org/friends/",
     "links": [
       {
         "rel": "feed",
-        "href": "http://example.org/friends/rss"
+        "href": "https://example.org/friends/rss"
       }
     ],
     "items": [
       {
-        "href": "http://example.org/friends/jdoe",
+        "href": "https://example.org/friends/jdoe",
         "data": [
           {
             "name": "fullname",
@@ -26,19 +26,19 @@
         "links": [
           {
             "rel": "blog",
-            "href": "http://examples.org/blogs/jdoe",
+            "href": "https://examples.org/blogs/jdoe",
             "prompt": "Blog"
           },
           {
             "rel": "avatar",
-            "href": "http://examples.org/images/jdoe",
+            "href": "https://examples.org/images/jdoe",
             "prompt": "Avatar",
             "render": "image"
           }
         ]
       },
       {
-        "href": "http://example.org/friends/msmith",
+        "href": "https://example.org/friends/msmith",
         "data": [
           {
             "name": "fullname",
@@ -54,19 +54,19 @@
         "links": [
           {
             "rel": "blog",
-            "href": "http://examples.org/blogs/msmith",
+            "href": "https://examples.org/blogs/msmith",
             "prompt": "Blog"
           },
           {
             "rel": "avatar",
-            "href": "http://examples.org/images/msmith",
+            "href": "https://examples.org/images/msmith",
             "prompt": "Avatar",
             "render": "image"
           }
         ]
       },
       {
-        "href": "http://example.org/friends/rwilliams",
+        "href": "https://example.org/friends/rwilliams",
         "data": [
           {
             "name": "fullname",
@@ -82,12 +82,12 @@
         "links": [
           {
             "rel": "blog",
-            "href": "http://examples.org/blogs/rwilliams",
+            "href": "https://examples.org/blogs/rwilliams",
             "prompt": "Blog"
           },
           {
             "rel": "avatar",
-            "href": "http://examples.org/images/rwilliams",
+            "href": "https://examples.org/images/rwilliams",
             "prompt": "Avatar",
             "render": "image"
           }
@@ -97,7 +97,7 @@
     "queries": [
       {
         "rel": "search",
-        "href": "http://example.org/friends/search",
+        "href": "https://example.org/friends/search",
         "prompt": "Search",
         "data": [
           {

--- a/src/test/resources/org/springframework/hateoas/mediatype/collectionjson/spec-part3.json
+++ b/src/test/resources/org/springframework/hateoas/mediatype/collectionjson/spec-part3.json
@@ -1,24 +1,24 @@
 {
   "collection": {
     "version": "1.0",
-    "href": "http://example.org/friends/",
+    "href": "https://example.org/friends/",
     "links": [
       {
         "rel": "feed",
-        "href": "http://example.org/friends/rss"
+        "href": "https://example.org/friends/rss"
       },
       {
         "rel": "queries",
-        "href": "http://example.org/friends/?queries"
+        "href": "https://example.org/friends/?queries"
       },
       {
         "rel": "template",
-        "href": "http://example.org/friends/?template"
+        "href": "https://example.org/friends/?template"
       }
     ],
     "items": [
       {
-        "href": "http://example.org/friends/jdoe",
+        "href": "https://example.org/friends/jdoe",
         "data": [
           {
             "name": "fullname",
@@ -34,12 +34,12 @@
         "links": [
           {
             "rel": "blog",
-            "href": "http://examples.org/blogs/jdoe",
+            "href": "https://examples.org/blogs/jdoe",
             "prompt": "Blog"
           },
           {
             "rel": "avatar",
-            "href": "http://examples.org/images/jdoe",
+            "href": "https://examples.org/images/jdoe",
             "prompt": "Avatar",
             "render": "image"
           }

--- a/src/test/resources/org/springframework/hateoas/mediatype/collectionjson/spec-part4.json
+++ b/src/test/resources/org/springframework/hateoas/mediatype/collectionjson/spec-part4.json
@@ -1,11 +1,11 @@
 {
   "collection": {
     "version": "1.0",
-    "href": "http://example.org/friends/",
+    "href": "https://example.org/friends/",
     "queries": [
       {
         "rel": "search",
-        "href": "http://example.org/friends/search",
+        "href": "https://example.org/friends/search",
         "prompt": "Search",
         "data": [
           {

--- a/src/test/resources/org/springframework/hateoas/mediatype/collectionjson/spec-part5.json
+++ b/src/test/resources/org/springframework/hateoas/mediatype/collectionjson/spec-part5.json
@@ -1,7 +1,7 @@
 {
   "collection": {
     "version": "1.0",
-    "href": "http://example.org/friends/",
+    "href": "https://example.org/friends/",
     "template": {
       "data": [
         {

--- a/src/test/resources/org/springframework/hateoas/mediatype/collectionjson/spec-part6.json
+++ b/src/test/resources/org/springframework/hateoas/mediatype/collectionjson/spec-part6.json
@@ -1,7 +1,7 @@
 {
   "collection": {
     "version": "1.0",
-    "href": "http://example.org/friends/",
+    "href": "https://example.org/friends/",
     "error": {
       "title": "Server Error",
       "code": "X1C2",

--- a/src/test/resources/org/springframework/hateoas/mediatype/collectionjson/spec-part7-adjusted.json
+++ b/src/test/resources/org/springframework/hateoas/mediatype/collectionjson/spec-part7-adjusted.json
@@ -11,11 +11,11 @@
       },
       {
         "name": "blog",
-        "value": "http://example.org/blogs/wchandry"
+        "value": "https://example.org/blogs/wchandry"
       },
       {
         "name": "avatar",
-        "value": "http://example.org/images/wchandry"
+        "value": "https://example.org/images/wchandry"
       }
     ]
   }

--- a/src/test/resources/org/springframework/hateoas/mediatype/collectionjson/spec-part7.json
+++ b/src/test/resources/org/springframework/hateoas/mediatype/collectionjson/spec-part7.json
@@ -11,11 +11,11 @@
       },
       {
         "name": "blog",
-        "value": "http://example.org/blogs/wchandry"
+        "value": "https://example.org/blogs/wchandry"
       },
       {
         "name": "avatar",
-        "value": "http://example.org/images/wchandry"
+        "value": "https://example.org/images/wchandry"
       }
     ]
   }

--- a/src/test/resources/org/springframework/hateoas/mediatype/hal/forms/hal-forms-link-discoverer.json
+++ b/src/test/resources/org/springframework/hateoas/mediatype/hal/forms/hal-forms-link-discoverer.json
@@ -11,7 +11,7 @@
         "href": "secondHref"
       }
     ],
-    "http://foo.com/bar": {
+    "http://www.foo.com/bar": {
       "href": "fullRelHref"
     }
   }

--- a/src/test/resources/org/springframework/hateoas/mediatype/hal/forms/hal-forms-link.json
+++ b/src/test/resources/org/springframework/hateoas/mediatype/hal/forms/hal-forms-link.json
@@ -6,7 +6,7 @@
       "media" : "pdf",
       "title" : "pdf customer copy",
       "type" : "portable document",
-      "deprecation" : "http://example.com/customers/deprecated",
+      "deprecation" : "https://example.com/customers/deprecated",
       "profile" : "my-profile",
       "name" : "my-name"
     }

--- a/src/test/resources/org/springframework/hateoas/mediatype/hal/hal-link-discoverer.json
+++ b/src/test/resources/org/springframework/hateoas/mediatype/hal/hal-link-discoverer.json
@@ -11,7 +11,7 @@
         "href": "secondHref"
       }
     ],
-    "http://foo.com/bar": {
+    "http://www.foo.com/bar": {
       "href": "fullRelHref"
     }
   }

--- a/src/test/resources/org/springframework/hateoas/mediatype/hal/hal-link.json
+++ b/src/test/resources/org/springframework/hateoas/mediatype/hal/hal-link.json
@@ -6,7 +6,7 @@
       "media" : "pdf",
       "title" : "pdf customer copy",
       "type" : "portable document",
-      "deprecation" : "http://example.com/customers/deprecated",
+      "deprecation" : "https://example.com/customers/deprecated",
       "profile" : "my-profile",
       "name" : "my-name"
     }

--- a/src/test/resources/org/springframework/hateoas/mediatype/uber/link-discovery.json
+++ b/src/test/resources/org/springframework/hateoas/mediatype/uber/link-discovery.json
@@ -17,7 +17,7 @@
         "url" : "secondHref"
       },
       {
-        "rel" : ["http://foo.com/bar"],
+        "rel" : ["http://www.foo.com/bar"],
         "url" : "fullRelHref"
       }
     ]

--- a/src/test/resources/org/springframework/hateoas/mediatype/uber/resource4.json
+++ b/src/test/resources/org/springframework/hateoas/mediatype/uber/resource4.json
@@ -2,7 +2,7 @@
   "uber" : {
     "version" : "1.0",
     "data" : [ {
-      "rel" : [ "self", "http://example.org/rels/todo" ],
+      "rel" : [ "self", "https://example.org/rels/todo" ],
       "url" : "localhost"
     }, {
       "rel" : [ "second" ],


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://alps.io (200) with 1 occurrences could not be migrated:  
   ([https](https://alps.io) result AnnotatedConnectException).
* [ ] http://alps.io/spec/ (200) with 6 occurrences could not be migrated:  
   ([https](https://alps.io/spec/) result AnnotatedConnectException).
* [ ] http://amundsen.com/media-types/collection/ (200) with 1 occurrences could not be migrated:  
   ([https](https://amundsen.com/media-types/collection/) result AnnotatedConnectException).
* [ ] http://amundsen.com/media-types/collection/examples/ (200) with 7 occurrences could not be migrated:  
   ([https](https://amundsen.com/media-types/collection/examples/) result AnnotatedConnectException).
* [ ] http://amundsen.com/media-types/collection/format/ (200) with 2 occurrences could not be migrated:  
   ([https](https://amundsen.com/media-types/collection/format/) result AnnotatedConnectException).
* [ ] http://stateless.co/hal_specification.html (200) with 2 occurrences could not be migrated:  
   ([https](https://stateless.co/hal_specification.html) result SSLHandshakeException).
* [ ] http://www.opensearch.org/Specifications/OpenSearch/1.1 (200) with 1 occurrences could not be migrated:  
   ([https](https://www.opensearch.org/Specifications/OpenSearch/1.1) result SSLHandshakeException).
* [ ] http://foo.com/bar (301) with 8 occurrences could not be migrated:  
   ([https](https://foo.com/bar) result SSLHandshakeException).
* [ ] http://www.csse.monash.edu.au/~damian/papers/HTML/Plurals.html (302) with 1 occurrences could not be migrated:  
   ([https](https://www.csse.monash.edu.au/~damian/papers/HTML/Plurals.html) result SSLHandshakeException).
* [ ] http://alps.io/ext/range (404) with 2 occurrences could not be migrated:  
   ([https](https://alps.io/ext/range) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://tools.ietf.org/html/draft-kelly-json-hal (301) with 2 occurrences migrated to:  
  https://tools.ietf.org/html/draft-kelly-json-hal ([https](https://tools.ietf.org/html/draft-kelly-json-hal) result ReadTimeoutException).
* [ ] http://api.acme.com/foo/ (UnknownHostException) with 1 occurrences migrated to:  
  https://api.acme.com/foo/ ([https](https://api.acme.com/foo/) result UnknownHostException).
* [ ] http://barfoo:8888 (UnknownHostException) with 2 occurrences migrated to:  
  https://barfoo:8888 ([https](https://barfoo:8888) result UnknownHostException).
* [ ] http://examples.org/blogs/jdoe (UnknownHostException) with 7 occurrences migrated to:  
  https://examples.org/blogs/jdoe ([https](https://examples.org/blogs/jdoe) result UnknownHostException).
* [ ] http://examples.org/blogs/msmith (UnknownHostException) with 4 occurrences migrated to:  
  https://examples.org/blogs/msmith ([https](https://examples.org/blogs/msmith) result UnknownHostException).
* [ ] http://examples.org/blogs/rwilliams (UnknownHostException) with 4 occurrences migrated to:  
  https://examples.org/blogs/rwilliams ([https](https://examples.org/blogs/rwilliams) result UnknownHostException).
* [ ] http://examples.org/images/jdoe (UnknownHostException) with 7 occurrences migrated to:  
  https://examples.org/images/jdoe ([https](https://examples.org/images/jdoe) result UnknownHostException).
* [ ] http://examples.org/images/msmith (UnknownHostException) with 4 occurrences migrated to:  
  https://examples.org/images/msmith ([https](https://examples.org/images/msmith) result UnknownHostException).
* [ ] http://examples.org/images/rwilliams (UnknownHostException) with 4 occurrences migrated to:  
  https://examples.org/images/rwilliams ([https](https://examples.org/images/rwilliams) result UnknownHostException).
* [ ] http://foobar (UnknownHostException) with 1 occurrences migrated to:  
  https://foobar ([https](https://foobar) result UnknownHostException).
* [ ] http://foobar:8088 (UnknownHostException) with 2 occurrences migrated to:  
  https://foobar:8088 ([https](https://foobar:8088) result UnknownHostException).
* [ ] http://foobarhost/ (UnknownHostException) with 2 occurrences migrated to:  
  https://foobarhost/ ([https](https://foobarhost/) result UnknownHostException).
* [ ] http://foobarhost:9090/ (UnknownHostException) with 2 occurrences migrated to:  
  https://foobarhost:9090/ ([https](https://foobarhost:9090/) result UnknownHostException).
* [ ] http://myhost/cart/42 (UnknownHostException) with 1 occurrences migrated to:  
  https://myhost/cart/42 ([https](https://myhost/cart/42) result UnknownHostException).
* [ ] http://myhost/inventory/12 (UnknownHostException) with 3 occurrences migrated to:  
  https://myhost/inventory/12 ([https](https://myhost/inventory/12) result UnknownHostException).
* [ ] http://myhost/people/42 (UnknownHostException) with 2 occurrences migrated to:  
  https://myhost/people/42 ([https](https://myhost/people/42) result UnknownHostException).
* [ ] http://myhost/person/1 (UnknownHostException) with 1 occurrences migrated to:  
  https://myhost/person/1 ([https](https://myhost/person/1) result UnknownHostException).
* [ ] http://myhost/person/1/orders (UnknownHostException) with 1 occurrences migrated to:  
  https://myhost/person/1/orders ([https](https://myhost/person/1/orders) result UnknownHostException).
* [ ] http://proxy1:1443 (UnknownHostException) with 2 occurrences migrated to:  
  https://proxy1:1443 ([https](https://proxy1:1443) result UnknownHostException).
* [ ] http://somehost/bar (UnknownHostException) with 1 occurrences migrated to:  
  https://somehost/bar ([https](https://somehost/bar) result UnknownHostException).
* [ ] http://somehost/foo (UnknownHostException) with 1 occurrences migrated to:  
  https://somehost/foo ([https](https://somehost/foo) result UnknownHostException).
* [ ] http://somehost/foo/ (UnknownHostException) with 1 occurrences migrated to:  
  https://somehost/foo/ ([https](https://somehost/foo/) result UnknownHostException).
* [ ] http://somehost/foo/bar (UnknownHostException) with 1 occurrences migrated to:  
  https://somehost/foo/bar ([https](https://somehost/foo/bar) result UnknownHostException).
* [ ] http://somehost/foo/bar/foobar (UnknownHostException) with 1 occurrences migrated to:  
  https://somehost/foo/bar/foobar ([https](https://somehost/foo/bar/foobar) result UnknownHostException).
* [ ] http://somethingDifferent (UnknownHostException) with 2 occurrences migrated to:  
  https://somethingDifferent ([https](https://somethingDifferent) result UnknownHostException).
* [ ] http://acme.com/rels/foo-bar (404) with 2 occurrences migrated to:  
  https://acme.com/rels/foo-bar ([https](https://acme.com/rels/foo-bar) result 404).
* [ ] http://example.com/api (404) with 2 occurrences migrated to:  
  https://example.com/api ([https](https://example.com/api) result 404).
* [ ] http://example.com/custom/deprecated (404) with 1 occurrences migrated to:  
  https://example.com/custom/deprecated ([https](https://example.com/custom/deprecated) result 404).
* [ ] http://example.com/customers/deprecated (404) with 6 occurrences migrated to:  
  https://example.com/customers/deprecated ([https](https://example.com/customers/deprecated) result 404).
* [ ] http://example.com/rels/ (404) with 2 occurrences migrated to:  
  https://example.com/rels/ ([https](https://example.com/rels/) result 404).
* [ ] http://example.com/rels/persons (404) with 1 occurrences migrated to:  
  https://example.com/rels/persons ([https](https://example.com/rels/persons) result 404).
* [ ] http://example.org/blogs/wchandry (404) with 3 occurrences migrated to:  
  https://example.org/blogs/wchandry ([https](https://example.org/blogs/wchandry) result 404).
* [ ] http://example.org/friends/ (404) with 19 occurrences migrated to:  
  https://example.org/friends/ ([https](https://example.org/friends/) result 404).
* [ ] http://example.org/friends/?queries (404) with 3 occurrences migrated to:  
  https://example.org/friends/?queries ([https](https://example.org/friends/?queries) result 404).
* [ ] http://example.org/friends/?template (404) with 3 occurrences migrated to:  
  https://example.org/friends/?template ([https](https://example.org/friends/?template) result 404).
* [ ] http://example.org/friends/jdoe (404) with 6 occurrences migrated to:  
  https://example.org/friends/jdoe ([https](https://example.org/friends/jdoe) result 404).
* [ ] http://example.org/friends/msmith (404) with 3 occurrences migrated to:  
  https://example.org/friends/msmith ([https](https://example.org/friends/msmith) result 404).
* [ ] http://example.org/friends/rss (404) with 7 occurrences migrated to:  
  https://example.org/friends/rss ([https](https://example.org/friends/rss) result 404).
* [ ] http://example.org/friends/rwilliams (404) with 3 occurrences migrated to:  
  https://example.org/friends/rwilliams ([https](https://example.org/friends/rwilliams) result 404).
* [ ] http://example.org/friends/search (404) with 4 occurrences migrated to:  
  https://example.org/friends/search ([https](https://example.org/friends/search) result 404).
* [ ] http://example.org/images/wchandry (404) with 3 occurrences migrated to:  
  https://example.org/images/wchandry ([https](https://example.org/images/wchandry) result 404).
* [ ] http://example.org/rels/todo (404) with 3 occurrences migrated to:  
  https://example.org/rels/todo ([https](https://example.org/rels/todo) result 404).
* [ ] http://example.org/samples/full/doc.html (404) with 3 occurrences migrated to:  
  https://example.org/samples/full/doc.html ([https](https://example.org/samples/full/doc.html) result 404).
* [ ] http://pubsubhubbub.googlecode.com (404) with 1 occurrences migrated to:  
  https://pubsubhubbub.googlecode.com ([https](https://pubsubhubbub.googlecode.com) result 404).
* [ ] http://www.example.com/rels/ (404) with 1 occurrences migrated to:  
  https://www.example.com/rels/ ([https](https://www.example.com/rels/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-hateoas/docs/current/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-hateoas/docs/current/reference/html/ ([https](https://docs.spring.io/spring-hateoas/docs/current/reference/html/) result 200).
* [ ] http://docs.spring.io/spring-hateoas/docs/current/reference/pdf/spring-hateoas-reference.pdf with 1 occurrences migrated to:  
  https://docs.spring.io/spring-hateoas/docs/current/reference/pdf/spring-hateoas-reference.pdf ([https](https://docs.spring.io/spring-hateoas/docs/current/reference/pdf/spring-hateoas-reference.pdf) result 200).
* [ ] http://en.wikipedia.org/wiki/HATEOAS with 2 occurrences migrated to:  
  https://en.wikipedia.org/wiki/HATEOAS ([https](https://en.wikipedia.org/wiki/HATEOAS) result 200).
* [ ] http://example.com?name=foo with 1 occurrences migrated to:  
  https://example.com?name=foo ([https](https://example.com?name=foo) result 200).
* [ ] http://mamund.site44.com/misc/hal-forms/ with 1 occurrences migrated to:  
  https://mamund.site44.com/misc/hal-forms/ ([https](https://mamund.site44.com/misc/hal-forms/) result 200).
* [ ] http://uberhypermedia.org/ (302) with 2 occurrences migrated to:  
  https://rawgit.com/uber-hypermedia/specification/master/uber-hypermedia.html ([https](https://uberhypermedia.org/) result 200).
* [ ] http://tools.ietf.org/html/draft-kelly-json-hal-05 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/draft-kelly-json-hal-05 ([https](https://tools.ietf.org/html/draft-kelly-json-hal-05) result 200).
* [ ] http://tools.ietf.org/html/rfc6570 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc6570 ([https](https://tools.ietf.org/html/rfc6570) result 200).
* [ ] http://www.example.com with 2 occurrences migrated to:  
  https://www.example.com ([https](https://www.example.com) result 200).
* [ ] http://www.hixie.ch/specs/pingback/pingback with 1 occurrences migrated to:  
  https://www.hixie.ch/specs/pingback/pingback ([https](https://www.hixie.ch/specs/pingback/pingback) result 200).
* [ ] http://www.iana.org/assignments/link-relations/link-relations.xhtml with 2 occurrences migrated to:  
  https://www.iana.org/assignments/link-relations/link-relations.xhtml ([https](https://www.iana.org/assignments/link-relations/link-relations.xhtml) result 200).
* [ ] http://www.w3.org/TR/2011/WD-html5-20110113/links.html with 1 occurrences migrated to:  
  https://www.w3.org/TR/2011/WD-html5-20110113/links.html ([https](https://www.w3.org/TR/2011/WD-html5-20110113/links.html) result 200).
* [ ] http://www.w3.org/TR/html5/links.html with 11 occurrences migrated to:  
  https://www.w3.org/TR/html5/links.html ([https](https://www.w3.org/TR/html5/links.html) result 200).
* [ ] http://www.w3.org/TR/powder-dr/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/powder-dr/ ([https](https://www.w3.org/TR/powder-dr/) result 200).
* [ ] http://www.w3.org/TR/preload/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/preload/ ([https](https://www.w3.org/TR/preload/) result 200).
* [ ] http://www.w3.org/TR/resource-hints/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/resource-hints/ ([https](https://www.w3.org/TR/resource-hints/) result 200).
* [ ] http://www.w3.org/TR/webmention/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/webmention/ ([https](https://www.w3.org/TR/webmention/) result 200).
* [ ] http://amazon.com with 4 occurrences migrated to:  
  https://amazon.com ([https](https://amazon.com) result 301).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://www.w3.org/TR/1999/REC-html401-19991224 with 10 occurrences migrated to:  
  https://www.w3.org/TR/1999/REC-html401-19991224 ([https](https://www.w3.org/TR/1999/REC-html401-19991224) result 301).
* [ ] http://www.w3.org/TR/curie with 1 occurrences migrated to:  
  https://www.w3.org/TR/curie ([https](https://www.w3.org/TR/curie) result 301).
* [ ] http://tools.ietf.org/html/rfc5988=section-4 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc5988=section-4 ([https](https://tools.ietf.org/html/rfc5988=section-4) result 302).
* [ ] http://www.springsource.org/download with 1 occurrences migrated to:  
  https://www.springsource.org/download ([https](https://www.springsource.org/download) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 11 occurrences
* http://localhost/ with 1 occurrences
* http://localhost/customers/15 with 1 occurrences
* http://localhost/employees with 56 occurrences
* http://localhost/employees/0 with 34 occurrences
* http://localhost/employees/1 with 15 occurrences
* http://localhost/employees/2 with 24 occurrences
* http://localhost/sample/1/foo with 1 occurrences
* http://localhost/sample/2/bar with 1 occurrences
* http://localhost/something/bar/foo with 2 occurrences
* http://localhost:8080/ with 2 occurrences
* http://localhost:8080/api with 8 occurrences
* http://localhost:8080/api/ with 1 occurrences
* http://localhost:8080/api/employees with 4 occurrences
* http://localhost:8080/employees/1 with 4 occurrences
* http://localhost:8080/foo with 2 occurrences
* http://localhost:8080/my/custom/location with 2 occurrences
* http://localhost:8080/rels with 1 occurrences
* http://localhost:8080/rels/ with 6 occurrences
* http://localhost:8080/test?page=0&filter=foo,bar with 2 occurrences
* http://localhost:8080/your-app with 1 occurrences
* http://localhost:8080/your-app/people with 1 occurrences
* http://www.w3.org/2005/Atom with 1 occurrences