### PR TITLE
Jackson uses platform line endings.

### DIFF
--- a/src/test/java/org/springframework/hateoas/mediatype/hal/forms/Jackson2HalFormsIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/forms/Jackson2HalFormsIntegrationTest.java
@@ -415,7 +415,8 @@ class Jackson2HalFormsIntegrationTest extends AbstractJackson2MarshallingIntegra
 
 		String serialized = mapper.writeValueAsString(original);
 
-		String expected = "{\n  \"_links\" : {\n    \"order\" : {\n      \"href\" : \"/orders{?id}\",\n      \"templated\" : true\n    }\n  }\n}";
+		String expected = "{\n  \"_links\" : {\n    \"order\" : {\n      \"href\" : \"/orders{?id}\",\n      \"templated\" : true\n    }\n  }\n}"
+				.replaceAll("\n", System.getProperty("line.separator"));
 
 		assertThat(serialized).isEqualTo(expected);
 


### PR DESCRIPTION
When building the project on Windows, I encountered an issue with one of Jackson2HalFormsIntegrationTest's methods. It seems Jackson is using the underlying platform's line ending when serializing. The expected is not met on Windows (nor should it on Mac).