### PR TITLE
#867 - Reenable default encoders and decoders.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.springframework.hateoas</groupId>
 	<artifactId>spring-hateoas</artifactId>
-	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<version>1.0.0.SLEUTH-BUILD-SNAPSHOT</version>
 
 	<name>Spring HATEOAS</name>
 	<url>https://github.com/SpringSource/spring-hateoas</url>
@@ -115,6 +115,39 @@
 			</build>
 
 		</profile>
+
+		<profile>
+			<id>snapshot</id>
+
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.jfrog.buildinfo</groupId>
+						<artifactId>artifactory-maven-plugin</artifactId>
+						<version>2.6.1</version>
+						<inherited>false</inherited>
+						<executions>
+							<execution>
+								<id>build-info</id>
+								<goals>
+									<goal>publish</goal>
+								</goals>
+								<configuration>
+									<publisher>
+										<contextUrl>http://repo.spring.io</contextUrl>
+										<username>{{USERNAME}}</username>
+										<password>{{PASSWORD}}</password>
+										<repoKey>libs-snapshot-local</repoKey>
+										<snapshotRepoKey>libs-snapshot-local</snapshotRepoKey>
+									</publisher>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
 
 		<profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
 								</goals>
 								<configuration>
 									<publisher>
-										<contextUrl>http://repo.spring.io</contextUrl>
+										<contextUrl>https://repo.spring.io</contextUrl>
 										<username>{{USERNAME}}</username>
 										<password>{{PASSWORD}}</password>
 										<repoKey>libs-snapshot-local</repoKey>

--- a/src/main/asciidoc/configuration.adoc
+++ b/src/main/asciidoc/configuration.adoc
@@ -6,7 +6,7 @@ This section describes how to configure Spring HATEOAS.
 [[configuration.at-enable]]
 == Using `@EnableHypermediaSupport`
 
-To let the `RepresentationModel` subtypes be rendered according to the specification of various hypermedia representations types, you can activate support for a particular hypermedia representation format through `@EnableHypermediaSupport`. The annotation takes a `HypermediaType` enumeration as its argument. Currently, we support http://tools.ietf.org/html/draft-kelly-json-hal[HAL] as well as a default rendering. Using the annotation triggers the following:
+To let the `RepresentationModel` subtypes be rendered according to the specification of various hypermedia representations types, you can activate support for a particular hypermedia representation format through `@EnableHypermediaSupport`. The annotation takes a `HypermediaType` enumeration as its argument. Currently, we support https://tools.ietf.org/html/draft-kelly-json-hal[HAL] as well as a default rendering. Using the annotation triggers the following:
 
 * It registers necessary Jackson modules to render `EntityModel` and `CollectionModel` in the hypermedia specific format.
 * If JSONPath is on the classpath, it automatically registers a `LinkDiscoverer` instance to look up links by their `rel` in plain JSON representations (see <<client.link-discoverer>>).

--- a/src/main/java/org/springframework/hateoas/config/WebClientConfigurer.java
+++ b/src/main/java/org/springframework/hateoas/config/WebClientConfigurer.java
@@ -1,16 +1,10 @@
 package org.springframework.hateoas.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.codec.CharSequenceEncoder;
 import org.springframework.core.codec.Decoder;
 import org.springframework.core.codec.Encoder;
-import org.springframework.core.codec.StringDecoder;
 import org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType;
 import org.springframework.http.codec.json.Jackson2JsonDecoder;
 import org.springframework.http.codec.json.Jackson2JsonEncoder;
@@ -18,7 +12,9 @@ import org.springframework.util.MimeType;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Assembles {@link ExchangeStrategies} needed to wire a {@link WebClient} with hypermedia support.
@@ -52,15 +48,11 @@ public class WebClientConfigurer {
 			decoders.add(new Jackson2JsonDecoder(objectMapper, mimeTypes));
 		});
 
-		encoders.add(CharSequenceEncoder.allMimeTypes());
-		decoders.add(StringDecoder.allMimeTypes());
-
 		return ExchangeStrategies.builder().codecs(clientCodecConfigurer -> {
 
 			encoders.forEach(encoder -> clientCodecConfigurer.customCodecs().encoder(encoder));
 			decoders.forEach(decoder -> clientCodecConfigurer.customCodecs().decoder(decoder));
 
-			clientCodecConfigurer.registerDefaults(false);
 		}).build();
 	}
 


### PR DESCRIPTION
Spring Framework 5.1 puts custom encoders and decoders in the wrong place, so Spring HATEOAS can't properly register with WebFlux. To make Spring HATEOS media types work requires overriding features that break other toolkits, like Spring Cloud Sleuth. However, in Spring Framework 5.2, this is no longer needed, so we need only disable the registry when Spring Framework 5.1 is on the classpath.

Related issues: #885, https://github.com/spring-projects/spring-framework/issues/22612