### PR TITLE
Add MARKDOWN as a supported Alps documentation format

### DIFF
--- a/src/main/java/org/springframework/hateoas/mediatype/alps/Format.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/alps/Format.java
@@ -27,7 +27,7 @@ import java.util.Locale;
  */
 public enum Format {
 
-	TEXT, HTML, ASCIIDOC;
+	TEXT, HTML, ASCIIDOC, MARKDOWN;
 
 	/*
 	 * (non-Javadoc)


### PR DESCRIPTION
What the title say (ref. current I-D version)