### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -24,4 +24,4 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
 Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
 
-This Code of Conduct is adapted from the http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].
+This Code of Conduct is adapted from the https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,9 +1,9 @@
-image:https://spring.io/badges/spring-hateoas/ga.svg[http://projects.spring.io/spring-hateoas/#quick-start]
-image:https://spring.io/badges/spring-hateoas/snapshot.svg[http://projects.spring.io/spring-hateoas/#quick-start]
+image:https://spring.io/badges/spring-hateoas/ga.svg[https://projects.spring.io/spring-hateoas/#quick-start]
+image:https://spring.io/badges/spring-hateoas/snapshot.svg[https://projects.spring.io/spring-hateoas/#quick-start]
 
 = Spring HATEOAS
 
-This project provides some APIs to ease creating REST representations that follow the http://en.wikipedia.org/wiki/HATEOAS[HATEOAS] principle when working with Spring and especially Spring MVC. The core problem it tries to address is link creation and representation assembly.
+This project provides some APIs to ease creating REST representations that follow the https://en.wikipedia.org/wiki/HATEOAS[HATEOAS] principle when working with Spring and especially Spring MVC. The core problem it tries to address is link creation and representation assembly.
 
 == Working with Spring HATEOAS
 
@@ -16,6 +16,6 @@ git config core.commentchar "/"
 
 == Resources
 
-* Reference documentation - http://docs.spring.io/spring-hateoas/docs/current/reference/html/[html], http://docs.spring.io/spring-hateoas/docs/current/reference/pdf/spring-hateoas-reference.pdf[pdf]
-* http://docs.spring.io/spring-hateoas/docs/current-SNAPSHOT/api/[JavaDoc]
+* Reference documentation - https://docs.spring.io/spring-hateoas/docs/current/reference/html/[html], https://docs.spring.io/spring-hateoas/docs/current/reference/pdf/spring-hateoas-reference.pdf[pdf]
+* https://docs.spring.io/spring-hateoas/docs/current-SNAPSHOT/api/[JavaDoc]
 * https://spring.io/guides/gs/rest-hateoas/[Getting started guide]

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -6,7 +6,7 @@ Oliver Gierke, Greg Turnquist;
 :toc-placement!:
 
 
-This project provides some APIs to ease creating REST representations that follow the http://en.wikipedia.org/wiki/HATEOAS[HATEOAS] principle when working with Spring and especially Spring MVC. The core problem it tries to address is link creation and representation assembly.
+This project provides some APIs to ease creating REST representations that follow the https://en.wikipedia.org/wiki/HATEOAS[HATEOAS] principle when working with Spring and especially Spring MVC. The core problem it tries to address is link creation and representation assembly.
 
 (C) 2012-2015 The original authors.
 
@@ -290,7 +290,7 @@ List<PersonResource> resources = assembler.toResources(people);
 
 [[configuration.at-enable]]
 === @EnableHypermediaSupport
-To enable the `ResourceSupport` subtypes be rendered according to the specification of various hypermedia representations types, the support for a particular hypermedia representation format can be activated through `@EnableHypermediaSupport`. The annotation takes a `HypermediaType` enumeration as argument. Currently we support http://tools.ietf.org/html/draft-kelly-json-hal[HAL] as well as a default rendering. Using the annotation triggers the following:
+To enable the `ResourceSupport` subtypes be rendered according to the specification of various hypermedia representations types, the support for a particular hypermedia representation format can be activated through `@EnableHypermediaSupport`. The annotation takes a `HypermediaType` enumeration as argument. Currently we support https://tools.ietf.org/html/draft-kelly-json-hal[HAL] as well as a default rendering. Using the annotation triggers the following:
 
 * registers necessary Jackson modules to render `Resource`/`Resources` in the hypermedia specific format.
 * if JSONPath is on the classpath, it automatically registers a `LinkDiscoverer` instance to lookup links by their `rel` in plain JSON representations (see <<client.link-discoverer>>).
@@ -316,7 +316,7 @@ A `RelProvider` is exposed as Spring bean when using `@EnableHypermediaSupport` 
 [[spis.curie-provider]]
 === CurieProvider API
 
-The http://tools.ietf.org/html/rfc5988=section-4[Web Linking RFC] describes registered and extension link relation types. Registered rels are well-known strings registered with the http://www.iana.org/assignments/link-relations/link-relations.xhtml[IANA registry of link relation types]. Extension rels can be used by applications that do not wish to register a relation type. They are a URI that uniquely identifies the relation type. The rel URI can be serialized as a compact URI or http://www.w3.org/TR/curie[Curie]. E.g. a curie `ex:persons` stands for the link relation type `http://example.com/rels/persons` if `ex` is defined as `http://example.com/rels/{rel}`. If curies are used, the base URI must be present in the response scope.
+The https://tools.ietf.org/html/rfc5988=section-4[Web Linking RFC] describes registered and extension link relation types. Registered rels are well-known strings registered with the https://www.iana.org/assignments/link-relations/link-relations.xhtml[IANA registry of link relation types]. Extension rels can be used by applications that do not wish to register a relation type. They are a URI that uniquely identifies the relation type. The rel URI can be serialized as a compact URI or https://www.w3.org/TR/curie[Curie]. E.g. a curie `ex:persons` stands for the link relation type `https://example.com/rels/persons` if `ex` is defined as `https://example.com/rels/{rel}`. If curies are used, the base URI must be present in the response scope.
 
 The rels created by the default `RelProvider` are extension relation types and as such must be URIs, which can cause a lot of overhead. The `CurieProvider` API takes care of that: it allows to define a base URI as URI template and a prefix which stands for that base URI. If a `CurieProvider` is present, the `RelProvider` prepends all rels with the curie prefix. Furthermore a `curies` link is automatically added to the HAL resource.
 
@@ -331,7 +331,7 @@ public class Config {
 
   @Bean
   public CurieProvider curieProvider() {
-    return new DefaultCurieProvider("ex", new UriTemplate("http://www.example.com/rels/{rel}"));
+    return new DefaultCurieProvider("ex", new UriTemplate("https://www.example.com/rels/{rel}"));
   }
 }
 ----
@@ -345,7 +345,7 @@ Note that now the prefix `ex:` automatically appears before all rels which are n
     "self" : { href: "http://myhost/person/1" },
     "curies" : {
          "name" : "ex",
-         "href" : "http://example.com/rels/{rel}",
+         "href" : "https://example.com/rels/{rel}",
          "templated" : true
     },
     "ex:orders" : { href : "http://myhost/person/1/orders" }

--- a/src/main/java/org/springframework/hateoas/IanaRels.java
+++ b/src/main/java/org/springframework/hateoas/IanaRels.java
@@ -25,7 +25,7 @@ import java.util.HashSet;
 /**
  * Static class to find out whether a relation type is defined by the IANA.
  * 
- * @see http://www.iana.org/assignments/link-relations/link-relations.xhtml
+ * @see https://www.iana.org/assignments/link-relations/link-relations.xhtml
  * @author Oliver Gierke
  * @author Roland Kulcsár
  */

