### PR TITLE
When EnableHypermediaSupport(types) is an empty array, enable ALL hypermedia types.

### DIFF
--- a/src/main/java/org/springframework/hateoas/config/EnableHypermediaSupport.java
+++ b/src/main/java/org/springframework/hateoas/config/EnableHypermediaSupport.java
@@ -44,11 +44,12 @@ import org.springframework.web.reactive.function.client.WebClient;
 public @interface EnableHypermediaSupport {
 
 	/**
-	 * The hypermedia type to be supported.
+	 * The hypermedia type to be supported. By default, it is empty, thus activating all available
+	 * {@link MediaTypeConfigurationProvider}s.
 	 *
 	 * @return
 	 */
-	HypermediaType[] type();
+	HypermediaType[] type() default {};
 
 	/**
 	 * Configures which {@link WebStack}s we're supposed to enable support for. By default we're activating it for all

--- a/src/test/java/org/springframework/hateoas/config/HypermediaConfigurationImportSelectorUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/config/HypermediaConfigurationImportSelectorUnitTest.java
@@ -89,6 +89,22 @@ class HypermediaConfigurationImportSelectorUnitTest {
 		});
 	}
 
+	@Test // #1060
+	void testEmptyHypermediaTypes() {
+
+		withContext(NoConfig.class, context -> {
+
+			Map<String, LinkDiscoverer> linkDiscoverers = context.getBeansOfType(LinkDiscoverer.class);
+
+			assertThat(linkDiscoverers.values()).extracting("class") //
+				.containsExactlyInAnyOrder( //
+					HalLinkDiscoverer.class, //
+					HalFormsLinkDiscoverer.class, //
+					UberLinkDiscoverer.class, //
+					CollectionJsonLinkDiscoverer.class);
+		});
+	}
+
 	@EnableHypermediaSupport(type = HAL)
 	static class HalConfig {
 
@@ -106,6 +122,11 @@ class HypermediaConfigurationImportSelectorUnitTest {
 
 	@EnableHypermediaSupport(type = { HAL, HAL_FORMS, UBER, COLLECTION_JSON })
 	static class AllConfig {
+
+	}
+
+	@EnableHypermediaSupport(type = { })
+	static class NoConfig {
 
 	}
 }

--- a/src/test/java/org/springframework/hateoas/support/CustomHypermediaConfigurationProvider.java
+++ b/src/test/java/org/springframework/hateoas/support/CustomHypermediaConfigurationProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.support;
+
+import java.util.Collection;
+
+import org.springframework.hateoas.config.HypermediaMappingInformation;
+import org.springframework.hateoas.config.MediaTypeConfigurationProvider;
+import org.springframework.http.MediaType;
+
+/**
+ * @author Greg Turnquist
+ */
+public class CustomHypermediaConfigurationProvider implements MediaTypeConfigurationProvider {
+
+	@Override
+	public Class<? extends HypermediaMappingInformation> getConfiguration() {
+		return CustomHypermediaType.class;
+	}
+
+	@Override
+	public boolean supportsAny(Collection<MediaType> mediaTypes) {
+		return mediaTypes.stream().anyMatch(mediaType -> mediaType.isCompatibleWith(CustomHypermediaType.FRODO_MEDIATYPE));
+	}
+}

--- a/src/test/resources/META-INF/spring.factories
+++ b/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.hateoas.config.MediaTypeConfigurationProvider=\
+ org.springframework.hateoas.support.CustomHypermediaConfigurationProvider


### PR DESCRIPTION
Also, default types to an empty list.