### PR TITLE
Update documentation and toString() methods in renamed classes

### DIFF
--- a/src/main/java/org/springframework/hateoas/CollectionModel.java
+++ b/src/main/java/org/springframework/hateoas/CollectionModel.java
@@ -115,7 +115,6 @@ public class CollectionModel<T> extends RepresentationModel<CollectionModel<T>> 
 	 * Creates a {@link CollectionModel} instance with the given content.
 	 *
 	 * @param content must not be {@literal null}.
-	 * @param links the links to be added to the {@link CollectionModel}.
 	 * @return
 	 * @since 1.1
 	 */
@@ -189,16 +188,16 @@ public class CollectionModel<T> extends RepresentationModel<CollectionModel<T>> 
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.hateoas.ResourceSupport#toString()
+	 * @see org.springframework.hateoas.RepresentationModel#toString()
 	 */
 	@Override
 	public String toString() {
-		return String.format("Resources { content: %s, %s }", getContent(), super.toString());
+		return String.format("CollectionModel { content: %s, %s }", getContent(), super.toString());
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.hateoas.ResourceSupport#equals(java.lang.Object)
+	 * @see org.springframework.hateoas.RepresentationModel#equals(java.lang.Object)
 	 */
 	@Override
 	public boolean equals(@Nullable Object obj) {
@@ -219,7 +218,7 @@ public class CollectionModel<T> extends RepresentationModel<CollectionModel<T>> 
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.hateoas.ResourceSupport#hashCode()
+	 * @see org.springframework.hateoas.RepresentationModel#hashCode()
 	 */
 	@Override
 	public int hashCode() {

--- a/src/main/java/org/springframework/hateoas/EntityModel.java
+++ b/src/main/java/org/springframework/hateoas/EntityModel.java
@@ -78,7 +78,6 @@ public class EntityModel<T> extends RepresentationModel<EntityModel<T>> {
 	 * Creates a new {@link EntityModel} with the given content.
 	 *
 	 * @param content must not be {@literal null}.
-	 * @param links the links to add to the {@link EntityModel}.
 	 * @return
 	 * @since 1.1
 	 */
@@ -149,16 +148,16 @@ public class EntityModel<T> extends RepresentationModel<EntityModel<T>> {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.hateoas.ResourceSupport#toString()
+	 * @see org.springframework.hateoas.RepresentationModel#toString()
 	 */
 	@Override
 	public String toString() {
-		return String.format("Resource { content: %s, %s }", getContent(), super.toString());
+		return String.format("EntityModel { content: %s, %s }", getContent(), super.toString());
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.hateoas.ResourceSupport#equals(java.lang.Object)
+	 * @see org.springframework.hateoas.RepresentationModel#equals(java.lang.Object)
 	 */
 	@Override
 	public boolean equals(@Nullable Object obj) {
@@ -179,7 +178,7 @@ public class EntityModel<T> extends RepresentationModel<EntityModel<T>> {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.hateoas.ResourceSupport#hashCode()
+	 * @see org.springframework.hateoas.RepresentationModel#hashCode()
 	 */
 	@Override
 	public int hashCode() {

--- a/src/main/java/org/springframework/hateoas/PagedModel.java
+++ b/src/main/java/org/springframework/hateoas/PagedModel.java
@@ -234,16 +234,16 @@ public class PagedModel<T> extends CollectionModel<T> {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.hateoas.ResourceSupport#toString()
+	 * @see org.springframework.hateoas.RepresentationModel#toString()
 	 */
 	@Override
 	public String toString() {
-		return String.format("PagedResource { content: %s, metadata: %s, links: %s }", getContent(), metadata, getLinks());
+		return String.format("PagedModel { content: %s, metadata: %s, links: %s }", getContent(), metadata, getLinks());
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.hateoas.Resources#equals(java.lang.Object)
+	 * @see org.springframework.hateoas.CollectionModel#equals(java.lang.Object)
 	 */
 	@Override
 	public boolean equals(@Nullable Object obj) {
@@ -264,7 +264,7 @@ public class PagedModel<T> extends CollectionModel<T> {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.hateoas.Resources#hashCode()
+	 * @see org.springframework.hateoas.CollectionModel#hashCode()
 	 */
 	@Override
 	public int hashCode() {


### PR DESCRIPTION
A few of the names in the `toString()` methods and javadocs were not updated