--- a/src/main/java/org/springframework/hateoas/QueryParameter.java
+++ b/src/main/java/org/springframework/hateoas/QueryParameter.java
@@ -19,7 +19,7 @@ import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
 /**
- * Web framework-neutral representation of a web request's query parameter (http://example.com?name=foo).
+ * Web framework-neutral representation of a web request's query parameter (https://example.com?name=foo).
  *
  * @author Greg Turnquist
  */

--- a/src/main/java/org/springframework/hateoas/UriTemplate.java
+++ b/src/main/java/org/springframework/hateoas/UriTemplate.java
@@ -36,7 +36,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  * Custom URI template to support qualified URI template variables.
  * 
  * @author Oliver Gierke
- * @see http://tools.ietf.org/html/rfc6570
+ * @see https://tools.ietf.org/html/rfc6570
  * @since 0.9
  */
 public class UriTemplate implements Iterable<TemplateVariable>, Serializable {

--- a/src/main/java/org/springframework/hateoas/config/EnableHypermediaSupport.java
+++ b/src/main/java/org/springframework/hateoas/config/EnableHypermediaSupport.java
@@ -67,7 +67,7 @@ public @interface EnableHypermediaSupport {
 		 * HAL - Hypermedia Application Language.
 		 * 
 		 * @see http://stateless.co/hal_specification.html
-		 * @see http://tools.ietf.org/html/draft-kelly-json-hal-05
+		 * @see https://tools.ietf.org/html/draft-kelly-json-hal-05
 		 */
 		HAL,
 

--- a/src/main/java/org/springframework/hateoas/core/EvoInflectorRelProvider.java
+++ b/src/main/java/org/springframework/hateoas/core/EvoInflectorRelProvider.java
@@ -22,7 +22,7 @@ import org.springframework.hateoas.RelProvider;
  * {@link RelProvider} implementation using the Evo Inflector implementation of an algorithmic approach to English
  * plurals.
  * 
- * @see http://www.csse.monash.edu.au/~damian/papers/HTML/Plurals.html
+ * @see http://users.monash.edu/~damian/papers/HTML/Plurals.html
  * @author Oliver Gierke
  */
 public class EvoInflectorRelProvider extends DefaultRelProvider {

--- a/src/main/java/org/springframework/hateoas/hal/CurieProvider.java
+++ b/src/main/java/org/springframework/hateoas/hal/CurieProvider.java
@@ -23,7 +23,7 @@ import org.springframework.hateoas.Links;
 /**
  * API to provide HAL curie information for links.
  * 
- * @see http://tools.ietf.org/html/draft-kelly-json-hal#section-8.2
+ * @see https://tools.ietf.org/html/draft-kelly-json-hal#section-8.2
  * @author Oliver Gierke
  * @author Jeff Stano
  * @since 0.9

--- a/src/main/java/org/springframework/hateoas/hal/forms/HalFormsProperty.java
+++ b/src/main/java/org/springframework/hateoas/hal/forms/HalFormsProperty.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
  * Describe a parameter for the associated state transition in a HAL-FORMS document. A {@link HalFormsTemplate} may
  * contain a list of {@link HalFormsProperty}s
  * 
- * @see http://mamund.site44.com/misc/hal-forms/
+ * @see https://mamund.site44.com/misc/hal-forms/
  */
 @JsonInclude(Include.NON_DEFAULT)
 @Value

--- a/src/main/java/org/springframework/hateoas/mvc/ForwardedHeader.java
+++ b/src/main/java/org/springframework/hateoas/mvc/ForwardedHeader.java
@@ -32,7 +32,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  * Value object to partially implement the {@literal Forwarded} header defined in RFC 7239.
  *
  * @author Oliver Gierke
- * @see http://tools.ietf.org/html/rfc7239
+ * @see https://tools.ietf.org/html/rfc7239
  * @deprecated In Spring 5.1, all Forwarded headers will by handled by Spring MVC.
  */
 @Deprecated

--- a/src/main/resources/license.txt
+++ b/src/main/resources/license.txt
@@ -207,7 +207,7 @@ similar licenses that require the source code and/or modifications to
 source code to be made available (as would be noted above), you may obtain a 
 copy of the source code corresponding to the binaries for such open source 
 components and modifications thereto, if any, (the "Source Files"), by 
-downloading the Source Files from http://www.springsource.org/download, 
+downloading the Source Files from https://www.springsource.org/download, 
 or by sending a request, with your name and address to: VMware, Inc., 3401 Hillview 
 Avenue, Palo Alto, CA 94304, United States of America or email info@vmware.com.  All 
 such requests should clearly specify:  OPEN SOURCE FILES REQUEST, Attention General 

--- a/src/test/java/org/springframework/hateoas/LinkUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/LinkUnitTest.java
@@ -137,14 +137,14 @@ public class LinkUnitTest {
 					+ "media=\"pdf\";" //
 					+ "title=\"pdf customer copy\";" //
 					+ "type=\"portable document\";" //
-					+ "deprecation=\"http://example.com/customers/deprecated\";" //
+					+ "deprecation=\"https://example.com/customers/deprecated\";" //
 					+ "profile=\"my-profile\"")) //
 					.isEqualTo(new Link("/customer/1") //
 							.withHreflang("en") //
 							.withMedia("pdf") //
 							.withTitle("pdf customer copy") //
 							.withType("portable document") //
-							.withDeprecation("http://example.com/customers/deprecated").withProfile("my-profile"));
+							.withDeprecation("https://example.com/customers/deprecated").withProfile("my-profile"));
 		});
 	}
 
