### PR TITLE
logref property should be optional

### DIFF
--- a/src/main/java/org/springframework/hateoas/mediatype/vnderrors/VndErrors.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/vnderrors/VndErrors.java
@@ -45,7 +45,7 @@ public class VndErrors implements Iterable<VndErrors.VndError> {
 	 * Creates a new {@link VndErrors} instance containing a single {@link VndError} with the given logref, message and
 	 * optional {@link Link}s.
 	 *
-	 * @param logref must not be {@literal null} or empty.
+	 * @param logref can be {@literal null} or empty.
 	 * @param message must not be {@literal null} or empty.
 	 * @param links
 	 */
@@ -166,13 +166,12 @@ public class VndErrors implements Iterable<VndErrors.VndError> {
 		/**
 		 * Creates a new {@link VndError} with the given logref, a message as well as some {@link Link}s.
 		 *
-		 * @param logref must not be {@literal null} or empty.
+		 * @param logref can be null {@literal null} or empty.
 		 * @param message must not be {@literal null} or empty.
 		 * @param links
 		 */
 		public VndError(String logref, String message, Link... links) {
 
-			Assert.hasText(logref, "Logref must not be null or empty!");
 			Assert.hasText(message, "Message must not be null or empty!");
 
 			this.logref = logref;

--- a/src/main/java/org/springframework/hateoas/mediatype/vnderrors/VndErrors.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/vnderrors/VndErrors.java
@@ -166,7 +166,7 @@ public class VndErrors implements Iterable<VndErrors.VndError> {
 		/**
 		 * Creates a new {@link VndError} with the given logref, a message as well as some {@link Link}s.
 		 *
-		 * @param logref can be null {@literal null} or empty.
+		 * @param logref can be {@literal null} or empty.
 		 * @param message must not be {@literal null} or empty.
 		 * @param links
 		 */


### PR DESCRIPTION
Originally mentioned in issue #478 - `logref` property in spring-hateoas project is required to have value, where in vnd.error specification this field is optional.