### PR TITLE
Performance improvements in `TemplateVariable.essence()`

### DIFF
--- a/src/main/java/org/springframework/hateoas/TemplateVariable.java
+++ b/src/main/java/org/springframework/hateoas/TemplateVariable.java
@@ -288,10 +288,14 @@ public final class TemplateVariable implements Serializable, UriTemplate.Expanda
 	}
 
 	String essence() {
-
-		return String.format("%s%s%s", name,
-				limit != -1 ? ":".concat(String.valueOf(limit)) : "",
-				isComposite() ? "*" : "");
+		StringBuilder essenceBuilder = new StringBuilder(name);
+		if (limit != -1) {
+			essenceBuilder = essenceBuilder.append(":").append(limit);
+		}
+		if (isComposite()) {
+			essenceBuilder = essenceBuilder.append("*");
+		}
+		return essenceBuilder.toString();
 	}
 
 	public String getName() {

--- a/src/test/java/org/springframework/hateoas/TemplateVariablesUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/TemplateVariablesUnitTest.java
@@ -35,7 +35,7 @@ class TemplateVariablesUnitTest {
 	 * @see #137
 	 */
 	@Test
-	void rendersNoTempalteVariablesAsEmptyString() {
+	void rendersNoTemplateVariablesAsEmptyString() {
 		assertThat(TemplateVariables.NONE.toString()).isEqualTo("");
 	}
 
@@ -47,6 +47,18 @@ class TemplateVariablesUnitTest {
 
 		TemplateVariables variables = new TemplateVariables(new TemplateVariable("foo", SEGMENT));
 		assertThat(variables.toString()).isEqualTo("{/foo}");
+	}
+
+	@Test
+	void rendersCompositeVariableCorrectly() {
+		TemplateVariables variables = new TemplateVariables(new TemplateVariable("bars", SIMPLE).composite());
+		assertThat(variables.toString()).isEqualTo("{bars*}");
+	}
+
+	@Test
+	void rendersLimitedVariableCorrectly() {
+		TemplateVariables variables = new TemplateVariables(new TemplateVariable("apples", SIMPLE).limit(5));
+		assertThat(variables.toString()).isEqualTo("{apples:5}");
 	}
 
 	/**
@@ -151,7 +163,7 @@ class TemplateVariablesUnitTest {
 	 * @see #217
 	 */
 	@Test
-	void considersFragementVariable() {
+	void considersFragmentVariable() {
 
 		assertThat(new TemplateVariable("foo", VariableType.FRAGMENT).isFragment()).isTrue();
 		assertThat(new TemplateVariable("foo", VariableType.REQUEST_PARAM).isFragment()).isFalse();


### PR DESCRIPTION
Noticed this took a relatively large portion of time when Unit tests of LinkBuilding (via Integration testing and Testing Controller layer), due to String format needing to parse the format string for each template variable

Minor spell corrections on test methods when spotted

