### PR TITLE
#1074 - Add option to register additional media types for HAL and HAL-FORMS.

### DIFF
--- a/src/main/java/org/springframework/hateoas/mediatype/hal/HalConfiguration.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/hal/HalConfiguration.java
@@ -20,12 +20,15 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.experimental.Wither;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.LinkRelation;
+import org.springframework.http.MediaType;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.Assert;
 import org.springframework.util.PathMatcher;
@@ -47,6 +50,7 @@ public class HalConfiguration {
 	 */
 	private final @Wither @Getter RenderSingleLinks renderSingleLinks;
 	private final @Wither(AccessLevel.PRIVATE) Map<String, RenderSingleLinks> singleLinksPerPattern;
+	private final @Getter List<MediaType> additionalMediaTypes = new ArrayList<>();
 
 	/**
 	 * Creates a new default {@link HalConfiguration} rendering single links as immediate sub-document.
@@ -121,5 +125,17 @@ public class HalConfiguration {
 		 * A single {@link Link} is rendered as a JSON Array.
 		 */
 		AS_ARRAY
+	}
+
+	/**
+	 * Register other {@link MediaType}s this one should response to.
+	 *
+	 * @param mediatype
+	 * @return HalFormsConfiguration with new {@link MediaType} added
+	 */
+	public HalConfiguration withAdditionalMediatype(MediaType mediatype) {
+
+		this.additionalMediaTypes.add(mediatype);
+		return this;
 	}
 }

--- a/src/main/java/org/springframework/hateoas/mediatype/hal/HalMediaTypeConfiguration.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/hal/HalMediaTypeConfiguration.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.hateoas.mediatype.hal;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -71,7 +72,10 @@ public class HalMediaTypeConfiguration implements HypermediaMappingInformation {
 	 */
 	@Override
 	public List<MediaType> getMediaTypes() {
-		return HypermediaType.HAL.getMediaTypes();
+
+		List<MediaType> mediaTypes = new ArrayList<>(HypermediaType.HAL.getMediaTypes());
+		this.halConfiguration.ifAvailable(halConfig -> mediaTypes.addAll(halConfig.getAdditionalMediaTypes()));
+		return mediaTypes;
 	}
 
 	/*

--- a/src/main/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsConfiguration.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsConfiguration.java
@@ -18,12 +18,14 @@ package org.springframework.hateoas.mediatype.hal.forms;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.hateoas.mediatype.hal.HalConfiguration;
+import org.springframework.http.MediaType;
 
 /**
  * HAL-FORMS specific configuration extension of {@link HalConfiguration}.
@@ -59,5 +61,21 @@ public class HalFormsConfiguration {
 	 */
 	Optional<String> getTypePatternFor(ResolvableType type) {
 		return Optional.ofNullable(patterns.get(type.resolve(Object.class)));
+	}
+
+	/**
+	 * Register other {@link MediaType}s this one should response to.
+	 * 
+	 * @param mediatype
+	 * @return HalFormsConfiguration
+	 */
+	public HalFormsConfiguration withAdditionalMediatype(MediaType mediatype) {
+		
+		this.halConfiguration.getAdditionalMediaTypes().add(mediatype);
+		return this;
+	}
+
+	public Collection<? extends MediaType> getAdditionalMediaTypes() {
+		return this.halConfiguration.getAdditionalMediaTypes();
 	}
 }

