### PR TITLE
URL Cleanup

### DIFF
--- a/src/main/asciidoc/configuration.adoc
+++ b/src/main/asciidoc/configuration.adoc
@@ -6,7 +6,7 @@ This section describes how to configure Spring HATEOAS.
 [[configuration.at-enable]]
 == Using `@EnableHypermediaSupport`
 
-To let the `RepresentationModel` subtypes be rendered according to the specification of various hypermedia representations types, you can activate support for a particular hypermedia representation format through `@EnableHypermediaSupport`. The annotation takes a `HypermediaType` enumeration as its argument. Currently, we support http://tools.ietf.org/html/draft-kelly-json-hal[HAL] as well as a default rendering. Using the annotation triggers the following:
+To let the `RepresentationModel` subtypes be rendered according to the specification of various hypermedia representations types, you can activate support for a particular hypermedia representation format through `@EnableHypermediaSupport`. The annotation takes a `HypermediaType` enumeration as its argument. Currently, we support https://tools.ietf.org/html/draft-kelly-json-hal[HAL] as well as a default rendering. Using the annotation triggers the following:
 
 * It registers necessary Jackson modules to render `EntityModel` and `CollectionModel` in the hypermedia specific format.
 * If JSONPath is on the classpath, it automatically registers a `LinkDiscoverer` instance to look up links by their `rel` in plain JSON representations (see <<client.link-discoverer>>).


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://alps.io (200) with 1 occurrences could not be migrated:  
   ([https](https://alps.io) result AnnotatedConnectException).
* [ ] http://alps.io/spec/ (200) with 6 occurrences could not be migrated:  
   ([https](https://alps.io/spec/) result AnnotatedConnectException).
* [ ] http://amundsen.com/media-types/collection/ (200) with 1 occurrences could not be migrated:  
   ([https](https://amundsen.com/media-types/collection/) result AnnotatedConnectException).
* [ ] http://amundsen.com/media-types/collection/examples/ (200) with 7 occurrences could not be migrated:  
   ([https](https://amundsen.com/media-types/collection/examples/) result AnnotatedConnectException).
* [ ] http://amundsen.com/media-types/collection/format/ (200) with 2 occurrences could not be migrated:  
   ([https](https://amundsen.com/media-types/collection/format/) result AnnotatedConnectException).
* [ ] http://stateless.co/hal_specification.html (200) with 2 occurrences could not be migrated:  
   ([https](https://stateless.co/hal_specification.html) result SSLHandshakeException).
* [ ] http://users.monash.edu/~damian/papers/HTML/Plurals.html (200) with 1 occurrences could not be migrated:  
   ([https](https://users.monash.edu/~damian/papers/HTML/Plurals.html) result SSLHandshakeException).
* [ ] http://www.opensearch.org/Specifications/OpenSearch/1.1 (200) with 1 occurrences could not be migrated:  
   ([https](https://www.opensearch.org/Specifications/OpenSearch/1.1) result SSLHandshakeException).
* [ ] http://alps.io/ext/range (404) with 2 occurrences could not be migrated:  
   ([https](https://alps.io/ext/range) result AnnotatedConnectException).
* [ ] http://www.foo.com/bar (404) with 8 occurrences could not be migrated:  
   ([https](https://www.foo.com/bar) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://tools.ietf.org/html/draft-kelly-json-hal (301) with 1 occurrences migrated to:  
  https://tools.ietf.org/html/draft-kelly-json-hal ([https](https://tools.ietf.org/html/draft-kelly-json-hal) result ReadTimeoutException).

# Ignored
These URLs were intentionally ignored.

* http://barfoo:8888 with 2 occurrences
* http://foobar:8088 with 2 occurrences
* http://foobarhost/ with 2 occurrences
* http://foobarhost:9090/ with 2 occurrences
* http://localhost with 11 occurrences
* http://localhost/ with 1 occurrences
* http://localhost/customers/15 with 1 occurrences
* http://localhost/employees with 56 occurrences
* http://localhost/employees/0 with 34 occurrences
* http://localhost/employees/1 with 15 occurrences
* http://localhost/employees/2 with 24 occurrences
* http://localhost/sample/1/foo with 1 occurrences
* http://localhost/sample/2/bar with 1 occurrences
* http://localhost/something/bar/foo with 2 occurrences
* http://localhost:8080/ with 2 occurrences
* http://localhost:8080/api with 8 occurrences
* http://localhost:8080/api/ with 1 occurrences
* http://localhost:8080/api/employees with 4 occurrences
* http://localhost:8080/employees/1 with 4 occurrences
* http://localhost:8080/foo with 2 occurrences
* http://localhost:8080/my/custom/location with 2 occurrences
* http://localhost:8080/rels with 1 occurrences
* http://localhost:8080/rels/ with 6 occurrences
* http://localhost:8080/test?page=0&filter=foo,bar with 2 occurrences
* http://localhost:8080/your-app with 1 occurrences
* http://localhost:8080/your-app/people with 1 occurrences
* http://proxy1:1443 with 2 occurrences
* http://somethingDifferent with 2 occurrences
* http://www.w3.org/2005/Atom with 1 occurrences