### PR TITLE
Fixes Flaky tests

### DIFF
--- a/src/main/java/org/springframework/hateoas/Link.java
+++ b/src/main/java/org/springframework/hateoas/Link.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
  * Value object for links.
@@ -42,7 +43,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @author Greg Turnquist
  * @author Jens Schauder
  */
+// private Link(LinkRelation rel, String href, @Nullable String hreflang, @Nullable String media, @Nullable String title,
+// @Nullable String type, @Nullable String deprecation, @Nullable String profile, @Nullable String name,
+// @Nullable UriTemplate template, List<Affordance> affordances) {
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"rel", "href", "hreflang", "media", "title", "type", "deprecation", "profile", "name", "template", "affordances"})
 @JsonIgnoreProperties(value = { "templated", "template" }, ignoreUnknown = true)
 public class Link implements Serializable {
 

--- a/src/main/java/org/springframework/hateoas/Link.java
+++ b/src/main/java/org/springframework/hateoas/Link.java
@@ -43,9 +43,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * @author Greg Turnquist
  * @author Jens Schauder
  */
-// private Link(LinkRelation rel, String href, @Nullable String hreflang, @Nullable String media, @Nullable String title,
-// @Nullable String type, @Nullable String deprecation, @Nullable String profile, @Nullable String name,
-// @Nullable UriTemplate template, List<Affordance> affordances) {
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"rel", "href", "hreflang", "media", "title", "type", "deprecation", "profile", "name", "template", "affordances"})
 @JsonIgnoreProperties(value = { "templated", "template" }, ignoreUnknown = true)

--- a/src/main/java/org/springframework/hateoas/PagedModel.java
+++ b/src/main/java/org/springframework/hateoas/PagedModel.java
@@ -29,6 +29,7 @@ import org.springframework.util.Assert;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
  * DTO to implement binding response representations of pageable collections.
