### PR TITLE
RepresentationModelProcessor invoked for invalid CollectionModel payload if specialized

### DIFF
--- a/src/main/java/org/springframework/hateoas/server/mvc/RepresentationModelProcessorInvoker.java
+++ b/src/main/java/org/springframework/hateoas/server/mvc/RepresentationModelProcessorInvoker.java
@@ -434,7 +434,7 @@ public class RepresentationModelProcessorInvoker {
 
 			Class<?> rawType = source.getRawClass();
 
-			if (rawType != null && rawType.isAssignableFrom(superType)) {
+			if (rawType != null && rawType.equals(superType)) {
 				return source;
 			}
 

--- a/src/main/java/org/springframework/hateoas/server/mvc/RepresentationModelProcessorInvoker.java
+++ b/src/main/java/org/springframework/hateoas/server/mvc/RepresentationModelProcessorInvoker.java
@@ -434,7 +434,7 @@ public class RepresentationModelProcessorInvoker {
 
 			Class<?> rawType = source.getRawClass();
 
-			if (rawType != null && rawType.equals(superType)) {
+			if (rawType != null && rawType.isAssignableFrom(superType)) {
 				return source;
 			}
 


### PR DESCRIPTION
Hello my name is Karina and I am working on a project that uses Spring Hateoas. After migrating to Spring Boot 2.3.3, we ran into the problem that `RepresentationModelProcessor` performs a process for all objects of type `CollectionModel<EntityModel<no matter what type>>`. This is due to the fact that we created our inheritor from `CollectionModel`. The code describing the problem can be found [here](https://stackoverflow.com/questions/64333052/use-custom-inheritor-from-the-hateoas-collectionmodel-in-hateoas-server-represen).

After analyzing your code, I found out that the `RepresentationModelProcessorInvoker.getSuperType(…)` method does not handle inheritors in any way. As a result, this method returns `CollectionModelProcessorMyInheritor<?>`. Because of this, in the `RepresentationModelProcessorInvoker.isValueTypeMatch(…)`, the `resourceType` will be equal to `?`. Further, this `?`, comparing with anything in the `RMPI.isValueTypeMatch(…)` method, will return `true`, which is incorrect.

I propose a very small fix in the `….getSuperType(…)` method that consider inheritors.

I also found a change that resulted in incorrect work, since everything worked correctly before. In the `RMPI.isValueTypeMatch(…)` method, a line has appeared (highlighted in the picture) that just compares everything with `?`.
![image](https://user-images.githubusercontent.com/48187146/96421980-21b8ef00-1200-11eb-9a44-608a08f898be.png)
