### PR TITLE
Fix custom media type parser documentation

### DIFF
--- a/src/main/asciidoc/mediatypes.adoc
+++ b/src/main/asciidoc/mediatypes.adoc
@@ -832,7 +832,7 @@ public class MyMediaTypeConfiguration implements HypermediaMappingInformation {
 
   @Override
   public List<MediaType> getMediaTypes() {
-    return MediaType.parse("application/vnd-acme-media-type") <1>
+    return MediaType.parseMediaTypes("application/vnd-acme-media-type"); <1>
   }
 
   @Override


### PR DESCRIPTION
Noticed a slight error with the documentation while implementing my own custom media type for a project recently. Thanks!