### PR TITLE
#545 - Support for implicitly not required request parameters

### DIFF
--- a/src/main/java/org/springframework/hateoas/server/core/WebHandler.java
+++ b/src/main/java/org/springframework/hateoas/server/core/WebHandler.java
@@ -459,7 +459,7 @@ public class WebHandler {
 
 			RequestParam annotation = parameter.getParameterAnnotation(RequestParam.class);
 
-			if (!(annotation != null && annotation.required()) || parameter.isOptional()) {
+			if (!isRequired() || parameter.isOptional()) {
 				return SKIP_VALUE;
 			}
 

--- a/src/test/java/org/springframework/hateoas/server/mvc/WebMvcLinkBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/server/mvc/WebMvcLinkBuilderUnitTest.java
@@ -473,7 +473,7 @@ class WebMvcLinkBuilderUnitTest extends TestUtils {
 
 		Link link = linkTo(methodOn(ControllerWithMethods.class).methodForOptionalSizeWithDefaultValue(null)).withSelfRel();
 
-		assertThat(link.getHref()).endsWith("/bar");
+		assertThat(link.getHref()).endsWith("/bar{?size}");
 	}
 
 	/**


### PR DESCRIPTION
Fixes #545
Before this commit parameters annotated with `@RequestParam(defaultValue = "default")` where handled differently to parameters annotated with `@RequestParam(defaultValue = "default", required = false)`, although both annotations are semantically identicial.