@@ -248,8 +248,8 @@ public class LinkUnitTest {
 	@Test
 	public void parsesUriLinkRelations() {
 
-		assertThat(Link.valueOf("<http://localhost>; rel=\"http://acme.com/rels/foo-bar\"").getRel()) //
-				.isEqualTo("http://acme.com/rels/foo-bar");
+		assertThat(Link.valueOf("<http://localhost>; rel=\"https://acme.com/rels/foo-bar\"").getRel()) //
+				.isEqualTo("https://acme.com/rels/foo-bar");
 	}
 
 	/**

--- a/src/test/java/org/springframework/hateoas/VndErrorsMarshallingTest.java
+++ b/src/test/java/org/springframework/hateoas/VndErrorsMarshallingTest.java
@@ -60,9 +60,9 @@ public class VndErrorsMarshallingTest {
 		String json = read(new ClassPathResource("vnderror-single-item.json"));
 
 		VndError error = new VndError("Validation failed", "/username", 42, //
-			new Link("http://path.to/user/resource/1", VndErrors.REL_ABOUT),
-			new Link("http://path.to/describes", VndErrors.REL_DESCRIBES),
-			new Link("http://path.to/help", VndErrors.REL_HELP));
+			new Link("https://path.to/user/resource/1", VndErrors.REL_ABOUT),
+			new Link("https://path.to/describes", VndErrors.REL_DESCRIBES),
+			new Link("https://path.to/help", VndErrors.REL_HELP));
 
 		assertThat(mapper.readValue(json, VndError.class)).isEqualTo(error);
 	}
@@ -74,9 +74,9 @@ public class VndErrorsMarshallingTest {
 	public void singleItemVndErrorShouldSerialize() throws IOException {
 
 		VndError error = new VndError("Validation failed", "/username", 42, //
-			new Link("http://path.to/user/resource/1", VndErrors.REL_ABOUT),
-			new Link("http://path.to/describes", VndErrors.REL_DESCRIBES),
-			new Link("http://path.to/help", VndErrors.REL_HELP));
+			new Link("https://path.to/user/resource/1", VndErrors.REL_ABOUT),
+			new Link("https://path.to/describes", VndErrors.REL_DESCRIBES),
+			new Link("https://path.to/help", VndErrors.REL_HELP));
 
 		String json = read(new ClassPathResource("vnderror-single-item.json"));
 
@@ -93,10 +93,10 @@ public class VndErrorsMarshallingTest {
 		String json = read(new ClassPathResource("vnderrors-multiple-item.json"));
 
 		VndError error1 = new VndError("\"username\" field validation failed", null, 50, //
-			new Link("http://.../", VndErrors.REL_HELP));
+			new Link("https://.../", VndErrors.REL_HELP));
 
 		VndError error2 = new VndError("\"postcode\" field validation failed", null, 55, //
-			new Link("http://.../", VndErrors.REL_HELP));
+			new Link("https://.../", VndErrors.REL_HELP));
 
 		VndErrors vndErrors = new VndErrors().withError(error1).withError(error2);
 
@@ -110,10 +110,10 @@ public class VndErrorsMarshallingTest {
 	public void multipleItemVndErrorsShouldSerialize() throws IOException {
 
 		VndError error1 = new VndError("\"username\" field validation failed", null, 50, //
-			new Link("http://.../", VndErrors.REL_HELP));
+			new Link("https://.../", VndErrors.REL_HELP));
 
 		VndError error2 = new VndError("\"postcode\" field validation failed", null, 55, //
-			new Link("http://.../", VndErrors.REL_HELP));
+			new Link("https://.../", VndErrors.REL_HELP));
 
 		VndErrors vndErrors = new VndErrors().withError(error1).withError(error2);
 
@@ -131,13 +131,13 @@ public class VndErrorsMarshallingTest {
 		String json = read(new ClassPathResource("vnderrors-nested.json"));
 
 		VndError error = new VndError("Username must contain at least three characters", "/username", null, //
-			new Link("http://path.to/user/resource/1", VndErrors.REL_ABOUT));
+			new Link("https://path.to/user/resource/1", VndErrors.REL_ABOUT));
 
 		VndErrors vndErrors = new VndErrors()
 			.withError(error)
-			.withLink(new Link("http://path.to/describes").withRel(VndErrors.REL_DESCRIBES))
-			.withLink(new Link("http://path.to/help").withRel(VndErrors.REL_HELP))
-			.withLink(new Link("http://path.to/user/resource/1").withRel(VndErrors.REL_ABOUT))
+			.withLink(new Link("https://path.to/describes").withRel(VndErrors.REL_DESCRIBES))
+			.withLink(new Link("https://path.to/help").withRel(VndErrors.REL_HELP))
+			.withLink(new Link("https://path.to/user/resource/1").withRel(VndErrors.REL_ABOUT))
 			.withMessage("Validation failed")
 			.withLogref(42);
 
@@ -151,13 +151,13 @@ public class VndErrorsMarshallingTest {
 	public void nestedVndErrorsShouldSerialize() throws IOException {
 
 		VndError error = new VndError("Username must contain at least three characters", "/username", null, //
-			new Link("http://path.to/user/resource/1", VndErrors.REL_ABOUT));
+			new Link("https://path.to/user/resource/1", VndErrors.REL_ABOUT));
 
 		VndErrors vndErrors = new VndErrors()
 			.withError(error)
-			.withLink(new Link("http://path.to/describes").withRel(VndErrors.REL_DESCRIBES))
-			.withLink(new Link("http://path.to/help").withRel(VndErrors.REL_HELP))
-			.withLink(new Link("http://path.to/user/resource/1").withRel(VndErrors.REL_ABOUT))
+			.withLink(new Link("https://path.to/describes").withRel(VndErrors.REL_DESCRIBES))
+			.withLink(new Link("https://path.to/help").withRel(VndErrors.REL_HELP))
+			.withLink(new Link("https://path.to/user/resource/1").withRel(VndErrors.REL_ABOUT))
 			.withMessage("Validation failed")
 			.withLogref(42);
 

--- a/src/test/java/org/springframework/hateoas/alps/AlpsLinkDiscoverUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/alps/AlpsLinkDiscoverUnitTest.java
@@ -40,7 +40,7 @@ public class AlpsLinkDiscoverUnitTest extends AbstractLinkDiscovererUnitTest {
 	@Test
 	public void discoversFullyQualifiedRel() {
 
-		Link link = getDiscoverer().findLinkWithRel("http://foo.com/bar", getInputString());
+		Link link = getDiscoverer().findLinkWithRel("http://www.foo.com/bar", getInputString());
 
 		assertThat(link).isNotNull();
 		assertThat(link.getHref()).isEqualTo("fullRelHref");

--- a/src/test/java/org/springframework/hateoas/alps/JacksonSerializationTest.java
+++ b/src/test/java/org/springframework/hateoas/alps/JacksonSerializationTest.java
@@ -56,7 +56,7 @@ public class JacksonSerializationTest {
 	public void writesSampleDocument() throws Exception {
 
 		Alps alps = alps().//
-				doc(doc().href("http://example.org/samples/full/doc.html").build()). //
+				doc(doc().href("https://example.org/samples/full/doc.html").build()). //
 				descriptor(Arrays.asList(//
 						descriptor().id("search").type(Type.SAFE).//
 								doc(new Doc("A search form with two inputs.", Format.TEXT)).//

--- a/src/test/java/org/springframework/hateoas/client/TraversonTest.java
+++ b/src/test/java/org/springframework/hateoas/client/TraversonTest.java
@@ -150,7 +150,7 @@ public class TraversonTest {
 	@Test
 	public void sendsConfiguredHeadersForJsonPathExpression() {
 
-		String expectedHeader = "<http://www.example.com>;rel=\"home\"";
+		String expectedHeader = "<https://www.example.com>;rel=\"home\"";
 
 		HttpHeaders headers = new HttpHeaders();
 		headers.add("Link", expectedHeader);
@@ -169,7 +169,7 @@ public class TraversonTest {
 	@Test
 	public void sendsConfiguredHeadersForToEntity() {
 
-		String expectedHeader = "<http://www.example.com>;rel=\"home\"";
+		String expectedHeader = "<https://www.example.com>;rel=\"home\"";
 
 		HttpHeaders headers = new HttpHeaders();
 		headers.add("Link", expectedHeader);

--- a/src/test/java/org/springframework/hateoas/collectionjson/CollectionJsonLinkDiscovererUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/collectionjson/CollectionJsonLinkDiscovererUnitTest.java
@@ -49,7 +49,7 @@ public class CollectionJsonLinkDiscovererUnitTest {
 		Link link = this.discoverer.findLinkWithRel("self", specBasedJson);
 
 		assertThat(link).isNotNull();
-		assertThat(link.getHref()).isEqualTo("http://example.org/friends/");
+		assertThat(link.getHref()).isEqualTo("https://example.org/friends/");
 	}
 
 	@Test
@@ -60,29 +60,29 @@ public class CollectionJsonLinkDiscovererUnitTest {
 		Link selfLink = this.discoverer.findLinkWithRel("self", specBasedJson);
 
 		assertThat(selfLink).isNotNull();
-		assertThat(selfLink.getHref()).isEqualTo("http://example.org/friends/");
+		assertThat(selfLink.getHref()).isEqualTo("https://example.org/friends/");
 
 		Link feedLink = this.discoverer.findLinkWithRel("feed", specBasedJson);
 
 		assertThat(feedLink).isNotNull();
-		assertThat(feedLink.getHref()).isEqualTo("http://example.org/friends/rss");
+		assertThat(feedLink.getHref()).isEqualTo("https://example.org/friends/rss");
 
 		List<Link> links = this.discoverer.findLinksWithRel("blog", specBasedJson);
 
 		assertThat(links)
 			.extracting("href")
 			.containsExactlyInAnyOrder(
-				"http://examples.org/blogs/jdoe",
-				"http://examples.org/blogs/msmith",
-				"http://examples.org/blogs/rwilliams");
+				"https://examples.org/blogs/jdoe",
+				"https://examples.org/blogs/msmith",
+				"https://examples.org/blogs/rwilliams");
 
 		links = this.discoverer.findLinksWithRel("avatar", specBasedJson);
 
 		assertThat(links)
 			.extracting("href")
 			.containsExactlyInAnyOrder(
-				"http://examples.org/images/jdoe",
-				"http://examples.org/images/msmith",
-				"http://examples.org/images/rwilliams");
+				"https://examples.org/images/jdoe",
+				"https://examples.org/images/msmith",
+				"https://examples.org/images/rwilliams");
 	}
 }

--- a/src/test/java/org/springframework/hateoas/collectionjson/CollectionJsonSpecTest.java
+++ b/src/test/java/org/springframework/hateoas/collectionjson/CollectionJsonSpecTest.java
@@ -68,7 +68,7 @@ public class CollectionJsonSpecTest {
 		ResourceSupport resource = mapper.readValue(specBasedJson, ResourceSupport.class);
 
 		assertThat(resource.getLinks()).hasSize(1);
-		assertThat(resource.getRequiredLink(Link.REL_SELF)).isEqualTo(new Link("http://example.org/friends/"));
+		assertThat(resource.getRequiredLink(Link.REL_SELF)).isEqualTo(new Link("https://example.org/friends/"));
 	}
 
 	/**
@@ -85,29 +85,29 @@ public class CollectionJsonSpecTest {
 				mapper.getTypeFactory().constructParametricType(Resource.class, Friend.class)));
 
 		assertThat(resources.getLinks()).hasSize(2);
-		assertThat(resources.getRequiredLink(Link.REL_SELF)).isEqualTo(new Link("http://example.org/friends/"));
-		assertThat(resources.getRequiredLink("feed")).isEqualTo(new Link("http://example.org/friends/rss", "feed"));
+		assertThat(resources.getRequiredLink(Link.REL_SELF)).isEqualTo(new Link("https://example.org/friends/"));
+		assertThat(resources.getRequiredLink("feed")).isEqualTo(new Link("https://example.org/friends/rss", "feed"));
 		assertThat(resources.getContent()).hasSize(3);
 
 		List<Resource<Friend>> friends = new ArrayList<>(resources.getContent());
 
 		assertThat(friends.get(0).getContent().getEmail()).isEqualTo("jdoe@example.org");
 		assertThat(friends.get(0).getContent().getFullname()).isEqualTo("J. Doe");
-		assertThat(friends.get(0).getRequiredLink(Link.REL_SELF)).isEqualTo(new Link("http://example.org/friends/jdoe"));
-		assertThat(friends.get(0).getRequiredLink("blog")).isEqualTo(new Link("http://examples.org/blogs/jdoe", "blog"));
-		assertThat(friends.get(0).getRequiredLink("avatar")).isEqualTo(new Link("http://examples.org/images/jdoe", "avatar"));
+		assertThat(friends.get(0).getRequiredLink(Link.REL_SELF)).isEqualTo(new Link("https://example.org/friends/jdoe"));
+		assertThat(friends.get(0).getRequiredLink("blog")).isEqualTo(new Link("https://examples.org/blogs/jdoe", "blog"));
+		assertThat(friends.get(0).getRequiredLink("avatar")).isEqualTo(new Link("https://examples.org/images/jdoe", "avatar"));
 
 		assertThat(friends.get(1).getContent().getEmail()).isEqualTo("msmith@example.org");
 		assertThat(friends.get(1).getContent().getFullname()).isEqualTo("M. Smith");
-		assertThat(friends.get(1).getRequiredLink(Link.REL_SELF)).isEqualTo(new Link("http://example.org/friends/msmith"));
-		assertThat(friends.get(1).getRequiredLink("blog")).isEqualTo(new Link("http://examples.org/blogs/msmith", "blog"));
-		assertThat(friends.get(1).getRequiredLink("avatar")).isEqualTo(new Link("http://examples.org/images/msmith", "avatar"));
+		assertThat(friends.get(1).getRequiredLink(Link.REL_SELF)).isEqualTo(new Link("https://example.org/friends/msmith"));
+		assertThat(friends.get(1).getRequiredLink("blog")).isEqualTo(new Link("https://examples.org/blogs/msmith", "blog"));
+		assertThat(friends.get(1).getRequiredLink("avatar")).isEqualTo(new Link("https://examples.org/images/msmith", "avatar"));
 
 		assertThat(friends.get(2).getContent().getEmail()).isEqualTo("rwilliams@example.org");
 		assertThat(friends.get(2).getContent().getFullname()).isEqualTo("R. Williams");
-		assertThat(friends.get(2).getRequiredLink(Link.REL_SELF)).isEqualTo(new Link("http://example.org/friends/rwilliams"));
-		assertThat(friends.get(2).getRequiredLink("blog")).isEqualTo(new Link("http://examples.org/blogs/rwilliams", "blog"));
-		assertThat(friends.get(2).getRequiredLink("avatar")).isEqualTo(new Link("http://examples.org/images/rwilliams", "avatar"));
+		assertThat(friends.get(2).getRequiredLink(Link.REL_SELF)).isEqualTo(new Link("https://example.org/friends/rwilliams"));
+		assertThat(friends.get(2).getRequiredLink("blog")).isEqualTo(new Link("https://examples.org/blogs/rwilliams", "blog"));
+		assertThat(friends.get(2).getRequiredLink("avatar")).isEqualTo(new Link("https://examples.org/images/rwilliams", "avatar"));
 	}
 
 	/**
@@ -123,12 +123,12 @@ public class CollectionJsonSpecTest {
 				mapper.getTypeFactory().constructParametricType(Resource.class, Friend.class));
 
 		assertThat(resource.getLinks()).hasSize(6);
-		assertThat(resource.getRequiredLink(Link.REL_SELF)).isEqualTo(new Link("http://example.org/friends/jdoe"));
-		assertThat(resource.getRequiredLink("feed")).isEqualTo(new Link("http://example.org/friends/rss", "feed"));
-		assertThat(resource.getRequiredLink("queries")).isEqualTo(new Link("http://example.org/friends/?queries", "queries"));
-		assertThat(resource.getRequiredLink("template")).isEqualTo(new Link("http://example.org/friends/?template", "template"));
-		assertThat(resource.getRequiredLink("blog")).isEqualTo(new Link("http://examples.org/blogs/jdoe", "blog"));
-		assertThat(resource.getRequiredLink("avatar")).isEqualTo(new Link("http://examples.org/images/jdoe", "avatar"));
+		assertThat(resource.getRequiredLink(Link.REL_SELF)).isEqualTo(new Link("https://example.org/friends/jdoe"));
+		assertThat(resource.getRequiredLink("feed")).isEqualTo(new Link("https://example.org/friends/rss", "feed"));
+		assertThat(resource.getRequiredLink("queries")).isEqualTo(new Link("https://example.org/friends/?queries", "queries"));
+		assertThat(resource.getRequiredLink("template")).isEqualTo(new Link("https://example.org/friends/?template", "template"));
+		assertThat(resource.getRequiredLink("blog")).isEqualTo(new Link("https://examples.org/blogs/jdoe", "blog"));
+		assertThat(resource.getRequiredLink("avatar")).isEqualTo(new Link("https://examples.org/images/jdoe", "avatar"));
 
 		assertThat(resource.getContent().getEmail()).isEqualTo("jdoe@example.org");
 		assertThat(resource.getContent().getFullname()).isEqualTo("J. Doe");
@@ -148,7 +148,7 @@ public class CollectionJsonSpecTest {
 				mapper.getTypeFactory().constructParametricType(Resource.class, Friend.class)));
 
 		assertThat(resources.getContent()).hasSize(0);
-		assertThat(resources.getRequiredLink(Link.REL_SELF)).isEqualTo(new Link("http://example.org/friends/"));
+		assertThat(resources.getRequiredLink(Link.REL_SELF)).isEqualTo(new Link("https://example.org/friends/"));
 	}
 	/**
 	 * @see http://amundsen.com/media-types/collection/examples/ - Section 5. Template Representation
@@ -164,7 +164,7 @@ public class CollectionJsonSpecTest {
 				mapper.getTypeFactory().constructParametricType(Resource.class, Friend.class)));
 		
 		assertThat(resources.getContent()).hasSize(0);
-		assertThat(resources.getRequiredLink(Link.REL_SELF)).isEqualTo(new Link("http://example.org/friends/"));
+		assertThat(resources.getRequiredLink(Link.REL_SELF)).isEqualTo(new Link("https://example.org/friends/"));
 	}
 	/**
 	 * @see http://amundsen.com/media-types/collection/examples/ - Section 6. Error Representation
@@ -180,7 +180,7 @@ public class CollectionJsonSpecTest {
 				mapper.getTypeFactory().constructParametricType(Resource.class, Friend.class)));
 
 		assertThat(resources.getContent()).hasSize(0);
-		assertThat(resources.getRequiredLink(Link.REL_SELF)).isEqualTo(new Link("http://example.org/friends/"));
+		assertThat(resources.getRequiredLink(Link.REL_SELF)).isEqualTo(new Link("https://example.org/friends/"));
 	}
 	/**
 	 * @see http://amundsen.com/media-types/collection/examples/ - Section 7. Write Representation

--- a/src/test/java/org/springframework/hateoas/hal/DefaultCurieProviderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/hal/DefaultCurieProviderUnitTest.java
@@ -69,17 +69,17 @@ public class DefaultCurieProviderUnitTest {
 
 	@Test
 	public void doesNotPrefixIanaRels() {
-		assertThat(provider.getNamespacedRelFrom(new Link("http://amazon.com"))).isEqualTo("self");
+		assertThat(provider.getNamespacedRelFrom(new Link("https://amazon.com"))).isEqualTo("self");
 	}
 
 	@Test
 	public void prefixesNormalRels() {
-		assertThat(provider.getNamespacedRelFrom(new Link("http://amazon.com", "book"))).isEqualTo("acme:book");
+		assertThat(provider.getNamespacedRelFrom(new Link("https://amazon.com", "book"))).isEqualTo("acme:book");
 	}
 
 	@Test
 	public void doesNotPrefixQualifiedRels() {
-		assertThat(provider.getNamespacedRelFrom(new Link("http://amazon.com", "custom:rel"))).isEqualTo("custom:rel");
+		assertThat(provider.getNamespacedRelFrom(new Link("https://amazon.com", "custom:rel"))).isEqualTo("custom:rel");
 	}
 
 	/**
@@ -88,12 +88,12 @@ public class DefaultCurieProviderUnitTest {
 	@Test
 	public void prefixesNormalRelsThatHaveExtraRFC5988Attributes() {
 
-		Link link = new Link("http://amazon.com", "custom:rel") //
+		Link link = new Link("https://amazon.com", "custom:rel") //
 				.withHreflang("en") //
 				.withTitle("the title") //
 				.withMedia("the media") //
 				.withType("the type") //
-				.withDeprecation("http://example.com/custom/deprecated");
+				.withDeprecation("https://example.com/custom/deprecated");
 
 		assertThat(provider.getNamespacedRelFrom(link)).isEqualTo("custom:rel");
 	}

--- a/src/test/java/org/springframework/hateoas/hal/HalLinkDiscovererUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/hal/HalLinkDiscovererUnitTest.java
@@ -33,7 +33,7 @@ public class HalLinkDiscovererUnitTest extends AbstractLinkDiscovererUnitTest {
 	static final LinkDiscoverer discoverer = new HalLinkDiscoverer();
 	static final String SAMPLE = "{ _links : { self : { href : 'selfHref' }, " + //
 			"relation : [ { href : 'firstHref' }, { href : 'secondHref' }], " + //
-			"'http://foo.com/bar' : { href : 'fullRelHref' }, " + "}}";
+			"'http://www.foo.com/bar' : { href : 'fullRelHref' }, " + "}}";
 
 	/**
 	 * @see #314
@@ -41,7 +41,7 @@ public class HalLinkDiscovererUnitTest extends AbstractLinkDiscovererUnitTest {
 	@Test
 	public void discoversFullyQualifiedRel() {
 
-		Link link = getDiscoverer().findLinkWithRel("http://foo.com/bar", SAMPLE);
+		Link link = getDiscoverer().findLinkWithRel("http://www.foo.com/bar", SAMPLE);
 
 		assertThat(link).isNotNull();
 		assertThat(link.getHref()).isEqualTo("fullRelHref");

--- a/src/test/java/org/springframework/hateoas/hal/forms/HalFormsLinkDiscovererUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/hal/forms/HalFormsLinkDiscovererUnitTest.java
@@ -33,14 +33,14 @@ public class HalFormsLinkDiscovererUnitTest extends AbstractLinkDiscovererUnitTe
 	static final LinkDiscoverer discoverer = new HalFormsLinkDiscoverer();
 	static final String SAMPLE = "{ _links : { self : { href : 'selfHref' }, " + //
 			"relation : [ { href : 'firstHref' }, { href : 'secondHref' }], " + //
-			"'http://foo.com/bar' : { href : 'fullRelHref' }, " + "}}";
+			"'http://www.foo.com/bar' : { href : 'fullRelHref' }, " + "}}";
 
 	/**
 	 * @see #314
 	 */
 	@Test
 	public void discoversFullyQualifiedRel() {
-		assertThat(getDiscoverer().findLinkWithRel("http://foo.com/bar", SAMPLE), is(notNullValue()));
+		assertThat(getDiscoverer().findLinkWithRel("http://www.foo.com/bar", SAMPLE), is(notNullValue()));
 	}
 
 	@Override

--- a/src/test/resources/org/springframework/hateoas/alps/link-discoverer.json
+++ b/src/test/resources/org/springframework/hateoas/alps/link-discoverer.json
@@ -1,7 +1,7 @@
 {
   "version" : "1.0",
   "doc" : {
-    "href" : "http://example.org/samples/full/doc.html"
+    "href" : "https://example.org/samples/full/doc.html"
   },
   "descriptors" : [ {
     "id" : "sfirst descriptor",
@@ -17,7 +17,7 @@
     "href" : "selfHref"
   }, {
     "id" : "fully qualified descriptor",
-    "name" : "http://foo.com/bar",
+    "name" : "http://www.foo.com/bar",
     "href" : "fullRelHref"
   } ]
 }

--- a/src/test/resources/org/springframework/hateoas/alps/reference.json
+++ b/src/test/resources/org/springframework/hateoas/alps/reference.json
@@ -1,7 +1,7 @@
 {
   "version" : "1.0",
   "doc" : {
-    "href" : "http://example.org/samples/full/doc.html"
+    "href" : "https://example.org/samples/full/doc.html"
   },
   "descriptor" : [ {
     "id" : "search",

--- a/src/test/resources/org/springframework/hateoas/collectionjson/spec-part1.json
+++ b/src/test/resources/org/springframework/hateoas/collectionjson/spec-part1.json
@@ -1,6 +1,6 @@
 {
   "collection": {
     "version": "1.0",
-    "href": "http://example.org/friends/"
+    "href": "https://example.org/friends/"
   }
 }

--- a/src/test/resources/org/springframework/hateoas/collectionjson/spec-part2.json
+++ b/src/test/resources/org/springframework/hateoas/collectionjson/spec-part2.json
@@ -1,16 +1,16 @@
 {
   "collection": {
     "version": "1.0",
-    "href": "http://example.org/friends/",
+    "href": "https://example.org/friends/",
     "links": [
       {
         "rel": "feed",
-        "href": "http://example.org/friends/rss"
+        "href": "https://example.org/friends/rss"
       }
     ],
     "items": [
       {
-        "href": "http://example.org/friends/jdoe",
+        "href": "https://example.org/friends/jdoe",
         "data": [
           {
             "name": "fullname",
@@ -26,19 +26,19 @@
         "links": [
           {
             "rel": "blog",
-            "href": "http://examples.org/blogs/jdoe",
+            "href": "https://examples.org/blogs/jdoe",
             "prompt": "Blog"
           },
           {
             "rel": "avatar",
-            "href": "http://examples.org/images/jdoe",
+            "href": "https://examples.org/images/jdoe",
             "prompt": "Avatar",
             "render": "image"
           }
         ]
       },
       {
-        "href": "http://example.org/friends/msmith",
+        "href": "https://example.org/friends/msmith",
         "data": [
           {
             "name": "fullname",
@@ -54,19 +54,19 @@
         "links": [
           {
             "rel": "blog",
-            "href": "http://examples.org/blogs/msmith",
+            "href": "https://examples.org/blogs/msmith",
             "prompt": "Blog"
           },
           {
             "rel": "avatar",
-            "href": "http://examples.org/images/msmith",
+            "href": "https://examples.org/images/msmith",
             "prompt": "Avatar",
             "render": "image"
           }
         ]
       },
       {
-        "href": "http://example.org/friends/rwilliams",
+        "href": "https://example.org/friends/rwilliams",
         "data": [
           {
             "name": "fullname",
@@ -82,12 +82,12 @@
         "links": [
           {
             "rel": "blog",
-            "href": "http://examples.org/blogs/rwilliams",
+            "href": "https://examples.org/blogs/rwilliams",
             "prompt": "Blog"
           },
           {
             "rel": "avatar",
-            "href": "http://examples.org/images/rwilliams",
+            "href": "https://examples.org/images/rwilliams",
             "prompt": "Avatar",
             "render": "image"
           }
@@ -97,7 +97,7 @@
     "queries": [
       {
         "rel": "search",
-        "href": "http://example.org/friends/search",
+        "href": "https://example.org/friends/search",
         "prompt": "Search",
         "data": [
           {

--- a/src/test/resources/org/springframework/hateoas/collectionjson/spec-part3.json
+++ b/src/test/resources/org/springframework/hateoas/collectionjson/spec-part3.json
@@ -1,24 +1,24 @@
 {
   "collection": {
     "version": "1.0",
-    "href": "http://example.org/friends/",
+    "href": "https://example.org/friends/",
     "links": [
       {
         "rel": "feed",
-        "href": "http://example.org/friends/rss"
+        "href": "https://example.org/friends/rss"
       },
       {
         "rel": "queries",
-        "href": "http://example.org/friends/?queries"
+        "href": "https://example.org/friends/?queries"
       },
       {
         "rel": "template",
-        "href": "http://example.org/friends/?template"
+        "href": "https://example.org/friends/?template"
       }
     ],
     "items": [
       {
-        "href": "http://example.org/friends/jdoe",
+        "href": "https://example.org/friends/jdoe",
         "data": [
           {
             "name": "fullname",
@@ -34,12 +34,12 @@
         "links": [
           {
             "rel": "blog",
-            "href": "http://examples.org/blogs/jdoe",
+            "href": "https://examples.org/blogs/jdoe",
             "prompt": "Blog"
           },
           {
             "rel": "avatar",
-            "href": "http://examples.org/images/jdoe",
+            "href": "https://examples.org/images/jdoe",
             "prompt": "Avatar",
             "render": "image"
           }

--- a/src/test/resources/org/springframework/hateoas/collectionjson/spec-part4.json
+++ b/src/test/resources/org/springframework/hateoas/collectionjson/spec-part4.json
@@ -1,11 +1,11 @@
 {
   "collection": {
     "version": "1.0",
-    "href": "http://example.org/friends/",
+    "href": "https://example.org/friends/",
     "queries": [
       {
         "rel": "search",
-        "href": "http://example.org/friends/search",
+        "href": "https://example.org/friends/search",
         "prompt": "Search",
         "data": [
           {

--- a/src/test/resources/org/springframework/hateoas/collectionjson/spec-part5.json
+++ b/src/test/resources/org/springframework/hateoas/collectionjson/spec-part5.json
@@ -1,7 +1,7 @@
 {
   "collection": {
     "version": "1.0",
-    "href": "http://example.org/friends/",
+    "href": "https://example.org/friends/",
     "template": {
       "data": [
         {

--- a/src/test/resources/org/springframework/hateoas/collectionjson/spec-part6.json
+++ b/src/test/resources/org/springframework/hateoas/collectionjson/spec-part6.json
@@ -1,7 +1,7 @@
 {
   "collection": {
     "version": "1.0",
-    "href": "http://example.org/friends/",
+    "href": "https://example.org/friends/",
     "error": {
       "title": "Server Error",
       "code": "X1C2",

--- a/src/test/resources/org/springframework/hateoas/collectionjson/spec-part7-adjusted.json
+++ b/src/test/resources/org/springframework/hateoas/collectionjson/spec-part7-adjusted.json
@@ -11,11 +11,11 @@
       },
       {
         "name": "blog",
-        "value": "http://example.org/blogs/wchandry"
+        "value": "https://example.org/blogs/wchandry"
       },
       {
         "name": "avatar",
-        "value": "http://example.org/images/wchandry"
+        "value": "https://example.org/images/wchandry"
       }
     ]
   }

--- a/src/test/resources/org/springframework/hateoas/collectionjson/spec-part7.json
+++ b/src/test/resources/org/springframework/hateoas/collectionjson/spec-part7.json
@@ -11,11 +11,11 @@
       },
       {
         "name": "blog",
-        "value": "http://example.org/blogs/wchandry"
+        "value": "https://example.org/blogs/wchandry"
       },
       {
         "name": "avatar",
-        "value": "http://example.org/images/wchandry"
+        "value": "https://example.org/images/wchandry"
       }
     ]
   }

--- a/src/test/resources/vnderror-single-item.json
+++ b/src/test/resources/vnderror-single-item.json
@@ -4,13 +4,13 @@
   "logref" : 42,
   "_links" : {
     "about" : {
-      "href" : "http://path.to/user/resource/1"
+      "href" : "https://path.to/user/resource/1"
     },
     "describes" : {
-      "href" : "http://path.to/describes"
+      "href" : "https://path.to/describes"
     },
     "help" : {
-      "href" : "http://path.to/help"
+      "href" : "https://path.to/help"
     }
   }
 }

--- a/src/test/resources/vnderrors-multiple-item.json
+++ b/src/test/resources/vnderrors-multiple-item.json
@@ -6,7 +6,7 @@
       "logref" : 50,
       "_links" : {
         "help" : {
-          "href" : "http://.../"
+          "href" : "https://.../"
         }
       }
     }, {
@@ -14,7 +14,7 @@
       "logref" : 55,
       "_links" : {
         "help" : {
-          "href" : "http://.../"
+          "href" : "https://.../"
         }
       }
     } ]

--- a/src/test/resources/vnderrors-nested.json
+++ b/src/test/resources/vnderrors-nested.json
@@ -4,13 +4,13 @@
   "total" : 1,
   "_links" : {
     "describes" : {
-      "href" : "http://path.to/describes"
+      "href" : "https://path.to/describes"
     },
     "help" : {
-      "href" : "http://path.to/help"
+      "href" : "https://path.to/help"
     },
     "about" : {
-      "href" : "http://path.to/user/resource/1"
+      "href" : "https://path.to/user/resource/1"
     }
   },
   "_embedded" : {
@@ -19,7 +19,7 @@
       "path" : "/username",
       "_links" : {
         "about" : {
-          "href" : "http://path.to/user/resource/1"
+          "href" : "https://path.to/user/resource/1"
         }
       }
     } ]


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://alps.io (200) with 1 occurrences could not be migrated:  
   ([https](https://alps.io) result AnnotatedConnectException).
* [ ] http://alps.io/spec/ (200) with 6 occurrences could not be migrated:  
   ([https](https://alps.io/spec/) result AnnotatedConnectException).
* [ ] http://amundsen.com/media-types/collection/examples/ (200) with 7 occurrences could not be migrated:  
   ([https](https://amundsen.com/media-types/collection/examples/) result AnnotatedConnectException).
* [ ] http://amundsen.com/media-types/collection/format/ (200) with 1 occurrences could not be migrated:  
   ([https](https://amundsen.com/media-types/collection/format/) result AnnotatedConnectException).
* [ ] http://stateless.co/hal_specification.html (200) with 2 occurrences could not be migrated:  
   ([https](https://stateless.co/hal_specification.html) result SSLHandshakeException).
* [ ] http://foo.com/bar (301) with 6 occurrences could not be migrated:  
   ([https](https://foo.com/bar) result SSLHandshakeException).
* [ ] http://www.csse.monash.edu.au/~damian/papers/HTML/Plurals.html (302) with 1 occurrences could not be migrated:  
   ([https](https://www.csse.monash.edu.au/~damian/papers/HTML/Plurals.html) result SSLHandshakeException).
* [ ] http://alps.io/ext/range (404) with 2 occurrences could not be migrated:  
   ([https](https://alps.io/ext/range) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://tools.ietf.org/html/draft-kelly-json-hal (301) with 2 occurrences migrated to:  
  https://tools.ietf.org/html/draft-kelly-json-hal ([https](https://tools.ietf.org/html/draft-kelly-json-hal) result ReadTimeoutException).
* [ ] http://.../ (UnknownHostException) with 6 occurrences migrated to:  
  https://.../ ([https](https://.../) result UnknownHostException).
* [ ] http://examples.org/blogs/jdoe (UnknownHostException) with 5 occurrences migrated to:  
  https://examples.org/blogs/jdoe ([https](https://examples.org/blogs/jdoe) result UnknownHostException).
* [ ] http://examples.org/blogs/msmith (UnknownHostException) with 3 occurrences migrated to:  
  https://examples.org/blogs/msmith ([https](https://examples.org/blogs/msmith) result UnknownHostException).
* [ ] http://examples.org/blogs/rwilliams (UnknownHostException) with 3 occurrences migrated to:  
  https://examples.org/blogs/rwilliams ([https](https://examples.org/blogs/rwilliams) result UnknownHostException).
* [ ] http://examples.org/images/jdoe (UnknownHostException) with 5 occurrences migrated to:  
  https://examples.org/images/jdoe ([https](https://examples.org/images/jdoe) result UnknownHostException).
* [ ] http://examples.org/images/msmith (UnknownHostException) with 3 occurrences migrated to:  
  https://examples.org/images/msmith ([https](https://examples.org/images/msmith) result UnknownHostException).
* [ ] http://examples.org/images/rwilliams (UnknownHostException) with 3 occurrences migrated to:  
  https://examples.org/images/rwilliams ([https](https://examples.org/images/rwilliams) result UnknownHostException).
* [ ] http://path.to/describes (UnknownHostException) with 6 occurrences migrated to:  
  https://path.to/describes ([https](https://path.to/describes) result UnknownHostException).
* [ ] http://path.to/help (UnknownHostException) with 6 occurrences migrated to:  
  https://path.to/help ([https](https://path.to/help) result UnknownHostException).
* [ ] http://path.to/user/resource/1 (UnknownHostException) with 9 occurrences migrated to:  
  https://path.to/user/resource/1 ([https](https://path.to/user/resource/1) result UnknownHostException).
* [ ] http://acme.com/rels/foo-bar (404) with 2 occurrences migrated to:  
  https://acme.com/rels/foo-bar ([https](https://acme.com/rels/foo-bar) result 404).
* [ ] http://docs.spring.io/spring-hateoas/docs/current-SNAPSHOT/api/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-hateoas/docs/current-SNAPSHOT/api/ ([https](https://docs.spring.io/spring-hateoas/docs/current-SNAPSHOT/api/) result 404).
* [ ] http://example.com/custom/deprecated (404) with 1 occurrences migrated to:  
  https://example.com/custom/deprecated ([https](https://example.com/custom/deprecated) result 404).
* [ ] http://example.com/customers/deprecated (404) with 2 occurrences migrated to:  
  https://example.com/customers/deprecated ([https](https://example.com/customers/deprecated) result 404).
* [ ] http://example.com/rels/ (404) with 2 occurrences migrated to:  
  https://example.com/rels/ ([https](https://example.com/rels/) result 404).
* [ ] http://example.com/rels/persons (404) with 1 occurrences migrated to:  
  https://example.com/rels/persons ([https](https://example.com/rels/persons) result 404).
* [ ] http://example.org/blogs/wchandry (404) with 2 occurrences migrated to:  
  https://example.org/blogs/wchandry ([https](https://example.org/blogs/wchandry) result 404).
* [ ] http://example.org/friends/ (404) with 13 occurrences migrated to:  
  https://example.org/friends/ ([https](https://example.org/friends/) result 404).
* [ ] http://example.org/friends/?queries (404) with 2 occurrences migrated to:  
  https://example.org/friends/?queries ([https](https://example.org/friends/?queries) result 404).
* [ ] http://example.org/friends/?template (404) with 2 occurrences migrated to:  
  https://example.org/friends/?template ([https](https://example.org/friends/?template) result 404).
* [ ] http://example.org/friends/jdoe (404) with 4 occurrences migrated to:  
  https://example.org/friends/jdoe ([https](https://example.org/friends/jdoe) result 404).
* [ ] http://example.org/friends/msmith (404) with 2 occurrences migrated to:  
  https://example.org/friends/msmith ([https](https://example.org/friends/msmith) result 404).
* [ ] http://example.org/friends/rss (404) with 5 occurrences migrated to:  
  https://example.org/friends/rss ([https](https://example.org/friends/rss) result 404).
* [ ] http://example.org/friends/rwilliams (404) with 2 occurrences migrated to:  
  https://example.org/friends/rwilliams ([https](https://example.org/friends/rwilliams) result 404).
* [ ] http://example.org/friends/search (404) with 2 occurrences migrated to:  
  https://example.org/friends/search ([https](https://example.org/friends/search) result 404).
* [ ] http://example.org/images/wchandry (404) with 2 occurrences migrated to:  
  https://example.org/images/wchandry ([https](https://example.org/images/wchandry) result 404).
* [ ] http://example.org/samples/full/doc.html (404) with 3 occurrences migrated to:  
  https://example.org/samples/full/doc.html ([https](https://example.org/samples/full/doc.html) result 404).
* [ ] http://www.example.com/rels/ (404) with 1 occurrences migrated to:  
  https://www.example.com/rels/ ([https](https://www.example.com/rels/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-hateoas/docs/current/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-hateoas/docs/current/reference/html/ ([https](https://docs.spring.io/spring-hateoas/docs/current/reference/html/) result 200).
* [ ] http://docs.spring.io/spring-hateoas/docs/current/reference/pdf/spring-hateoas-reference.pdf with 1 occurrences migrated to:  
  https://docs.spring.io/spring-hateoas/docs/current/reference/pdf/spring-hateoas-reference.pdf ([https](https://docs.spring.io/spring-hateoas/docs/current/reference/pdf/spring-hateoas-reference.pdf) result 200).
* [ ] http://en.wikipedia.org/wiki/HATEOAS with 2 occurrences migrated to:  
  https://en.wikipedia.org/wiki/HATEOAS ([https](https://en.wikipedia.org/wiki/HATEOAS) result 200).
* [ ] http://example.com?name=foo with 1 occurrences migrated to:  
  https://example.com?name=foo ([https](https://example.com?name=foo) result 200).
* [ ] http://mamund.site44.com/misc/hal-forms/ with 1 occurrences migrated to:  
  https://mamund.site44.com/misc/hal-forms/ ([https](https://mamund.site44.com/misc/hal-forms/) result 200).
* [ ] http://projects.spring.io/spring-hateoas/ with 2 occurrences migrated to:  
  https://projects.spring.io/spring-hateoas/ ([https](https://projects.spring.io/spring-hateoas/) result 200).
* [ ] http://tools.ietf.org/html/draft-kelly-json-hal-05 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/draft-kelly-json-hal-05 ([https](https://tools.ietf.org/html/draft-kelly-json-hal-05) result 200).
* [ ] http://tools.ietf.org/html/rfc6570 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc6570 ([https](https://tools.ietf.org/html/rfc6570) result 200).
* [ ] http://tools.ietf.org/html/rfc7239 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc7239 ([https](https://tools.ietf.org/html/rfc7239) result 200).
* [ ] http://www.example.com with 2 occurrences migrated to:  
  https://www.example.com ([https](https://www.example.com) result 200).
* [ ] http://www.iana.org/assignments/link-relations/link-relations.xhtml with 2 occurrences migrated to:  
  https://www.iana.org/assignments/link-relations/link-relations.xhtml ([https](https://www.iana.org/assignments/link-relations/link-relations.xhtml) result 200).
* [ ] http://amazon.com with 4 occurrences migrated to:  
  https://amazon.com ([https](https://amazon.com) result 301).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://www.w3.org/TR/curie with 1 occurrences migrated to:  
  https://www.w3.org/TR/curie ([https](https://www.w3.org/TR/curie) result 301).
* [ ] http://tools.ietf.org/html/rfc5988=section-4 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc5988=section-4 ([https](https://tools.ietf.org/html/rfc5988=section-4) result 302).
* [ ] http://www.springsource.org/download with 1 occurrences migrated to:  
  https://www.springsource.org/download ([https](https://www.springsource.org/download) result 302).

# Ignored
These URLs were intentionally ignored.

* http://barfoo:8888 with 1 occurrences
* http://foobar with 1 occurrences
* http://foobar:8088 with 1 occurrences
* http://foobarhost/ with 1 occurrences
* http://foobarhost:9090/ with 1 occurrences
* http://localhost with 7 occurrences
* http://localhost/ with 1 occurrences
* http://localhost/employees with 21 occurrences
* http://localhost/employees/0 with 8 occurrences
* http://localhost/employees/1 with 2 occurrences
* http://localhost/employees/2 with 7 occurrences
* http://localhost/sample/1/foo with 1 occurrences
* http://localhost/sample/2/bar with 1 occurrences
* http://localhost/something/bar/foo with 1 occurrences
* http://localhost:8080/api/ with 1 occurrences
* http://localhost:8080/foo with 2 occurrences
* http://localhost:8080/my/custom/location with 2 occurrences
* http://localhost:8080/rels with 1 occurrences
* http://localhost:8080/rels/ with 6 occurrences
* http://localhost:8080/something with 4 occurrences
* http://localhost:8080/test?page=0&filter=foo,bar with 2 occurrences
* http://localhost:8080/your-app with 1 occurrences
* http://localhost:8080/your-app/people with 1 occurrences
* http://myhost/people with 4 occurrences
* http://myhost/person/1 with 1 occurrences
* http://myhost/person/1/orders with 1 occurrences
* http://proxy1:1443 with 1 occurrences
* http://somethingDifferent with 1 occurrences
* http://www.w3.org/2005/Atom with 2 occurrences