### PR TITLE
Fix also HAL_JSON_UTF8 media type

### DIFF
--- a/etc/migrate-to-1.0.sh
+++ b/etc/migrate-to-1.0.sh
@@ -65,6 +65,7 @@ s/hateoas\.core\.MethodParameters/hateoas.server.core.MethodParameters/g;\
 s/hateoas\.core\.Relation/hateoas.server.core.Relation/g;\
 \
 s/hateoas\.hal/hateoas.mediatype.hal/g;\
+s/HAL_JSON_UTF8/HAL_JSON/g;\
 \
 s/hateoas\.mvc\.BasicLinkBuilder/hateoas.server.mvc.BasicLinkBuilder/g;\
 s/hateoas\.mvc\.ControllerLinkBuilder/hateoas.server.mvc.WebMvcLinkBuilder/g;\


### PR DESCRIPTION
org.springframework.hateoas.MediaTypes.HAL_JSON_UTF8 value was removed and only HAL_JSON is present. UTF8 is considered as default encoding for application/hal+json type.