@@ -388,6 +389,7 @@ public class PagedModel<T> extends CollectionModel<T> {
 	 *
 	 * @author Oliver Gierke
 	 */
+	@JsonPropertyOrder({"size", "totalElements", "totalPages", "number"})
 	public static class PageMetadata {
 
 		@JsonProperty private long size;

--- a/src/main/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsProperty.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsProperty.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
  * Describe a parameter for the associated state transition in a HAL-FORMS document. A {@link HalFormsTemplate} may
@@ -35,6 +36,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @see https://mamund.site44.com/misc/hal-forms/
  */
 @JsonInclude(Include.NON_DEFAULT)
+@JsonPropertyOrder({"name", "prompt", "regex", "placeholder", "value", "templated", "multi", "readOnly", "required", "min", "max", "minLength", "maxLength", "type", "options"})
 final class HalFormsProperty implements Named {
 
 	private final String name, prompt, regex, placeholder;

--- a/src/main/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsTemplateBuilder.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsTemplateBuilder.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.hateoas.mediatype.hal.forms;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -53,7 +53,7 @@ class HalFormsTemplateBuilder {
 	 */
 	public Map<String, HalFormsTemplate> findTemplates(RepresentationModel<?> resource) {
 
-		Map<String, HalFormsTemplate> templates = new HashMap<>();
+		Map<String, HalFormsTemplate> templates = new LinkedHashMap<>();
 		Link selfLink = resource.getLink(IanaLinkRelations.SELF).orElse(null);
 
 		resource.getLinks().stream() //

--- a/src/main/java/org/springframework/hateoas/mediatype/problem/Problem.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/problem/Problem.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
 /**
@@ -42,6 +43,7 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped;
  * @author Greg Turnquist
  * @author Oliver Drotbohm
  */
+@JsonPropertyOrder({"type", "title", "detail", "instance"})
 @JsonInclude(Include.NON_NULL)
 public class Problem {
 

--- a/src/test/java/org/springframework/hateoas/EntityModelIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/EntityModelIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -87,6 +88,7 @@ class EntityModelIntegrationTest extends AbstractJackson2MarshallingIntegrationT
 		protected PersonModel() {}
 	}
 
+	@JsonPropertyOrder({"firstname", "lastname"})
 	@JsonAutoDetect(fieldVisibility = Visibility.ANY)
 	static class Person {
 

--- a/src/test/java/org/springframework/hateoas/IanaLinkRelationUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/IanaLinkRelationUnitTest.java
@@ -16,6 +16,7 @@
 package org.springframework.hateoas;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import lombok.Value;
 
@@ -107,7 +108,7 @@ class IanaLinkRelationUnitTest {
 				.map(String.class::cast) //
 				.collect(Collectors.toSet());
 
-		assertThat(linkRelations).containsExactlyElementsOf(stringConstants);
+		assertEquals(linkRelations, stringConstants);
 	}
 
 	/**

--- a/src/test/java/org/springframework/hateoas/Jackson2PagedResourcesIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/Jackson2PagedResourcesIntegrationTest.java
@@ -24,6 +24,8 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Collections;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import org.apache.commons.io.output.WriterOutputStream;
 import org.junit.jupiter.api.Test;
 import org.springframework.hateoas.PagedModel.PageMetadata;
@@ -86,6 +88,7 @@ class Jackson2PagedResourcesIntegrationTest {
 		CollectionModel<?> someMethod();
 	}
 
+	@JsonPropertyOrder({"firstname", "lastname"})
 	static class User {
 		public String firstname, lastname;
 	}

--- a/src/test/java/org/springframework/hateoas/Jackson2ResourceIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/Jackson2ResourceIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
  * Integration tests for {@link EntityModel}.
@@ -54,6 +55,7 @@ class Jackson2ResourceIntegrationTest extends AbstractJackson2MarshallingIntegra
 		}
 	}
 
+	@JsonPropertyOrder({"firstname", "lastname"})
 	@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 	static class Person {
 

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/HalModelBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/HalModelBuilderUnitTest.java
@@ -49,6 +49,7 @@ import org.springframework.util.StringUtils;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -387,6 +388,7 @@ public class HalModelBuilderUnitTest {
 
 	@Value
 	@AllArgsConstructor
+	@JsonPropertyOrder({"name", "born", "died"})
 	static class Author {
 
 		private String name;

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/HalModelBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/HalModelBuilderUnitTest.java
@@ -406,6 +406,7 @@ public class HalModelBuilderUnitTest {
 
 	@Value
 	@AllArgsConstructor
+	@JsonPropertyOrder({"name", "price"})
 	static class Product {
 
 		private String name;

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/Jackson2HalIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/Jackson2HalIntegrationTest.java
@@ -21,6 +21,8 @@ import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 
 import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -58,6 +60,7 @@ import org.springframework.lang.Nullable;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
@@ -721,6 +724,9 @@ class Jackson2HalIntegrationTest {
 		mapper.registerModule(new Jackson2HalModule());
 		mapper.setHandlerInstantiator(
 				new HalHandlerInstantiator(new AnnotationLinkRelationProvider(), provider, MessageResolver.of(messageSource)));
+				
+		// the current alternative SerializationFeature.ORDERED_MAP_ENTRIES_BY_KEYS does not sort nested keys
+		mapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
 
 		return mapper;
 	}

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/Jackson2HalIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/Jackson2HalIntegrationTest.java
@@ -21,8 +21,6 @@ import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 
 import java.io.IOException;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/SimplePojo.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/SimplePojo.java
@@ -6,7 +6,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+@JsonPropertyOrder({"text", "number"})
 @Data
 @Getter(onMethod = @__(@JsonProperty))
 @NoArgsConstructor

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/forms/Jackson2HalFormsIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/forms/Jackson2HalFormsIntegrationTest.java
@@ -76,6 +76,7 @@ import org.springframework.lang.Nullable;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.jayway.jsonpath.DocumentContext;
@@ -668,6 +669,8 @@ class Jackson2HalFormsIntegrationTest {
 		return MappingTestUtils.createMapper(Jackson2HalFormsIntegrationTest.class, configurer.andThen(it -> {
 			it.setHandlerInstantiator(new Jackson2HalModule.HalHandlerInstantiator(this.provider, provider,
 					resolver, new HalConfiguration(), factory));
+			// the current alternative SerializationFeature.ORDERED_MAP_ENTRIES_BY_KEYS does not sort nested keys
+			it.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
 		}));
 	}
 

--- a/src/test/java/org/springframework/hateoas/mediatype/problem/JacksonSerializationTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/problem/JacksonSerializationTest.java
@@ -42,6 +42,7 @@ import org.springframework.http.HttpStatus;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
@@ -332,6 +333,7 @@ class JacksonSerializationTest {
 	 */
 	@Value
 	@Getter(onMethod = @__(@JsonProperty))
+	@JsonPropertyOrder({"balance", "accounts"})
 	@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 	@NoArgsConstructor(staticName = "empty", force = true)
 	@With

--- a/src/test/java/org/springframework/hateoas/server/core/TypeReferencesIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/server/core/TypeReferencesIntegrationTest.java
@@ -24,6 +24,8 @@ import lombok.Data;
 
 import java.util.Collection;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -218,6 +220,7 @@ class TypeReferencesIntegrationTest {
 	}
 
 	@Data
+	@JsonPropertyOrder({"firstname", "lastname"})
 	static class User {
 		public String firstname, lastname;
 	}

--- a/src/test/java/org/springframework/hateoas/support/Employee.java
+++ b/src/test/java/org/springframework/hateoas/support/Employee.java
@@ -22,6 +22,7 @@ import lombok.With;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
  * @author Greg Turnquist
@@ -30,6 +31,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @With
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder({"name", "role"})
 public class Employee {
 
 	private @NotNull String name;


### PR DESCRIPTION
There a several flaky tests and this PR fixes those. The problems are entirely ordering issues, and the proposed solutions is mainly to use annotations `@JsonPropertyOrder`. 

The flakiness can be test with `mvn -pl . edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=TESTNAME`

Tests fixed:
- `config.CustomHypermediaWebFluxTest#getUsingCustomMediaType`
- `config.CustomHypermediaWebMvcTest#getUsingCustomMediaType`
- `EntityModelIntegrationTest#inlinesContent`
- `IanaLinkRelationUnitTest#testAllIanaLinkRelationsHaveStringConstant`
- `Jackson2LinkIntegrationTest#writesLinkCorrectly`
- `Jackson2ResourceSupportIntegrationTest#doesNotRenderId`
- `Jackson2ResourceIntegrationTest#inlinesContent`
- `Jackson2PagedResourcesIntegrationTest#serializesPagedResourcesCorrectly`
- `mediatype.collectionjson.Jackson2CollectionJsonIntegrationTest#renderComplexStructure`
- `mediatype.collectionjson.Jackson2CollectionJsonIntegrationTest#renderSimplePojos`
- `mediatype.collectionjson.Jackson2CollectionJsonIntegrationTest#rendersMultipleLinkAsArray`
- `mediatype.collectionjson.Jackson2CollectionJsonIntegrationTest#serializesPagedResource`
- `mediatype.hal.forms.HalFormsObjectMapperCustomizerTest#objectMapperCustomizerShouldBeApplied`
- `mediatype.hal.forms.Jackson2HalFormsIntegrationTest#rendersTitleIfMessageSourceResolvesLocalKey`
- `mediatype.hal.forms.Jackson2HalFormsIntegrationTest#rendersTitleIfMessageSourceResolvesNamespacedKey`
- `mediatype.hal.forms.Jackson2HalFormsIntegrationTest#rendersCuriesCorrectly`
- `mediatype.hal.forms.Jackson2HalFormsIntegrationTest#rendersMultipleResourceResourcesAsEmbedded`
- `mediatype.hal.forms.Jackson2HalFormsIntegrationTest#rendersRepresentationModelWithTemplates`
- `mediatype.hal.forms.Jackson2HalFormsIntegrationTest#rendersMultipleCuries`
- `mediatype.hal.forms.Jackson2HalFormsIntegrationTest#rendersResource`
- `mediatype.hal.forms.Jackson2HalFormsIntegrationTest#serializesAnnotatedResourceResourcesAsEmbedded`
- `mediatype.hal.forms.Jackson2HalFormsIntegrationTest#serializesMultipleAnnotatedResourceResourcesAsEmbedded`
- `mediatype.hal.forms.Jackson2HalFormsIntegrationTest#serializesPagedResource`
- `mediatype.hal.Jackson2HalIntegrationTest#rendersTitleIfMessageSourceResolvesLocalKey`
- `mediatype.hal.Jackson2HalIntegrationTest#rendersTitleIfMessageSourceResolvesNamespacedKey`
- `mediatype.hal.Jackson2HalIntegrationTest#rendersAllExtraRFC8288Attributes`
- `mediatype.hal.Jackson2HalIntegrationTest#rendersMultipleCuries`
- `mediatype.hal.Jackson2HalIntegrationTest#rendersMultipleResourceResourcesAsEmbedded`
- `mediatype.hal.Jackson2HalIntegrationTest#serializesAnnotatedResourceResourcesAsEmbedded`
- `mediatype.hal.Jackson2HalIntegrationTest#serializesPagedResource`
- `mediatype.hal.HalModelBuilderUnitTest#previewForLinkRelationsUsingHalModelBuilder`
- `mediatype.hal.HalModelBuilderUnitTest#progressivelyAddingContentUsingHalModelBuilder`
- `mediatype.hal.HalModelBuilderUnitTest#renderDifferentlyTypedEntities`
- `mediatype.hal.HalModelBuilderUnitTest#renderExplicitAndImplicitLinkRelations`
- `mediatype.hal.HalModelBuilderUnitTest#renderSingleItemUsingDefaultModelBuilder`
- `mediatype.hal.HalModelBuilderUnitTest#renderSingleItemUsingHalModelBuilder`
- `mediatype.hal.HalModelBuilderUnitTest#embeddedSpecUsingHalModelBuilder`
- `mediatype.hal.HalObjectMapperCustomizerTest#objectMapperCustomizerShouldBeApplied`
- `mediatype.problem.JacksonSerializationTest#extensionSerialize`
- `RepresentationModelIntegrationTest#doesNotRenderId`