### PR TITLE
#1047 - Properly respond to application/json calls.

### DIFF
--- a/src/main/java/org/springframework/hateoas/config/HypermediaMappingInformation.java
+++ b/src/main/java/org/springframework/hateoas/config/HypermediaMappingInformation.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.hateoas.config;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -40,6 +41,10 @@ public interface HypermediaMappingInformation {
 	 */
 	List<MediaType> getMediaTypes();
 
+	default Collection<? extends MediaType> getRegisterableMediaTypes() {
+		return getMediaTypes();
+	}
+	
 	/**
 	 * Configure an {@link ObjectMapper} and register custom serializers and deserializers for the supported media types.
 	 * If all you want to do is register a Jackson {@link Module}, prefer implementing {@link #getJacksonModule()}.

--- a/src/main/java/org/springframework/hateoas/config/WebClientConfigurer.java
+++ b/src/main/java/org/springframework/hateoas/config/WebClientConfigurer.java
@@ -54,22 +54,27 @@ public class WebClientConfigurer {
 
 		List<Encoder<?>> encoders = new ArrayList<>();
 		List<Decoder<?>> decoders = new ArrayList<>();
-
+		
 		this.hypermediaTypes.forEach(hypermedia -> {
 
 			ObjectMapper objectMapper = hypermedia.configureObjectMapper(this.mapper.copy());
-			MimeType[] mimeTypes = hypermedia.getMediaTypes().toArray(new MimeType[0]);
+
+			MimeType[] mimeTypes = hypermedia.getRegisterableMediaTypes().toArray(new MimeType[0]);
 
 			encoders.add(new Jackson2JsonEncoder(objectMapper, mimeTypes));
 			decoders.add(new Jackson2JsonDecoder(objectMapper, mimeTypes));
 		});
 
-		return ExchangeStrategies.builder().codecs(clientCodecConfigurer -> {
+		ExchangeStrategies exchangeStrategies = ExchangeStrategies.builder().codecs(clientCodecConfigurer -> {
 
 			encoders.forEach(encoder -> clientCodecConfigurer.customCodecs().encoder(encoder));
 			decoders.forEach(decoder -> clientCodecConfigurer.customCodecs().decoder(decoder));
 
+			clientCodecConfigurer.registerDefaults(true);
+
 		}).build();
+
+		return exchangeStrategies;
 	}
 
 	/**

--- a/src/main/java/org/springframework/hateoas/config/WebFluxHateoasConfiguration.java
+++ b/src/main/java/org/springframework/hateoas/config/WebFluxHateoasConfiguration.java
@@ -17,7 +17,10 @@ package org.springframework.hateoas.config;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.ObjectProvider;
@@ -27,6 +30,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.codec.CharSequenceEncoder;
 import org.springframework.core.codec.StringDecoder;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.mediatype.hal.HalMediaTypeConfiguration;
+import org.springframework.hateoas.mediatype.hal.forms.HalFormsMediaTypeConfiguration;
+import org.springframework.http.MediaType;
 import org.springframework.http.codec.CodecConfigurer;
 import org.springframework.http.codec.ServerCodecConfigurer;
 import org.springframework.http.codec.json.Jackson2JsonDecoder;
@@ -125,10 +132,10 @@ class WebFluxHateoasConfiguration {
 		public void configureHttpMessageCodecs(ServerCodecConfigurer configurer) {
 
 			CodecConfigurer.CustomCodecs customCodecs = configurer.customCodecs();
-
+			
 			this.hypermediaTypes.forEach(hypermedia -> {
 
-				MimeType[] mimeTypes = hypermedia.getMediaTypes().toArray(new MimeType[0]);
+				MimeType[] mimeTypes = hypermedia.getRegisterableMediaTypes().toArray(new MimeType[0]);
 
 				ObjectMapper objectMapper = hypermedia.configureObjectMapper(this.mapper.copy());
 				customCodecs.encoder(new Jackson2JsonEncoder(objectMapper, mimeTypes));

--- a/src/main/java/org/springframework/hateoas/mediatype/hal/HalMediaTypeConfiguration.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/hal/HalMediaTypeConfiguration.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.hateoas.mediatype.hal;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -72,6 +74,17 @@ public class HalMediaTypeConfiguration implements HypermediaMappingInformation {
 	@Override
 	public List<MediaType> getMediaTypes() {
 		return HypermediaType.HAL.getMediaTypes();
+	}
+
+	/**
+	 * {@code HAL} media type must also register as {@link MediaType#APPLICATION_JSON}.
+	 */
+	@Override
+	public Collection<? extends MediaType> getRegisterableMediaTypes() {
+
+		List<MediaType> mediaTypes = new ArrayList<>(getMediaTypes());
+		mediaTypes.add(MediaType.APPLICATION_JSON);
+		return mediaTypes;
 	}
 
 	/*

--- a/src/main/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsMediaTypeConfiguration.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsMediaTypeConfiguration.java
@@ -17,6 +17,8 @@ package org.springframework.hateoas.mediatype.hal.forms;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -42,7 +44,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 @Configuration
 @RequiredArgsConstructor
-class HalFormsMediaTypeConfiguration implements HypermediaMappingInformation {
+public class HalFormsMediaTypeConfiguration implements HypermediaMappingInformation {
 
 	private final DelegatingLinkRelationProvider relProvider;
 	private final ObjectProvider<CurieProvider> curieProvider;
@@ -62,6 +64,17 @@ class HalFormsMediaTypeConfiguration implements HypermediaMappingInformation {
 	@Override
 	public List<MediaType> getMediaTypes() {
 		return HypermediaType.HAL_FORMS.getMediaTypes();
+	}
+
+	/**
+	 * {@code HAL-FORMS} media type must also register as {@link MediaType#APPLICATION_JSON}.
+	 */
+	@Override
+	public Collection<? extends MediaType> getRegisterableMediaTypes() {
+
+		List<MediaType> mediaTypes = new ArrayList<>(getMediaTypes());
+		mediaTypes.add(MediaType.APPLICATION_JSON);
+		return mediaTypes;
 	}
 
 	/*


### PR DESCRIPTION
Spring HATEAOS must be strict in what it registers, thus NOT use WebFlux's defaults. Yet it should register at least it's HAL-based media types for application/json, the default type used by testing toolkits such as WebTestClient. That way, if you craft a controller that does not deal with hypermedia, it will function as expected.

That is why I've expanded HypermediaMappingInformation to include a `getRegisterableMediaTypes` method. By default, it simply returns the results of `getMediaTypes`. But certain media types, like HAL and HAL-FORMS, can add `application/json` as a media type they will respond to if asked. This provides the means to support other formats using the same serializers.