### PR TITLE
Add support for @DecimalMin and @DecimalMax (or decimal) numbers annotations for Hal+Forms Min and Max property.

### DIFF
--- a/src/main/java/org/springframework/hateoas/mediatype/PropertyUtils.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/PropertyUtils.java
@@ -621,7 +621,7 @@ public class PropertyUtils {
 			}
 
 			return getAnnotationAttribute(Min.class, "value", Long.class)
-				.orElse(getAnnotationAttribute(DecimalMin.class, "value", String.class))
+				.orElse(Long.valueOf(getAnnotationAttribute(DecimalMin.class, "value", String.class)))
 				.orElse(null);
 		}
 
@@ -643,7 +643,7 @@ public class PropertyUtils {
 			}
 			
 			return getAnnotationAttribute(Max.class, "value", Long.class)
-				.orElse(getAnnotationAttribute(DecimalMax.class, "value", String.class).orElse(null))
+				.orElse(Long.valueOf(getAnnotationAttribute(DecimalMax.class, "value", String.class)))
 				.orElse(null);
 		}
 
@@ -671,7 +671,7 @@ public class PropertyUtils {
 					.orElse(null);
 		}
 
-		/*
+		/*`
 		 * (non-Javadoc)
 		 * @see org.springframework.hateoas.mediatype.PropertyUtils.DefaultPropertyMetadata#getInputType()
 		 */

--- a/src/main/java/org/springframework/hateoas/mediatype/PropertyUtils.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/PropertyUtils.java
@@ -30,6 +30,8 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
 
 import org.reactivestreams.Publisher;
 import org.springframework.beans.BeanUtils;
@@ -618,7 +620,9 @@ public class PropertyUtils {
 				}
 			}
 
-			return getAnnotationAttribute(Min.class, "value", Long.class).orElse(null);
+			return getAnnotationAttribute(Min.class, "value", Long.class)
+				.orElse(getAnnotationAttribute(DecimalMin.class, "value", String.class))
+				.orElse(null);
 		}
 
 		/*
@@ -637,8 +641,10 @@ public class PropertyUtils {
 					return attribute.get();
 				}
 			}
-
-			return getAnnotationAttribute(Max.class, "value", Long.class).orElse(null);
+			
+			return getAnnotationAttribute(Max.class, "value", Long.class)
+				.orElse(getAnnotationAttribute(DecimalMax.class, "value", String.class).orElse(null))
+				.orElse(null);
 		}
 
 		/*


### PR DESCRIPTION
Add support for @DecimalMax and @DecimalMin annotations for Spring Hateoas Hal+Forms property on min and max for decimal numbers that are annotated with @DecimalMax/Min. 