### PR TITLE
#1683 - Stop filtering out affordances with HttpMethod.GET

### DIFF
--- a/src/main/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsTemplateBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsTemplateBuilder.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
-
 import org.springframework.context.MessageSourceResolvable;
 import org.springframework.hateoas.Affordance;
 import org.springframework.hateoas.AffordanceModel.InputPayloadMetadata;
@@ -28,7 +27,6 @@ import org.springframework.hateoas.Link;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.RepresentationModel;
 import org.springframework.hateoas.mediatype.MessageResolver;
-import org.springframework.http.HttpMethod;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -63,7 +61,6 @@ class HalFormsTemplateBuilder {
 					Assert.notNull(it, "No HAL Forms affordance model found but expected!");
 				}) //
 				.map(HalFormsAffordanceModel.class::cast) //
-				.filter(it -> !it.hasHttpMethod(HttpMethod.GET)) //
 				.forEach(it -> {
 
 					HalFormsTemplate template = HalFormsTemplate.forMethod(it.getHttpMethod()) //

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsTemplateBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsTemplateBuilderUnitTest.java
@@ -206,6 +206,22 @@ class HalFormsTemplateBuilderUnitTest {
 		});
 	}
 
+	@Test // #1683
+	void allowHttpGetAffordances() {
+
+		Link link = Affordances.of(Link.of("/example", LinkRelation.of("getExample"))) //
+				.afford(HttpMethod.GET) //
+				.withName("getExample")
+				.toLink();
+
+		Map<String, HalFormsTemplate> templates = new HalFormsTemplateBuilder(new HalFormsConfiguration(),
+				MessageResolver.DEFAULTS_ONLY).findTemplates(new RepresentationModel<>().add(link));
+
+		HalFormsTemplate defaultTemplate = templates.get("default");
+		assertThat(defaultTemplate).isNotNull();
+		assertThat(defaultTemplate.getHttpMethod()).isEqualTo(HttpMethod.GET);
+	}
+
 	@Getter
 	static class PatternExample extends RepresentationModel<PatternExample> {
 

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsWebMvcIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsWebMvcIntegrationTest.java
@@ -75,12 +75,17 @@ class HalFormsWebMvcIntegrationTest {
 				.andExpect(jsonPath("$._links['self'].href", is("http://localhost/employees/0")))
 				.andExpect(jsonPath("$._links['employees'].href", is("http://localhost/employees")))
 
-				.andExpect(jsonPath("$._templates.*", hasSize(2)))
-				.andExpect(jsonPath("$._templates['default'].method", is("put")))
-				.andExpect(jsonPath("$._templates['default'].properties[0].name", is("name")))
-				.andExpect(jsonPath("$._templates['default'].properties[0].required").value(true))
-				.andExpect(jsonPath("$._templates['default'].properties[1].name", is("role")))
-				.andExpect(jsonPath("$._templates['default'].properties[1].required").doesNotExist())
+				.andExpect(jsonPath("$._templates.*", hasSize(4)))
+				.andExpect(jsonPath("$._templates['default'].method", is("get")))
+
+				.andExpect(jsonPath("$._templates['all'].method", is("get")))
+				.andExpect(jsonPath("$._templates['all'].target", is("http://localhost/employees")))
+
+				.andExpect(jsonPath("$._templates['updateEmployee'].method", is("put")))
+				.andExpect(jsonPath("$._templates['updateEmployee'].properties[0].name", is("name")))
+				.andExpect(jsonPath("$._templates['updateEmployee'].properties[0].required").value(true))
+				.andExpect(jsonPath("$._templates['updateEmployee'].properties[1].name", is("role")))
+				.andExpect(jsonPath("$._templates['updateEmployee'].properties[1].required").doesNotExist())
 
 				.andExpect(jsonPath("$._templates['partiallyUpdateEmployee'].method", is("patch")))
 				.andExpect(jsonPath("$._templates['partiallyUpdateEmployee'].properties[0].name", is("name")))
@@ -104,12 +109,18 @@ class HalFormsWebMvcIntegrationTest {
 				.andExpect(jsonPath("$._links.*", hasSize(1)))
 				.andExpect(jsonPath("$._links['self'].href", is("http://localhost/employees")))
 
-				.andExpect(jsonPath("$._templates.*", hasSize(1)))
-				.andExpect(jsonPath("$._templates['default'].method", is("post")))
-				.andExpect(jsonPath("$._templates['default'].properties[0].name", is("name")))
-				.andExpect(jsonPath("$._templates['default'].properties[0].required").value(true))
-				.andExpect(jsonPath("$._templates['default'].properties[1].name", is("role")))
-				.andExpect(jsonPath("$._templates['default'].properties[1].required").doesNotExist());
+				.andExpect(jsonPath("$._templates.*", hasSize(3)))
+
+				.andExpect(jsonPath("$._templates['default'].method", is("get")))
+
+				.andExpect(jsonPath("$._templates['search'].method", is("get")))
+				.andExpect(jsonPath("$._templates['search'].target", is("http://localhost/employees/search")))
+
+				.andExpect(jsonPath("$._templates['newEmployee'].method", is("post")))
+				.andExpect(jsonPath("$._templates['newEmployee'].properties[0].name", is("name")))
+				.andExpect(jsonPath("$._templates['newEmployee'].properties[0].required").value(true))
+				.andExpect(jsonPath("$._templates['newEmployee'].properties[1].name", is("role")))
+				.andExpect(jsonPath("$._templates['newEmployee'].properties[1].required").doesNotExist());
 	}
 
 	@Test


### PR DESCRIPTION
This PR tries to address the issue raised by https://github.com/spring-projects/spring-hateoas/issues/1683 by no longer filtering out affordances with `HttpMethod.GET`. 

I began fixing the tests (e.g. `HalFormsWebMvcIntegrationTest`) but am now unsure why each link seems to get an explicit Affordance that points to itself. That is, the tests fail because we are now emitting a GET affordance for each link even though it was not explicitly added by the user. I suspect this is why the filter in `HalFormsTemplateBuilder` was added in the first place?

As it stands this PR would break a lot of people's code. Is there a fundamental reason we don't want to support the user explicitly creating an affordance that points to a  `HttpMethod.GET` method?

Happy to fix the remaining tests if required.