--- a/src/main/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsMediaTypeConfiguration.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsMediaTypeConfiguration.java
@@ -17,6 +17,7 @@ package org.springframework.hateoas.mediatype.hal.forms;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -61,7 +62,10 @@ class HalFormsMediaTypeConfiguration implements HypermediaMappingInformation {
 	 */
 	@Override
 	public List<MediaType> getMediaTypes() {
-		return HypermediaType.HAL_FORMS.getMediaTypes();
+
+		List<MediaType> mediaTypes = new ArrayList<>(HypermediaType.HAL_FORMS.getMediaTypes());
+		this.halFormsConfiguration.ifAvailable(halFormsConfig -> mediaTypes.addAll(halFormsConfig.getAdditionalMediaTypes()));
+		return mediaTypes;
 	}
 
 	/*

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/HalHandleApplicationJsonWebFluxIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/HalHandleApplicationJsonWebFluxIntegrationTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.mediatype.hal;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.collection.IsCollectionWithSize.*;
+import static org.springframework.hateoas.support.JsonPathUtils.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.hateoas.config.EnableHypermediaSupport;
+import org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType;
+import org.springframework.hateoas.config.WebClientConfigurer;
+import org.springframework.hateoas.support.MappingUtils;
+import org.springframework.hateoas.support.WebFluxEmployeeController;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.config.EnableWebFlux;
+
+/**
+ * @author Greg Turnquist
+ */
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration
+class HalHandleApplicationJsonWebFluxIntegrationTest {
+
+	@Autowired WebTestClient testClient;
+
+	@BeforeEach
+	void setUp() {
+		WebFluxEmployeeController.reset();
+	}
+
+	/**
+	 * @see #728
+	 */
+	@Test
+	void singleEmployee() {
+
+		this.testClient.get().uri("http://localhost/employees/0").accept(MediaType.APPLICATION_JSON).exchange()
+
+				.expectStatus().isOk() //
+				.expectHeader().contentType(MediaType.APPLICATION_JSON) //
+				.expectBody(String.class)//
+
+				.value(jsonPath("$.name", is("Frodo Baggins"))) //
+				.value(jsonPath("$.role", is("ring bearer"))) //
+
+				.value(jsonPath("$._links.*", hasSize(2))) //
+				.value(jsonPath("$._links['self'].href", is("http://localhost/employees/0"))) //
+				.value(jsonPath("$._links['employees'].href", is("http://localhost/employees")));
+	}
+
+	/**
+	 * @see #728
+	 */
+	@Test
+	void collectionOfEmployees() {
+
+		this.testClient.get().uri("http://localhost/employees").accept(MediaType.APPLICATION_JSON).exchange().expectStatus()
+				.isOk().expectHeader().contentType(MediaType.APPLICATION_JSON).expectBody(String.class)
+				.value(jsonPath("$._embedded.employees[0].name", is("Frodo Baggins")))
+				.value(jsonPath("$._embedded.employees[0].role", is("ring bearer")))
+				.value(jsonPath("$._embedded.employees[0]._links['self'].href", is("http://localhost/employees/0")))
+				.value(jsonPath("$._embedded.employees[1].name", is("Bilbo Baggins")))
+				.value(jsonPath("$._embedded.employees[1].role", is("burglar")))
+				.value(jsonPath("$._embedded.employees[1]._links['self'].href", is("http://localhost/employees/1")))
+
+				.value(jsonPath("$._links.*", hasSize(1)))
+				.value(jsonPath("$._links['self'].href", is("http://localhost/employees")));
+	}
+
+	/**
+	 * @see #728
+	 */
+	@Test
+	void createNewEmployee() throws Exception {
+
+		String specBasedJson = MappingUtils.read(new ClassPathResource("new-employee.json", getClass()));
+
+		this.testClient.post().uri("http://localhost/employees").contentType(MediaType.APPLICATION_JSON)
+				.bodyValue(specBasedJson) //
+				.exchange() //
+				.expectStatus().isCreated() //
+				.expectHeader().valueEquals(HttpHeaders.LOCATION, "http://localhost/employees/2");
+	}
+
+	@Configuration
+	@EnableWebFlux
+	@EnableHypermediaSupport(type = { HypermediaType.HAL })
+	static class TestConfig {
+
+		@Bean
+		WebFluxEmployeeController employeeController() {
+			return new WebFluxEmployeeController();
+		}
+
+		@Bean
+		WebTestClient webTestClient(WebClientConfigurer webClientConfigurer, ApplicationContext ctx) {
+
+			return WebTestClient.bindToApplicationContext(ctx).build().mutate()
+					.exchangeStrategies(webClientConfigurer.hypermediaExchangeStrategies()).build();
+		}
+
+		@Bean
+		HalConfiguration halConfiguration() {
+			return new HalConfiguration().withAdditionalMediatype(MediaType.APPLICATION_JSON);
+		}
+	}
+}

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/HalHandleApplicationJsonWebMvcIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/HalHandleApplicationJsonWebMvcIntegrationTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.mediatype.hal;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.collection.IsCollectionWithSize.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.hateoas.config.EnableHypermediaSupport;
+import org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType;
+import org.springframework.hateoas.support.MappingUtils;
+import org.springframework.hateoas.support.WebMvcEmployeeController;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+/**
+ * @author Greg Turnquist
+ */
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration
+class HalHandleApplicationJsonWebMvcIntegrationTest {
+
+	@Autowired WebApplicationContext context;
+
+	MockMvc mockMvc;
+
+	@BeforeEach
+	void setUp() {
+
+		this.mockMvc = webAppContextSetup(this.context).build();
+		WebMvcEmployeeController.reset();
+	}
+
+	@Test
+	void singleEmployee() throws Exception {
+
+		this.mockMvc.perform(get("/employees/0").accept(MediaType.APPLICATION_JSON)) //
+
+				.andExpect(status().isOk()) //
+				.andExpect(jsonPath("$.name", is("Frodo Baggins"))) //
+				.andExpect(jsonPath("$.role", is("ring bearer")))
+
+				.andExpect(jsonPath("$._links.*", hasSize(2)))
+				.andExpect(jsonPath("$._links['self'].href", is("http://localhost/employees/0")))
+				.andExpect(jsonPath("$._links['employees'].href", is("http://localhost/employees")));
+	}
+
+	@Test
+	void collectionOfEmployees() throws Exception {
+
+		this.mockMvc.perform(get("/employees").accept(MediaType.APPLICATION_JSON)) //
+				.andExpect(status().isOk()) //
+				.andExpect(jsonPath("$._embedded.employees[0].name", is("Frodo Baggins")))
+				.andExpect(jsonPath("$._embedded.employees[0].role", is("ring bearer")))
+				.andExpect(jsonPath("$._embedded.employees[0]._links['self'].href", is("http://localhost/employees/0")))
+				.andExpect(jsonPath("$._embedded.employees[1].name", is("Bilbo Baggins")))
+				.andExpect(jsonPath("$._embedded.employees[1].role", is("burglar")))
+				.andExpect(jsonPath("$._embedded.employees[1]._links['self'].href", is("http://localhost/employees/1")))
+
+				.andExpect(jsonPath("$._links.*", hasSize(1)))
+				.andExpect(jsonPath("$._links['self'].href", is("http://localhost/employees")));
+	}
+
+	@Test
+	void createNewEmployee() throws Exception {
+
+		String specBasedJson = MappingUtils.read(new ClassPathResource("new-employee.json", getClass()));
+
+		this.mockMvc.perform(post("/employees") //
+				.content(specBasedJson) //
+				.contentType(MediaType.APPLICATION_JSON_VALUE)) //
+				.andExpect(status().isCreated())
+				.andExpect(header().stringValues(HttpHeaders.LOCATION, "http://localhost/employees/2"));
+	}
+
+	@Configuration
+	@EnableWebMvc
+	@EnableHypermediaSupport(type = HypermediaType.HAL)
+	static class TestConfig {
+
+		@Bean
+		WebMvcEmployeeController employeeController() {
+			return new WebMvcEmployeeController();
+		}
+
+		@Bean
+		HalConfiguration halFormsConfiguration() {
+			return new HalConfiguration().withAdditionalMediatype(MediaType.APPLICATION_JSON);
+		}
+
+	}
+
+	@Configuration
+	@EnableHypermediaSupport(type = HypermediaType.HAL)
+	static class WithHalConfiguration {
+
+		static final HalConfiguration CONFIG = new HalConfiguration().withAdditionalMediatype(MediaType.APPLICATION_JSON);
+
+		@Bean
+		public HalConfiguration halConfiguration() {
+			return CONFIG;
+		}
+	}
+}

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/HalWebFluxIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/HalWebFluxIntegrationTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.mediatype.hal;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.collection.IsCollectionWithSize.*;
+import static org.springframework.hateoas.support.JsonPathUtils.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.config.EnableHypermediaSupport;
+import org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType;
+import org.springframework.hateoas.config.WebClientConfigurer;
+import org.springframework.hateoas.support.MappingUtils;
+import org.springframework.hateoas.support.WebFluxEmployeeController;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.config.EnableWebFlux;
+
+/**
+ * @author Greg Turnquist
+ */
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration
+class HalWebFluxIntegrationTest {
+
+	@Autowired WebTestClient testClient;
+
+	@BeforeEach
+	void setUp() {
+		WebFluxEmployeeController.reset();
+	}
+
+	/**
+	 * @see #728
+	 */
+	@Test
+	void singleEmployee() {
+
+		this.testClient.get().uri("http://localhost/employees/0").accept(MediaTypes.HAL_JSON).exchange()
+
+				.expectStatus().isOk() //
+				.expectHeader().contentType(MediaTypes.HAL_JSON) //
+				.expectBody(String.class)//
+
+				.value(jsonPath("$.name", is("Frodo Baggins"))) //
+				.value(jsonPath("$.role", is("ring bearer"))) //
+
+				.value(jsonPath("$._links.*", hasSize(2))) //
+				.value(jsonPath("$._links['self'].href", is("http://localhost/employees/0"))) //
+				.value(jsonPath("$._links['employees'].href", is("http://localhost/employees")));
+	}
+
+	/**
+	 * @see #728
+	 */
+	@Test
+	void collectionOfEmployees() {
+
+		this.testClient.get().uri("http://localhost/employees").accept(MediaTypes.HAL_JSON).exchange().expectStatus()
+				.isOk().expectHeader().contentType(MediaTypes.HAL_JSON).expectBody(String.class)
+				.value(jsonPath("$._embedded.employees[0].name", is("Frodo Baggins")))
+				.value(jsonPath("$._embedded.employees[0].role", is("ring bearer")))
+				.value(jsonPath("$._embedded.employees[0]._links['self'].href", is("http://localhost/employees/0")))
+				.value(jsonPath("$._embedded.employees[1].name", is("Bilbo Baggins")))
+				.value(jsonPath("$._embedded.employees[1].role", is("burglar")))
+				.value(jsonPath("$._embedded.employees[1]._links['self'].href", is("http://localhost/employees/1")))
+
+				.value(jsonPath("$._links.*", hasSize(1)))
+				.value(jsonPath("$._links['self'].href", is("http://localhost/employees")));
+	}
+
+	/**
+	 * @see #728
+	 */
+	@Test
+	void createNewEmployee() throws Exception {
+
+		String specBasedJson = MappingUtils.read(new ClassPathResource("new-employee.json", getClass()));
+
+		this.testClient.post().uri("http://localhost/employees").contentType(MediaTypes.HAL_JSON)
+				.bodyValue(specBasedJson) //
+				.exchange() //
+				.expectStatus().isCreated() //
+				.expectHeader().valueEquals(HttpHeaders.LOCATION, "http://localhost/employees/2");
+	}
+
+	@Configuration
+	@EnableWebFlux
+	@EnableHypermediaSupport(type = { HypermediaType.HAL })
+	static class TestConfig {
+
+		@Bean
+		WebFluxEmployeeController employeeController() {
+			return new WebFluxEmployeeController();
+		}
+
+		@Bean
+		WebTestClient webTestClient(WebClientConfigurer webClientConfigurer, ApplicationContext ctx) {
+
+			return WebTestClient.bindToApplicationContext(ctx).build().mutate()
+					.exchangeStrategies(webClientConfigurer.hypermediaExchangeStrategies()).build();
+		}
+	}
+}

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/HalWebMvcIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/HalWebMvcIntegrationTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.mediatype.hal;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.collection.IsCollectionWithSize.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.config.EnableHypermediaSupport;
+import org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType;
+import org.springframework.hateoas.support.MappingUtils;
+import org.springframework.hateoas.support.WebMvcEmployeeController;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+/**
+ * @author Greg Turnquist
+ */
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration
+class HalWebMvcIntegrationTest {
+
+	@Autowired WebApplicationContext context;
+
+	MockMvc mockMvc;
+
+	@BeforeEach
+	void setUp() {
+
+		this.mockMvc = webAppContextSetup(this.context).build();
+		WebMvcEmployeeController.reset();
+	}
+
+	@Test
+	void singleEmployee() throws Exception {
+
+		this.mockMvc.perform(get("/employees/0").accept(MediaTypes.HAL_JSON)) //
+
+				.andExpect(status().isOk()) //
+				.andExpect(jsonPath("$.name", is("Frodo Baggins"))) //
+				.andExpect(jsonPath("$.role", is("ring bearer")))
+
+				.andExpect(jsonPath("$._links.*", hasSize(2)))
+				.andExpect(jsonPath("$._links['self'].href", is("http://localhost/employees/0")))
+				.andExpect(jsonPath("$._links['employees'].href", is("http://localhost/employees")));
+	}
+
+	@Test
+	void collectionOfEmployees() throws Exception {
+
+		this.mockMvc.perform(get("/employees").accept(MediaTypes.HAL_JSON)) //
+				.andExpect(status().isOk()) //
+				.andExpect(jsonPath("$._embedded.employees[0].name", is("Frodo Baggins")))
+				.andExpect(jsonPath("$._embedded.employees[0].role", is("ring bearer")))
+				.andExpect(jsonPath("$._embedded.employees[0]._links['self'].href", is("http://localhost/employees/0")))
+				.andExpect(jsonPath("$._embedded.employees[1].name", is("Bilbo Baggins")))
+				.andExpect(jsonPath("$._embedded.employees[1].role", is("burglar")))
+				.andExpect(jsonPath("$._embedded.employees[1]._links['self'].href", is("http://localhost/employees/1")))
+
+				.andExpect(jsonPath("$._links.*", hasSize(1)))
+				.andExpect(jsonPath("$._links['self'].href", is("http://localhost/employees")));
+	}
+
+	@Test
+	void createNewEmployee() throws Exception {
+
+		String specBasedJson = MappingUtils.read(new ClassPathResource("new-employee.json", getClass()));
+
+		this.mockMvc.perform(post("/employees") //
+				.content(specBasedJson) //
+				.contentType(MediaTypes.HAL_JSON_VALUE)) //
+				.andExpect(status().isCreated())
+				.andExpect(header().stringValues(HttpHeaders.LOCATION, "http://localhost/employees/2"));
+	}
+
+	@Configuration
+	@EnableWebMvc
+	@EnableHypermediaSupport(type = HypermediaType.HAL)
+	static class TestConfig {
+
+		@Bean
+		WebMvcEmployeeController employeeController() {
+			return new WebMvcEmployeeController();
+		}
+	}
+
+	@Configuration
+	@EnableHypermediaSupport(type = HypermediaType.HAL)
+	static class WithHalConfiguration {
+
+		static final HalConfiguration CONFIG = new HalConfiguration();
+
+		@Bean
+		public HalConfiguration halConfiguration() {
+			return CONFIG;
+		}
+	}
+}

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsHandleApplicationJsonWebFluxIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsHandleApplicationJsonWebFluxIntegrationTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.mediatype.hal.forms;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.collection.IsCollectionWithSize.*;
+import static org.springframework.hateoas.support.JsonPathUtils.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.hateoas.config.EnableHypermediaSupport;
+import org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType;
+import org.springframework.hateoas.config.WebClientConfigurer;
+import org.springframework.hateoas.support.MappingUtils;
+import org.springframework.hateoas.support.WebFluxEmployeeController;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.config.EnableWebFlux;
+
+/**
+ * @author Greg Turnquist
+ */
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration
+class HalFormsHandleApplicationJsonWebFluxIntegrationTest {
+
+	@Autowired WebTestClient testClient;
+
+	@BeforeEach
+	void setUp() {
+		WebFluxEmployeeController.reset();
+	}
+
+	/**
+	 * @see #728
+	 */
+	@Test
+	void singleEmployee() {
+
+		this.testClient.get().uri("http://localhost/employees/0").accept(MediaType.APPLICATION_JSON).exchange()
+
+				.expectStatus().isOk() //
+				.expectHeader().contentType(MediaType.APPLICATION_JSON) //
+				.expectBody(String.class)//
+
+				.value(jsonPath("$.name", is("Frodo Baggins"))) //
+				.value(jsonPath("$.role", is("ring bearer"))) //
+
+				.value(jsonPath("$._links.*", hasSize(2))) //
+				.value(jsonPath("$._links['self'].href", is("http://localhost/employees/0"))) //
+				.value(jsonPath("$._links['employees'].href", is("http://localhost/employees"))) //
+
+				.value(jsonPath("$._templates.*", hasSize(2))) //
+				.value(jsonPath("$._templates['default'].method", is("put"))) //
+				.value(jsonPath("$._templates['default'].properties[0].name", is("name"))) //
+				.value(jsonPath("$._templates['default'].properties[0].required", is(true))) //
+				.value(jsonPath("$._templates['default'].properties[1].name", is("role"))) //
+				.value(jsonPath("$._templates['default'].properties[1].required").doesNotExist()) //
+
+				.value(jsonPath("$._templates['partiallyUpdateEmployee'].method", is("patch"))) //
+				.value(jsonPath("$._templates['partiallyUpdateEmployee'].properties[0].name", is("name"))) //
+				.value(jsonPath("$._templates['partiallyUpdateEmployee'].properties[0].required").doesNotExist()) //
+				.value(jsonPath("$._templates['partiallyUpdateEmployee'].properties[1].name", is("role"))) //
+				.value(jsonPath("$._templates['partiallyUpdateEmployee'].properties[1].required").doesNotExist());
+	}
+
+	/**
+	 * @see #728
+	 */
+	@Test
+	void collectionOfEmployees() {
+
+		this.testClient.get().uri("http://localhost/employees").accept(MediaType.APPLICATION_JSON).exchange().expectStatus()
+				.isOk().expectHeader().contentType(MediaType.APPLICATION_JSON).expectBody(String.class)
+				.value(jsonPath("$._embedded.employees[0].name", is("Frodo Baggins")))
+				.value(jsonPath("$._embedded.employees[0].role", is("ring bearer")))
+				.value(jsonPath("$._embedded.employees[0]._links['self'].href", is("http://localhost/employees/0")))
+				.value(jsonPath("$._embedded.employees[1].name", is("Bilbo Baggins")))
+				.value(jsonPath("$._embedded.employees[1].role", is("burglar")))
+				.value(jsonPath("$._embedded.employees[1]._links['self'].href", is("http://localhost/employees/1")))
+
+				.value(jsonPath("$._links.*", hasSize(1)))
+				.value(jsonPath("$._links['self'].href", is("http://localhost/employees")))
+
+				.value(jsonPath("$._templates.*", hasSize(1))).value(jsonPath("$._templates['default'].method", is("post")))
+				.value(jsonPath("$._templates['default'].properties[0].name", is("name")))
+				.value(jsonPath("$._templates['default'].properties[0].required", is(true)))
+				.value(jsonPath("$._templates['default'].properties[1].name", is("role")))
+				.value(jsonPath("$._templates['default'].properties[1].required").doesNotExist());
+	}
+
+	/**
+	 * @see #728
+	 */
+	@Test
+	void createNewEmployee() throws Exception {
+
+		String specBasedJson = MappingUtils.read(new ClassPathResource("new-employee.json", getClass()));
+
+		this.testClient.post().uri("http://localhost/employees").contentType(MediaType.APPLICATION_JSON)
+				.bodyValue(specBasedJson) //
+				.exchange() //
+				.expectStatus().isCreated() //
+				.expectHeader().valueEquals(HttpHeaders.LOCATION, "http://localhost/employees/2");
+	}
+
+	@Configuration
+	@EnableWebFlux
+	@EnableHypermediaSupport(type = { HypermediaType.HAL_FORMS })
+	static class TestConfig {
+
+		@Bean
+		WebFluxEmployeeController employeeController() {
+			return new WebFluxEmployeeController();
+		}
+
+		@Bean
+		WebTestClient webTestClient(WebClientConfigurer webClientConfigurer, ApplicationContext ctx) {
+
+			return WebTestClient.bindToApplicationContext(ctx).build().mutate()
+					.exchangeStrategies(webClientConfigurer.hypermediaExchangeStrategies()).build();
+		}
+
+		@Bean
+		HalFormsConfiguration halFormsConfiguration() {
+			return new HalFormsConfiguration().withAdditionalMediatype(MediaType.APPLICATION_JSON);
+		}
+	}
+}

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsHandleApplicationJsonWebMvcIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsHandleApplicationJsonWebMvcIntegrationTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.mediatype.hal.forms;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.collection.IsCollectionWithSize.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.hateoas.Links;
+import org.springframework.hateoas.config.EnableHypermediaSupport;
+import org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType;
+import org.springframework.hateoas.mediatype.hal.HalConfiguration;
+import org.springframework.hateoas.mediatype.hal.Jackson2HalModule.HalLinkListSerializer;
+import org.springframework.hateoas.support.MappingUtils;
+import org.springframework.hateoas.support.WebMvcEmployeeController;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Greg Turnquist
+ */
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration
+class HalFormsHandleApplicationJsonWebMvcIntegrationTest {
+
+	@Autowired WebApplicationContext context;
+
+	MockMvc mockMvc;
+
+	@BeforeEach
+	void setUp() {
+
+		this.mockMvc = webAppContextSetup(this.context).build();
+		WebMvcEmployeeController.reset();
+	}
+
+	@Test
+	void singleEmployee() throws Exception {
+
+		this.mockMvc.perform(get("/employees/0").accept(MediaType.APPLICATION_JSON)) //
+
+				.andExpect(status().isOk()) //
+				.andExpect(jsonPath("$.name", is("Frodo Baggins"))) //
+				.andExpect(jsonPath("$.role", is("ring bearer")))
+
+				.andExpect(jsonPath("$._links.*", hasSize(2)))
+				.andExpect(jsonPath("$._links['self'].href", is("http://localhost/employees/0")))
+				.andExpect(jsonPath("$._links['employees'].href", is("http://localhost/employees")))
+
+				.andExpect(jsonPath("$._templates.*", hasSize(2)))
+				.andExpect(jsonPath("$._templates['default'].method", is("put")))
+				.andExpect(jsonPath("$._templates['default'].properties[0].name", is("name")))
+				.andExpect(jsonPath("$._templates['default'].properties[0].required").value(true))
+				.andExpect(jsonPath("$._templates['default'].properties[1].name", is("role")))
+				.andExpect(jsonPath("$._templates['default'].properties[1].required").doesNotExist())
+
+				.andExpect(jsonPath("$._templates['partiallyUpdateEmployee'].method", is("patch")))
+				.andExpect(jsonPath("$._templates['partiallyUpdateEmployee'].properties[0].name", is("name")))
+				.andExpect(jsonPath("$._templates['partiallyUpdateEmployee'].properties[0].required").doesNotExist())
+				.andExpect(jsonPath("$._templates['partiallyUpdateEmployee'].properties[1].name", is("role")))
+				.andExpect(jsonPath("$._templates['partiallyUpdateEmployee'].properties[1].required").doesNotExist());
+	}
+
+	@Test
+	void collectionOfEmployees() throws Exception {
+
+		this.mockMvc.perform(get("/employees").accept(MediaType.APPLICATION_JSON)) //
+				.andExpect(status().isOk()) //
+				.andExpect(jsonPath("$._embedded.employees[0].name", is("Frodo Baggins")))
+				.andExpect(jsonPath("$._embedded.employees[0].role", is("ring bearer")))
+				.andExpect(jsonPath("$._embedded.employees[0]._links['self'].href", is("http://localhost/employees/0")))
+				.andExpect(jsonPath("$._embedded.employees[1].name", is("Bilbo Baggins")))
+				.andExpect(jsonPath("$._embedded.employees[1].role", is("burglar")))
+				.andExpect(jsonPath("$._embedded.employees[1]._links['self'].href", is("http://localhost/employees/1")))
+
+				.andExpect(jsonPath("$._links.*", hasSize(1)))
+				.andExpect(jsonPath("$._links['self'].href", is("http://localhost/employees")))
+
+				.andExpect(jsonPath("$._templates.*", hasSize(1)))
+				.andExpect(jsonPath("$._templates['default'].method", is("post")))
+				.andExpect(jsonPath("$._templates['default'].properties[0].name", is("name")))
+				.andExpect(jsonPath("$._templates['default'].properties[0].required").value(true))
+				.andExpect(jsonPath("$._templates['default'].properties[1].name", is("role")))
+				.andExpect(jsonPath("$._templates['default'].properties[1].required").doesNotExist());
+	}
+
+	@Test
+	void createNewEmployee() throws Exception {
+
+		String specBasedJson = MappingUtils.read(new ClassPathResource("new-employee.json", getClass()));
+
+		this.mockMvc.perform(post("/employees") //
+				.content(specBasedJson) //
+				.contentType(MediaType.APPLICATION_JSON_VALUE)) //
+				.andExpect(status().isCreated())
+				.andExpect(header().stringValues(HttpHeaders.LOCATION, "http://localhost/employees/2"));
+	}
+
+	@Test // #832
+	public void usesRegisteredHalFormsConfiguration() {
+		assertInstanceUsed(WithHalFormsConfiguration.class, WithHalFormsConfiguration.CONFIG);
+	}
+
+	@Test // #832
+	public void usesRegisteredHalConfiguration() {
+		assertInstanceUsed(WithHalConfiguration.class, WithHalConfiguration.CONFIG);
+	}
+
+	private static void assertInstanceUsed(Class<?> configurationClass, HalConfiguration configuration) {
+
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(configurationClass)) {
+
+			HalFormsMediaTypeConfiguration mediaTypeConfiguration = context.getBean(HalFormsMediaTypeConfiguration.class);
+			ObjectMapper mapper = mediaTypeConfiguration.configureObjectMapper(new ObjectMapper());
+
+			assertThatCode(() -> {
+
+				JsonSerializer<Object> serializer = mapper.getSerializerProviderInstance() //
+						.findValueSerializer(Links.class);
+
+				assertThat(serializer).isInstanceOfSatisfying(HalLinkListSerializer.class, it -> {
+					assertThat(ReflectionTestUtils.getField(serializer, "halConfiguration")).isSameAs(configuration);
+				});
+
+			}).doesNotThrowAnyException();
+		}
+	}
+
+	@Configuration
+	@EnableWebMvc
+	@EnableHypermediaSupport(type = { HypermediaType.HAL_FORMS })
+	static class TestConfig {
+
+		@Bean
+		WebMvcEmployeeController employeeController() {
+			return new WebMvcEmployeeController();
+		}
+
+		@Bean
+		HalFormsConfiguration halFormsConfiguration() {
+			return new HalFormsConfiguration().withAdditionalMediatype(MediaType.APPLICATION_JSON);
+		}
+	}
+
+	@Configuration
+	@EnableHypermediaSupport(type = HypermediaType.HAL_FORMS)
+	static class WithHalFormsConfiguration {
+
+		static final HalConfiguration CONFIG = new HalConfiguration().withAdditionalMediatype(MediaType.APPLICATION_JSON);
+
+		@Bean
+		public HalFormsConfiguration halFormsConfiguration() {
+
+			HalFormsConfiguration config = mock(HalFormsConfiguration.class);
+			when(config.getHalConfiguration()).thenReturn(CONFIG);
+
+			return config;
+		}
+	}
+
+	@Configuration
+	@EnableHypermediaSupport(type = HypermediaType.HAL_FORMS)
+	static class WithHalConfiguration {
+
+		static final HalConfiguration CONFIG = new HalConfiguration().withAdditionalMediatype(MediaType.APPLICATION_JSON);
+
+		@Bean
+		public HalConfiguration halConfiguration() {
+			return CONFIG;
+		}
+	}
+}

--- a/src/test/resources/org/springframework/hateoas/mediatype/hal/new-employee.json
+++ b/src/test/resources/org/springframework/hateoas/mediatype/hal/new-employee.json
@@ -1,0 +1,7 @@
+{
+  "name" : "Samwise Gamgee",
+  "role" : "gardener",
+  "_links" : {
+
+  }
+}


### PR DESCRIPTION
Inside HalConfiguration and HalFormsConfiguration, add a "wither" to support registering additional mediatypes. This makes it possible for Spring Boot to create a bean that will yield HAL when clients ask for application/json.

NOTE: This is NOT implemented in Collection+JSON, UBER, or any other mediatypes, and has not been captured as an interface that all custom mediatypes would pick up. So far, it's custom for HAL and HAL-FORMS. If there is a big draw, we can look at extracting some type of interface. But for now, community feedback would be nice before going down that road.