### PR TITLE
add two more patterns: RepresentationModel and RepresentationModelAssemblerSupport

### DIFF
--- a/etc/migrate-to-1.0.sh
+++ b/etc/migrate-to-1.0.sh
@@ -98,6 +98,8 @@ s/\([^a-z]\)RelProvider\([ ><,#();:\.]\)/\1LinkRelationProvider\2/g;\
 \
 s/linkForSingleResource/linkForItemResource/g;\
 s/linkToSingleResource/linkToItemResource/g;\
+s/ResourceAssemblerSupport/RepresentationModelAssemblerSupport/g;\
+s/public[[:space:]]class[[:space:]]\(.*\)[[:space:]]extends[[:space:]]RepresentationModel[[:space:]]{$/public class \1 extends RepresentationModel<\1> {/g;\
 "
 
 #EXPRESSION="s/[\s\.]PagedResources\([;<]\)/.PagedRepresentationModel\1/g;"


### PR DESCRIPTION
- in my project I had to change `RepresentationModel` to `RepresentationModelAssemblerSupport` and also their signature from `RepresentationModel` to `RepresenationModelAssemblerSupport<T>`
- I don't know if these were intentionally not included in the script but if its useful then merge?