### PR TITLE
Optimization around constructing `UriTemplate` with multiple template variables of the same type

### DIFF
--- a/src/main/java/org/springframework/hateoas/TemplateVariable.java
+++ b/src/main/java/org/springframework/hateoas/TemplateVariable.java
@@ -19,11 +19,7 @@ import static org.springframework.hateoas.TemplateVariable.VariableType.*;
 
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -499,7 +495,7 @@ public final class TemplateVariable implements Serializable, UriTemplate.Expanda
 		 */
 		COMPOSITE_PARAM("*", "", true);
 
-		private static final List<VariableType> COMBINABLE_TYPES = Arrays.asList(REQUEST_PARAM, REQUEST_PARAM_CONTINUED);
+		private static final EnumSet<VariableType> COMBINABLE_TYPES = EnumSet.of(REQUEST_PARAM, REQUEST_PARAM_CONTINUED);
 		static final String DEFAULT_SEPARATOR = ",";
 
 		private final String key, combiner;

--- a/src/main/java/org/springframework/hateoas/TemplateVariables.java
+++ b/src/main/java/org/springframework/hateoas/TemplateVariables.java
@@ -68,11 +68,12 @@ public final class TemplateVariables implements Iterable<TemplateVariable>, Seri
 
 		for (TemplateVariable variable : variables) {
 
-			processed.add(variable.isRequestParameterVariable() && requestParameterFound
+			boolean isRequestParameter = variable.isRequestParameterVariable();
+			processed.add(isRequestParameter && requestParameterFound
 					? variable.withType(REQUEST_PARAM_CONTINUED)
 					: variable);
 
-			if (variable.isRequestParameterVariable()) {
+			if (isRequestParameter) {
 				requestParameterFound = true;
 			}
 		}
@@ -100,12 +101,11 @@ public final class TemplateVariables implements Iterable<TemplateVariable>, Seri
 
 		List<TemplateVariable> result = new ArrayList<>(this.variables.size() + variables.size());
 		result.addAll(this.variables);
-
-		List<TemplateVariable> filtered = variables.stream() //
-				.filter(variable -> !containsEquivalentFor(variable)).collect(Collectors.toList());
-
-		result.addAll(filtered);
-
+		for (TemplateVariable otherVariable : variables) {
+			if (!containsEquivalentFor(otherVariable)) {
+				result.add(otherVariable);
+			}
+		}
 		return new TemplateVariables(result);
 	}
 
@@ -133,9 +133,12 @@ public final class TemplateVariables implements Iterable<TemplateVariable>, Seri
 	}
 
 	private boolean containsEquivalentFor(TemplateVariable candidate) {
-
-		return this.variables.stream() //
-				.anyMatch(variable -> variable.isEquivalent(candidate));
+		for (TemplateVariable variable : variables) {
+			if (variable.isEquivalent(candidate)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/*


### PR DESCRIPTION
when supplying TemplateVariables of same Type.

This is done to reduce the repeated merge routines on ExpandGroups

I believe the current implementation degrades when more template variables are added, to demonstrate this
```
    @Benchmark
    @Fork(warmups = 1, value = 1)
    public void concat() {
        List<TemplateVariable> templateVariables = new LinkedList<>();
        for (int i = 0; i < 30; i++) {
            templateVariables.add(new TemplateVariable("a" + i, TemplateVariable.VariableType.REQUEST_PARAM));
        }
        TemplateVariables variables = new TemplateVariables(templateVariables);

        String uri = "http://localhost/autotrader/makes";
        UriTemplate template = UriTemplate.of(uri, variables);

    }
 ```
### Results

Before
```
Benchmark                Mode  Cnt     Score    Error  Units
BenchmarkRunner.concat  thrpt    5  8177.940 ± 55.365  ops/s
```


After

```

Benchmark                Mode  Cnt       Score       Error  Units
BenchmarkRunner.concat  thrpt    5  109527.885 ± 20025.995  ops/s
```


Hope this is ok and helpful! :)