### PR TITLE
Add support for @JsonProperty annotation for DefaultMetadataProperty field "name".

### DIFF
--- a/src/main/java/org/springframework/hateoas/mediatype/PropertyUtils.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/PropertyUtils.java
@@ -448,7 +448,7 @@ public class PropertyUtils {
 		 */
 		@Override
 		public String getName() {
-			return property.getName();
+			return getAnnotationAttribute(JsonProperty.class, "value", String.class).orElse(property.getName());
 		}
 
 		/*
@@ -528,6 +528,20 @@ public class PropertyUtils {
 			String value = annotation.isPresent() ? annotation.getString("value") : null;
 
 			return StringUtils.hasText(value) ? value : null;
+		}
+	
+		protected <T> Optional<T> getAnnotationAttribute(Class<? extends Annotation> annotation, String attribute,
+			Class<T> type) {
+
+		MergedAnnotation<? extends Annotation> mergedAnnotation = property.getAnnotation(annotation);
+
+		if (mergedAnnotation.isPresent()) {
+			return mergedAnnotation.getValue(attribute, type);
+		}
+
+		mergedAnnotation = property.getTypeAnnotations().get(annotation);
+
+		return mergedAnnotation.isPresent() ? mergedAnnotation.getValue(attribute, type) : Optional.empty();
 		}
 	}
 
@@ -706,20 +720,6 @@ public class PropertyUtils {
 					})
 					.findFirst()
 					.orElse(null);
-		}
-
-		private <T> Optional<T> getAnnotationAttribute(Class<? extends Annotation> annotation, String attribute,
-				Class<T> type) {
-
-			MergedAnnotation<? extends Annotation> mergedAnnotation = property.getAnnotation(annotation);
-
-			if (mergedAnnotation.isPresent()) {
-				return mergedAnnotation.getValue(attribute, type);
-			}
-
-			mergedAnnotation = property.getTypeAnnotations().get(annotation);
-
-			return mergedAnnotation.isPresent() ? mergedAnnotation.getValue(attribute, type) : Optional.empty();
 		}
 	}
 }

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsTemplateBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsTemplateBuilderUnitTest.java
@@ -42,6 +42,8 @@ import org.springframework.hateoas.mediatype.MessageResolver;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * @author Oliver Drotbohm
  */
@@ -111,7 +113,7 @@ class HalFormsTemplateBuilderUnitTest {
 		HalFormsTemplate template = new HalFormsTemplateBuilder(new HalFormsConfiguration(),
 				MessageResolver.DEFAULTS_ONLY).findTemplates(new RepresentationModel<>().add(link)).get("default");
 
-		Optional<HalFormsProperty> number = template.getPropertyByName("number");
+		Optional<HalFormsProperty> number = template.getPropertyByName("example");
 		assertThat(number).map(HalFormsProperty::getMin).hasValue(2L);
 		assertThat(number).map(HalFormsProperty::getMax).hasValue(5L);
 
@@ -197,6 +199,7 @@ class HalFormsTemplateBuilderUnitTest {
 						.afford(HttpMethod.POST)
 						.withInput(PatternExample.class)
 						.toLink());
+		
 
 		Map<String, HalFormsTemplate> templates = new HalFormsTemplateBuilder(configuration, MessageResolver.DEFAULTS_ONLY)
 				.findTemplates(models);
@@ -231,6 +234,7 @@ class HalFormsTemplateBuilderUnitTest {
 
 		@Min(2) //
 		@Max(5) //
+		@JsonProperty("example")
 		Integer number;
 
 		@Length(min = 2, max = 5) //
@@ -238,5 +242,6 @@ class HalFormsTemplateBuilderUnitTest {
 
 		@Range(min = 8, max = 10) //
 		Integer range;
+		
 	}
 }


### PR DESCRIPTION
Make the default name of the DefaultMetadataProperty field "name" as the value of a @JsonProperty annotation given that the value is present, else, use the default implementation. 
Tests are located in the HalFormsTemplateBuilderUnitTest.
