### PR TITLE
Change UriTemplate constructor to of() method in documentation

### DIFF
--- a/src/main/asciidoc/mediatypes.adoc
+++ b/src/main/asciidoc/mediatypes.adoc
@@ -260,7 +260,7 @@ public class Config {
 
   @Bean
   public CurieProvider curieProvider() {
-    return new DefaultCurieProvider("ex", new UriTemplate("https://www.example.com/rels/{rel}"));
+    return new DefaultCurieProvider("ex", UriTemplate.of("https://www.example.com/rels/{rel}"));
   }
 }
 ----


### PR DESCRIPTION
The second parameter of the `DefaultCurieProvider` constructor is a `org.springframework.hateoas.UriTemplate`. But it has no constructor, it has an `of()` static factory method.