### PR TITLE
Support for HAL-FORMS value element

### DIFF
--- a/src/main/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsConfiguration.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsConfiguration.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.hateoas.mediatype.hal.forms;
 
+import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.json.JsonMapper.Builder;
 
 import java.util.ArrayList;
@@ -45,6 +46,7 @@ public class HalFormsConfiguration {
 	private final Map<Class<?>, String> patterns;
 	private final UnaryOperator<Builder> mapperCustomizer;
 	private final HalFormsOptionsFactory options;
+	private final HalFormsValueFactory values;
 	private final List<MediaType> mediaTypes;
 	private final boolean defaultSingleTemplate;
 
@@ -61,24 +63,26 @@ public class HalFormsConfiguration {
 	 * @param halConfiguration must not be {@literal null}.
 	 */
 	public HalFormsConfiguration(HalConfiguration halConfiguration) {
-		this(halConfiguration, new HashMap<>(), new HalFormsOptionsFactory(), UnaryOperator.identity(),
+		this(halConfiguration, new HashMap<>(), new HalFormsOptionsFactory(), new HalFormsValueFactory(), UnaryOperator.identity(),
 				Collections.singletonList(MediaTypes.HAL_FORMS_JSON), false);
 	}
 
 	private HalFormsConfiguration(HalConfiguration halConfiguration, Map<Class<?>, String> patterns,
-			HalFormsOptionsFactory options, UnaryOperator<Builder> mapperCustomizer, List<MediaType> mediaTypes,
+			HalFormsOptionsFactory options, HalFormsValueFactory values, UnaryOperator<Builder> mapperCustomizer, List<MediaType> mediaTypes,
 			boolean defaultSingleTemplate) {
 
 		Assert.notNull(halConfiguration, "HalConfiguration must not be null!");
 		Assert.notNull(patterns, "Patterns must not be null!");
 		Assert.notNull(mapperCustomizer, "Mapper customizer must not be null!");
 		Assert.notNull(options, "HalFormsSuggests must not be null!");
+		Assert.notNull(values, "HalFormsValueFactory must not be null!");
 		Assert.notNull(mediaTypes, "Media types must not be null!");
 
 		this.halConfiguration = halConfiguration;
 		this.patterns = patterns;
 		this.mapperCustomizer = mapperCustomizer;
 		this.options = options;
+		this.values = values;
 		this.mediaTypes = new ArrayList<>(mediaTypes);
 		this.defaultSingleTemplate = defaultSingleTemplate;
 	}
@@ -98,7 +102,7 @@ public class HalFormsConfiguration {
 		Map<Class<?>, String> newPatterns = new HashMap<>(patterns);
 		newPatterns.put(type, pattern);
 
-		return new HalFormsConfiguration(halConfiguration, newPatterns, options, mapperCustomizer, mediaTypes,
+		return new HalFormsConfiguration(halConfiguration, newPatterns, options, values, mapperCustomizer, mediaTypes,
 				defaultSingleTemplate);
 	}
 
@@ -111,7 +115,7 @@ public class HalFormsConfiguration {
 	 */
 	public HalFormsConfiguration withMapperBuilderCustomizer(UnaryOperator<Builder> customizer) {
 
-		return new HalFormsConfiguration(halConfiguration, patterns, options, customizer, mediaTypes,
+		return new HalFormsConfiguration(halConfiguration, patterns, options, values, customizer, mediaTypes,
 				defaultSingleTemplate);
 	}
 
@@ -135,7 +139,7 @@ public class HalFormsConfiguration {
 		List<MediaType> newMediaTypes = new ArrayList<>(mediaTypes);
 		newMediaTypes.add(mediaTypes.size() - 1, mediaType);
 
-		return new HalFormsConfiguration(halConfiguration, patterns, options, mapperCustomizer, newMediaTypes,
+		return new HalFormsConfiguration(halConfiguration, patterns, options, values, mapperCustomizer, newMediaTypes,
 				defaultSingleTemplate);
 	}
 
@@ -165,7 +169,14 @@ public class HalFormsConfiguration {
 	public <T> HalFormsConfiguration withOptions(Class<T> type, String property,
 			Function<PropertyMetadata, HalFormsOptions> creator) {
 
-		return new HalFormsConfiguration(halConfiguration, patterns, options.withOptions(type, property, creator),
+		return new HalFormsConfiguration(halConfiguration, patterns, options.withOptions(type, property, creator), values,
+				mapperCustomizer, mediaTypes, defaultSingleTemplate);
+	}
+
+	public <T> HalFormsConfiguration withValues(Class<T> type, String property,
+			Function<PropertyMetadata, @Nullable Object> creator) {
+
+		return new HalFormsConfiguration(halConfiguration, patterns, options, values.withValues(type, property, creator),
 				mapperCustomizer, mediaTypes, defaultSingleTemplate);
 	}
 
@@ -179,7 +190,7 @@ public class HalFormsConfiguration {
 	 */
 	public HalFormsConfiguration withDefaultSingleTemplate(boolean defaultSingleTemplate) {
 
-		return new HalFormsConfiguration(halConfiguration, patterns, options, mapperCustomizer, mediaTypes,
+		return new HalFormsConfiguration(halConfiguration, patterns, options, values, mapperCustomizer, mediaTypes,
 				defaultSingleTemplate);
 	}
 
@@ -199,6 +210,15 @@ public class HalFormsConfiguration {
 	 */
 	HalFormsOptionsFactory getOptionsFactory() {
 		return options;
+	}
+
+	/**
+	 * Returns the {@link HalFormsValueFactory} to look up value from payload and property metadata.
+	 *
+	 * @return will never be {@literal null}.
+	 */
+	HalFormsValueFactory getValuesFactory() {
+		return values;
 	}
 
 	/**

--- a/src/main/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsPropertyFactory.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsPropertyFactory.java
@@ -79,6 +79,7 @@ class HalFormsPropertyFactory {
 		}
 
 		HalFormsOptionsFactory optionsFactory = configuration.getOptionsFactory();
+		HalFormsValueFactory valuesFactory = configuration.getValuesFactory();
 
 		return model.createProperties((payload, metadata) -> {
 
@@ -95,7 +96,7 @@ class HalFormsPropertyFactory {
 					.withMaxLength(metadata.getMaxLength())
 					.withRegex(lookupRegex(metadata)) //
 					.withType(inputType) //
-					.withValue(options != null ? options.getSelectedValue() : null) //
+					.withValue(options != null ? options.getSelectedValue() : valuesFactory.getValue(payload, metadata)) //
 					.withOptions(options);
 
 			Function<String, I18nedPropertyMetadata> factory = I18nedPropertyMetadata.factory(payload, property);

--- a/src/main/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsValueFactory.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsValueFactory.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.hateoas.mediatype.hal.forms;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.hateoas.AffordanceModel;
+import org.springframework.util.Assert;
+
+/**
+ *
+ * Factory implementation to register creator functions to eventually create value from
+ * {@link AffordanceModel.PropertyMetadata} to decouple the registration (via {@link HalFormsConfiguration}) from the consumption during
+ * rendering.
+ *
+ * @author Réda Housni Alaoui
+ */
+class HalFormsValueFactory {
+
+	private final Map<Class<?>, Map<String, Function<AffordanceModel.PropertyMetadata, @Nullable Object>>> values;
+
+	/**
+	 * Creates a new, empty {@link HalFormsValueFactory}.
+	 */
+	public HalFormsValueFactory() {
+		this.values = new HashMap<>();
+	}
+
+	/**
+	 * Copy-constructor to keep {@link HalFormsValueFactory} immutable during registrations.
+	 *
+	 * @param values must not be {@literal null}.
+	 */
+	private HalFormsValueFactory(Map<Class<?>, Map<String, Function<AffordanceModel.PropertyMetadata, @Nullable Object>>> values) {
+		this.values = values;
+	}
+
+	/**
+	 * Registers a {@link Function} to create a {@link String} instance from the given {@link AffordanceModel.PropertyMetadata}
+	 * to supply value for the given property of the given type.
+	 *
+	 * @param type must not be {@literal null}.
+	 */
+	HalFormsValueFactory withValues(Class<?> type, String property,
+									   Function<AffordanceModel.PropertyMetadata, @Nullable Object> creator) {
+
+		Assert.notNull(type, "Type must not be null!");
+		Assert.hasText(property, "Property must not be null or empty!");
+		Assert.notNull(creator, "Creator function must not be null!");
+
+		Map<Class<?>, Map<String, Function<AffordanceModel.PropertyMetadata, @Nullable Object>>> values = new HashMap<>(this.values);
+
+		values.compute(type, (it, map) -> {
+
+			if (map == null) {
+				map = new HashMap<>();
+			}
+
+			map.put(property, creator);
+
+			return map;
+		});
+
+		return new HalFormsValueFactory(values);
+	}
+
+	/**
+	 * Returns the value to be used for the property with the given {@link AffordanceModel.PayloadMetadata} and
+	 * {@link AffordanceModel.PropertyMetadata}.
+	 *
+	 * @param payload must not be {@literal null}.
+	 * @param property must not be {@literal null}.
+	 */
+	@Nullable
+	Object getValue(AffordanceModel.PayloadMetadata payload, AffordanceModel.PropertyMetadata property) {
+
+		Assert.notNull(payload, "Payload metadata must not be null!");
+		Assert.notNull(property, "Property metadata must not be null!");
+
+		Class<?> type = payload.getType();
+		String name = property.getName();
+
+		Map<String, Function<AffordanceModel.PropertyMetadata, @Nullable Object>> map = values.get(type);
+
+		if (map == null) {
+			return null;
+		}
+
+		Function<AffordanceModel.PropertyMetadata, @Nullable Object> function = map.get(name);
+
+		return function == null ? null : function.apply(property);
+	}
+
+}

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsTemplateBuilderUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/forms/HalFormsTemplateBuilderUnitTest.java
@@ -201,6 +201,44 @@ class HalFormsTemplateBuilderUnitTest {
 				});
 	}
 
+	@Test
+	void rendersStringValue() {
+		String value = "1234123412341234";
+
+		HalFormsConfiguration configuration = new HalFormsConfiguration() //
+				.withValues(PatternExample.class, "number", metadata -> value);
+
+		RepresentationModel<?> models = new RepresentationModel<>(
+				Affordances.of(Link.of("/example", LinkRelation.of("create"))) //
+						.afford(HttpMethod.POST) //
+						.withInput(PatternExample.class) //
+						.toLink());
+
+		Map<String, HalFormsTemplate> templates = new HalFormsTemplateBuilder(configuration, MessageResolver.DEFAULTS_ONLY)
+				.findTemplates(models);
+
+		assertThat(templates.get("postPatternExample").getPropertyByName("number")) //
+				.hasValueSatisfying(it -> assertThat(it.getValue()).isEqualTo(value));
+	}
+
+	@Test
+	void rendersBooleanValue() {
+		HalFormsConfiguration configuration = new HalFormsConfiguration() //
+				.withValues(PatternExample.class, "number", metadata -> true);
+
+		RepresentationModel<?> models = new RepresentationModel<>(
+				Affordances.of(Link.of("/example", LinkRelation.of("create"))) //
+						.afford(HttpMethod.POST) //
+						.withInput(PatternExample.class) //
+						.toLink());
+
+		Map<String, HalFormsTemplate> templates = new HalFormsTemplateBuilder(configuration, MessageResolver.DEFAULTS_ONLY)
+				.findTemplates(models);
+
+		assertThat(templates.get("postPatternExample").getPropertyByName("number")) //
+				.hasValueSatisfying(it -> assertThat(it.getValue()).isEqualTo(true));
+	}
+
 	@Test // #1510
 	void propagatesSelectedValueToProperty() {
 


### PR DESCRIPTION
Fixes #1717

# Behaviour before this change

Let be:
```java

  class MyController {
    @GetMapping
    public ResponseEntity<?> list() {
      Link selfLink = selfLink.andAffordance(afford(methodOn(MyController.class).create(null)));
      return ResponseEntity.ok(new RepresentationModel<>(selfLink));
    }
  
    @PostMapping
    public ResponseEntity<?> create(@RequestBody Payload payload) {
      return ResponseEntity.created().build();
    }
  }
  
  record Payload(String foo, String bar) {
    Payload {
     // 'foo' and 'bar' are mandatory
     // we verify this invariant in the constructor to automatically end up with an HTTP 400 bad request in case of thrown exception
     requireNonNull(foo);
     requireNonNull(bar);
   }
  }
```

Calling GET will return something like:
```json
{
  "_templates": {
    "default": {
      "properties": [
        {
           "name": "foo"
         },
         {
           "name": "bar"
         }
      ]
    }
  }
}
```

We want to be able to assign a default value `hello` to attribute `foo` in the `HAL-FORMS` payload to obtain something like this:
```json
{
  "_templates": {
    "default": {
      "properties": [
        {
           "name": "foo",
           "value": "hello"
         },
         {
           "name": "bar"
         }
      ]
    }
  }
}
```

# Solution brought by this change

The implemented solution is heavily inspired from `HalFormsOptionsFactory`. A consumer can provide a value creator, taking a property metadata as input and returning a value of type `String` as output.

# Considered alternatives

## Retrieve the value directly from the payload instance

To do that, this kind of consumer code would be needed:
```java
@GetMapping
public ResponseEntity<?> list() {
    Link selfLink = selfLink.andAffordance(afford(methodOn(MyController.class).create(new Payload("hello", null))));
    return ResponseEntity.ok(new RepresentationModel<>(selfLink));
}
```

1. this will not work since `bar` is verified for non-nullity in `Payload` constructor. 
1. consumers will not either accept to relax the constructor invariant validation

On the 2nd point, some may argue that `jakarta.validation.constraints.NotNull` should be used instead of the in-house constructor validation. On that my opinion is as follow:
1. `@NotNull` should be avoided when plain simple java code is able to enforce the same constraint
1. IDEs will probably at least emit a warning when seeing a `null` value assigned to a  `@NotNull` property, at worst will fail the compilation

## Retrieve the value from a new annotation on the considered property

This would force the consumer to know the value before compilation.