### PR TITLE
Fix link parsing for non-trivial cases

### DIFF
--- a/src/main/java/org/springframework/hateoas/Link.java
+++ b/src/main/java/org/springframework/hateoas/Link.java
@@ -23,17 +23,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
+import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.util.StringUtils;
 
 /**
  * Value object for links.
@@ -41,13 +40,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @author Oliver Gierke
  * @author Greg Turnquist
  * @author Jens Schauder
+ * @author Viliam Durina
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(value = { "templated", "template" }, ignoreUnknown = true)
 public class Link implements Serializable {
 
 	private static final long serialVersionUID = -9037755944661782121L;
-	private static final Pattern URI_AND_ATTRIBUTES_PATTERN = Pattern.compile("<(.*)>;(.*)");
 
 	public static final String ATOM_NAMESPACE = "http://www.w3.org/2005/Atom";
 
@@ -241,7 +240,7 @@ public class Link implements Serializable {
 	}
 
 	/**
-	 * Creats a new {@link Link} with the given {@link Affordance}s.
+	 * Creates a new {@link Link} with the given {@link Affordance}s.
 	 *
 	 * @param affordances must not be {@literal null}.
 	 * @return will never be {@literal null}.
@@ -384,77 +383,162 @@ public class Link implements Serializable {
 	}
 
 	/**
+	 * Internal method to parse and consume one link from input string.
+	 *
+	 * @param input The input string
+	 * @param pos Position to start from. It must be a 1-element array. The element will be
+	 *              mutated to point to the first non-consumed character (either ',' or the end of input).
+	 * @return a non-null Link
+	 */
+	@NonNull
+	static Link valueOfInt(@NonNull String input, @NonNull int[] pos) {
+		assert pos.length == 1;
+		int l = input.length();
+		while (pos[0] < l && Character.isWhitespace(input.charAt(pos[0]))) {
+			pos[0]++;
+		}
+		if (input.charAt(pos[0]) != '<') {
+			throw new IllegalArgumentException("Expecting '<' at index " + pos[0]);
+		}
+		pos[0]++;
+		int urlEnd = input.indexOf('>', pos[0]);
+		if (urlEnd < 0) {
+			throw new IllegalArgumentException("Missing closing '>' at index " + input.length());
+		}
+		String url = input.substring(pos[0], urlEnd);
+		pos[0] = urlEnd + 1;
+
+		// parse parameters
+		Map<String, String> params = new HashMap<>();
+		enum State { INITIAL, IN_KEY, BEFORE_VALUE, IN_VALUE };
+		State state = State.INITIAL;
+		StringBuilder
+				key = new StringBuilder(),
+				value = new StringBuilder();
+
+		outer:
+		while (pos[0] <= l) {
+			boolean eoi = pos[0] == l; // EOI - end of input
+			char ch = eoi ? 0 : input.charAt(pos[0]);
+			switch (state) {
+				// searching for the initial `;`
+				case INITIAL:
+					if (Character.isWhitespace(ch)) {
+						pos[0]++;
+					}
+					else if (ch == ';') {
+						state = State.IN_KEY;
+						pos[0]++;
+					}
+					else {
+						// if there's something else, it's the end of this link
+						break outer;
+					}
+					break;
+
+				// consuming the key up to `=`
+				case IN_KEY:
+					if (ch == '=') {
+						state = State.BEFORE_VALUE;
+					}
+					// value isn't mandatory, so param separator, link separator, or end of input all create a new param
+					else if (ch == ';' || ch == ',' || eoi) {
+						if (!key.isEmpty()) {
+							params.put(key.toString().trim(), "");
+							key.setLength(0);
+						}
+					} else {
+						key.append(ch);
+					}
+					pos[0]++;
+					break;
+
+				case BEFORE_VALUE:
+					if (Character.isWhitespace(ch)) {
+						pos[0]++;
+					}
+					else if (ch == '"' || ch == '\'') {
+						consumeQuotedString(input, value, pos);
+						params.putIfAbsent(key.toString().trim(), value.toString());
+						key.setLength(0);
+						value.setLength(0);
+						state = State.INITIAL;
+					} else {
+						state = State.IN_VALUE;
+					}
+					break;
+
+				case IN_VALUE:
+					if (ch == ';' || ch == ',' || eoi) {
+						params.putIfAbsent(key.toString().trim(), value.toString().trim());
+						key.setLength(0);
+						value.setLength(0);
+						state = State.INITIAL;
+					} else {
+						value.append(ch);
+						pos[0]++;
+					}
+					break;
+
+				default:
+					throw new AssertionError();
+			}
+		}
+
+		String sRel = params.get("rel");
+		if (!StringUtils.hasText(sRel)) {
+			throw new IllegalArgumentException("Missing 'rel' attribute at index " + pos[0]);
+		}
+		LinkRelation rel = LinkRelation.of(sRel);
+		String hrefLang = params.get("hreflang");
+		String media = params.get("media");
+		String title = params.get("title");
+		String type = params.get("type");
+		String deprecation = params.get("deprecation");
+		String profile = params.get("profile");
+		String name = params.get("name");
+
+		return new Link(rel, url, hrefLang, media, title, type, deprecation, profile, name, templateOrNull(url),
+				Collections.emptyList());
+	}
+
+	/**
+	 * Consume a quoted string from `input`, adding its contents to `target`. The starting position should be at
+	 * starting quote. After consuming, the ending position will be just after the last final quote.
+	 */
+	private static void consumeQuotedString(String input, StringBuilder target, int[] pos) {
+		int l = input.length();
+		char quotingChar = input.charAt(pos[0]);
+		assert quotingChar == '"' || quotingChar == '\'';
+		// skip quoting char
+		pos[0]++;
+		for (; pos[0] < l; pos[0]++) {
+			char ch = input.charAt(pos[0]);
+			if (ch == quotingChar) {
+				pos[0]++; // consume the final quote
+				return;
+			}
+			if (ch == '\\') {
+				ch = input.charAt(++pos[0]);
+			}
+			target.append(ch);
+		}
+		throw new IllegalArgumentException("Missing final quote at index " + pos[0]);
+	}
+
+	/**
 	 * Factory method to easily create {@link Link} instances from RFC-8288 compatible {@link String} representations of a
 	 * link.
 	 *
 	 * @param element an RFC-8288 compatible representation of a link.
 	 * @throws IllegalArgumentException if a {@link String} was given that does not adhere to RFC-8288.
 	 * @throws IllegalArgumentException if no {@code rel} attribute could be found.
-	 * @return
+	 * @return The parsed link
+	 * @deprecated Use {@link Links#parse(String)} instead. This method parses only the first link from a list of links.
 	 */
+	@Deprecated
 	public static Link valueOf(String element) {
-
-		if (!StringUtils.hasText(element)) {
-			throw new IllegalArgumentException(String.format("Given link header %s is not RFC-8288 compliant!", element));
-		}
-
-		Matcher matcher = URI_AND_ATTRIBUTES_PATTERN.matcher(element);
-
-		if (matcher.find()) {
-
-			Map<String, String> attributes = getAttributeMap(matcher.group(2));
-
-			if (!attributes.containsKey("rel")) {
-				throw new IllegalArgumentException("Link does not provide a rel attribute!");
-			}
-
-			LinkRelation rel = LinkRelation.of(attributes.get("rel"));
-			String href = matcher.group(1);
-			String hrefLang = attributes.get("hreflang");
-			String media = attributes.get("media");
-			String title = attributes.get("title");
-			String type = attributes.get("type");
-			String deprecation = attributes.get("deprecation");
-			String profile = attributes.get("profile");
-			String name = attributes.get("name");
-
-			return new Link(rel, href, hrefLang, media, title, type, deprecation, profile, name, templateOrNull(href),
-					Collections.emptyList());
-
-		} else {
-			throw new IllegalArgumentException(String.format("Given link header %s is not RFC-8288 compliant!", element));
-		}
-	}
-
-	/**
-	 * Parses the links attributes from the given source {@link String}.
-	 *
-	 * @param source
-	 * @return
-	 */
-	private static Map<String, String> getAttributeMap(String source) {
-
-		if (!StringUtils.hasText(source)) {
-			return Collections.emptyMap();
-		}
-
-		String[] parts = source.split(";");
-		Map<String, String> attributes = new HashMap<>();
-
-		for (String part : parts) {
-
-			int delimiter = part.indexOf('=');
-
-			String key = part.substring(0, delimiter).trim();
-			String value = part.substring(delimiter + 1).trim();
-
-			// Potentially unquote value
-			value = value.startsWith("\"") ? value.substring(1, value.length() - 1) : value;
-
-			attributes.put(key, value);
-		}
-
-		return attributes;
+        return valueOfInt(element, new int[]{0});
 	}
 
 	/**
@@ -471,7 +555,7 @@ public class Link implements Serializable {
 	}
 
 	/**
-	 * Create a new {@link Link} by copying all attributes and applying the new {@literal hrefleng}.
+	 * Create a new {@link Link} by copying all attributes and applying the new {@literal hreflang}.
 	 *
 	 * @param hreflang can be {@literal null}
 	 * @return will never be {@literal null}.
@@ -659,38 +743,71 @@ public class Link implements Serializable {
 	 */
 	@Override
 	public String toString() {
-
-		String linkString = String.format("<%s>;rel=\"%s\"", href, rel.value());
+		StringBuilder result = new StringBuilder(64);
+		result.append('<')
+				// We only url-encode the `>`. We expect other special chars to already be escaped. `;` and `,` need not
+				// be escaped within the URL
+				.append(href.replace(">", "%3e"))
+				.append(">;rel=");
+		quoteParamValue(rel.value(), result);
 
 		if (hreflang != null) {
-			linkString += ";hreflang=\"" + hreflang + "\"";
+			result.append(";hreflang=");
+			quoteParamValue(hreflang, result);
 		}
 
 		if (media != null) {
-			linkString += ";media=\"" + media + "\"";
+			result.append(";media=");
+			quoteParamValue(media, result);
 		}
 
 		if (title != null) {
-			linkString += ";title=\"" + title + "\"";
+			result.append(";title=");
+			quoteParamValue(title, result);
 		}
 
 		if (type != null) {
-			linkString += ";type=\"" + type + "\"";
+			result.append(";type=");
+			quoteParamValue(type, result);
 		}
 
 		if (deprecation != null) {
-			linkString += ";deprecation=\"" + deprecation + "\"";
+			result.append(";deprecation=");
+			quoteParamValue(deprecation, result);
 		}
 
 		if (profile != null) {
-			linkString += ";profile=\"" + profile + "\"";
+			result.append(";profile=");
+			quoteParamValue(profile, result);
 		}
 
 		if (name != null) {
-			linkString += ";name=\"" + name + "\"";
+			result.append(";name=");
+			quoteParamValue(name, result);
 		}
 
-		return linkString;
+		return result.toString();
+	}
+
+	/**
+	 * Quotes the given string `s` and appends the result to the `target`. This method appends the start quote, the
+	 * escaped text, and the end quote.
+	 *
+	 * @param s Text to quote
+	 * @param target StringBuilder to append to
+	 */
+	private void quoteParamValue(String s, StringBuilder target) {
+		// we reserve extra 6 chars: two for the start and end quote, 2 is a reserve for potential escaped chars
+		target.ensureCapacity(target.length() + s.length() + 2);
+		target.append('"');
+		for (int i = 0, l = s.length(); i < l; i++) {
+			char ch = s.charAt(i);
+			if (ch == '"' || ch == '\\') {
+				target.append('\\');
+			}
+			target.append(ch);
+		}
+		target.append('"');
 	}
 
 	@Nullable

--- a/src/main/java/org/springframework/hateoas/Link.java
+++ b/src/main/java/org/springframework/hateoas/Link.java
@@ -538,7 +538,7 @@ public class Link implements Serializable {
 	 */
 	@Deprecated
 	public static Link valueOf(String element) {
-        return valueOfInt(element, new int[]{0});
+		return valueOfInt(element, new int[]{0});
 	}
 
 	/**

--- a/src/main/java/org/springframework/hateoas/Link.java
+++ b/src/main/java/org/springframework/hateoas/Link.java
@@ -646,7 +646,7 @@ public class Link implements Serializable {
 	 * Quotes the given string `s` and appends the result to the `target`. This method appends the start quote, the
 	 * escaped text, and the end quote.
 	 *
-	 * @param s Text to quote
+	 * @param s      Text to quote
 	 * @param target StringBuilder to append to
 	 */
 	private void quoteParamValue(String s, StringBuilder target) {

--- a/src/main/java/org/springframework/hateoas/LinkParser.java
+++ b/src/main/java/org/springframework/hateoas/LinkParser.java
@@ -1,9 +1,12 @@
 package org.springframework.hateoas;
 
-import java.util.ArrayList;
+import org.springframework.lang.NonNull;
+import org.springframework.util.StringUtils;
+
+import java.util.*;
 
 class LinkParser {
-    public static Links parse(String source) {
+    public static List<Link> parseLinks(String source) {
         var links = new ArrayList<Link>();
         int[] pos = {0}; // single-element array used as a mutable integer
         int l = source.length();
@@ -17,7 +20,7 @@ class LinkParser {
             if (inLink) {
                 if (ch == '<') {
                     // start of a link, consume it using the Link class
-                    Link link = Link.valueOfInt(source, pos);
+                    Link link = parseLink(source, pos);
                     // In a single link there can be multiple rels separated by whitespace. The Link class doesn't handle this
                     // because it doesn't have API to handle it. However, at this level, we can split the rels and create a
                     // separate Link for each rel.
@@ -50,10 +53,150 @@ class LinkParser {
             throw new IllegalArgumentException("Unexpected data at the end of Link header at index " + pos[0]);
         }
 
-        if (links.isEmpty()) {
-            return Links.NONE;
+        return links;
+    }
+
+    /**
+     * Internal method to parse and consume one link from input string.
+     *
+     * @param input The input string
+     * @param pos Position to start from. It must be a 1-element array. The element will be
+     *              mutated to point to the first non-consumed character (either ',' or the end of input).
+     * @return a non-null Link
+     */
+    @NonNull
+    static Link parseLink(@NonNull String input, @NonNull int[] pos) {
+        assert pos.length == 1;
+        int l = input.length();
+        while (pos[0] < l && Character.isWhitespace(input.charAt(pos[0]))) {
+            pos[0]++;
+        }
+        if (input.charAt(pos[0]) != '<') {
+            throw new IllegalArgumentException("Expecting '<' at index " + pos[0]);
+        }
+        pos[0]++;
+        int urlEnd = input.indexOf('>', pos[0]);
+        if (urlEnd < 0) {
+            throw new IllegalArgumentException("Missing closing '>' at index " + input.length());
+        }
+        String url = input.substring(pos[0], urlEnd);
+        pos[0] = urlEnd + 1;
+
+        // parse parameters
+        Map<String, String> params = new HashMap<>();
+        enum State { INITIAL, IN_KEY, BEFORE_VALUE, IN_VALUE };
+        State state = State.INITIAL;
+        StringBuilder
+                key = new StringBuilder(),
+                value = new StringBuilder();
+
+        outer:
+        while (pos[0] <= l) {
+            boolean eoi = pos[0] == l; // EOI - end of input
+            char ch = eoi ? 0 : input.charAt(pos[0]);
+            switch (state) {
+                // searching for the initial `;`
+                case INITIAL:
+                    if (Character.isWhitespace(ch)) {
+                        pos[0]++;
+                    }
+                    else if (ch == ';') {
+                        state = State.IN_KEY;
+                        pos[0]++;
+                    }
+                    else {
+                        // if there's something else, it's the end of this link
+                        break outer;
+                    }
+                    break;
+
+                // consuming the key up to `=`
+                case IN_KEY:
+                    if (ch == '=') {
+                        state = State.BEFORE_VALUE;
+                    }
+                    // value isn't mandatory, so param separator, link separator, or end of input all create a new param
+                    else if (ch == ';' || ch == ',' || eoi) {
+                        if (!key.isEmpty()) {
+                            params.put(key.toString().trim(), "");
+                            key.setLength(0);
+                        }
+                    } else {
+                        key.append(ch);
+                    }
+                    pos[0]++;
+                    break;
+
+                case BEFORE_VALUE:
+                    if (Character.isWhitespace(ch)) {
+                        pos[0]++;
+                    }
+                    else if (ch == '"' || ch == '\'') {
+                        consumeQuotedString(input, value, pos);
+                        params.putIfAbsent(key.toString().trim(), value.toString());
+                        key.setLength(0);
+                        value.setLength(0);
+                        state = State.INITIAL;
+                    } else {
+                        state = State.IN_VALUE;
+                    }
+                    break;
+
+                case IN_VALUE:
+                    if (ch == ';' || ch == ',' || eoi) {
+                        params.putIfAbsent(key.toString().trim(), value.toString().trim());
+                        key.setLength(0);
+                        value.setLength(0);
+                        state = State.INITIAL;
+                    } else {
+                        value.append(ch);
+                        pos[0]++;
+                    }
+                    break;
+
+                default:
+                    throw new AssertionError();
+            }
         }
 
-        return new Links(links);
+        String sRel = params.get("rel");
+        if (!StringUtils.hasText(sRel)) {
+            throw new IllegalArgumentException("Missing 'rel' attribute at index " + pos[0]);
+        }
+        LinkRelation rel = LinkRelation.of(sRel);
+        String hrefLang = params.get("hreflang");
+        String media = params.get("media");
+        String title = params.get("title");
+        String type = params.get("type");
+        String deprecation = params.get("deprecation");
+        String profile = params.get("profile");
+        String name = params.get("name");
+
+        return new Link(rel, url, hrefLang, media, title, type, deprecation, profile, name, Link.templateOrNull(url),
+                Collections.emptyList());
+    }
+
+    /**
+     * Consume a quoted string from `input`, adding its contents to `target`. The starting position should be at
+     * starting quote. After consuming, the ending position will be just after the last final quote.
+     */
+    private static void consumeQuotedString(String input, StringBuilder target, int[] pos) {
+        int l = input.length();
+        char quotingChar = input.charAt(pos[0]);
+        assert quotingChar == '"' || quotingChar == '\'';
+        // skip quoting char
+        pos[0]++;
+        for (; pos[0] < l; pos[0]++) {
+            char ch = input.charAt(pos[0]);
+            if (ch == quotingChar) {
+                pos[0]++; // consume the final quote
+                return;
+            }
+            if (ch == '\\') {
+                ch = input.charAt(++pos[0]);
+            }
+            target.append(ch);
+        }
+        throw new IllegalArgumentException("Missing final quote at index " + pos[0]);
     }
 }

--- a/src/main/java/org/springframework/hateoas/LinkParser.java
+++ b/src/main/java/org/springframework/hateoas/LinkParser.java
@@ -6,197 +6,192 @@ import org.springframework.util.StringUtils;
 import java.util.*;
 
 class LinkParser {
-    public static List<Link> parseLinks(String source) {
-        var links = new ArrayList<Link>();
-        int[] pos = {0}; // single-element array used as a mutable integer
-        int l = source.length();
-        boolean inLink = true; // true if we're expecting to find a link; false if we're expecting end of input, or a comma
-        while (pos[0] < l) {
-            char ch = source.charAt(pos[0]);
-            if (Character.isWhitespace(ch)) {
-                pos[0]++;
-                continue;
-            }
-            if (inLink) {
-                if (ch == '<') {
-                    // start of a link, consume it using the Link class
-                    Link link = parseLink(source, pos);
-                    // In a single link there can be multiple rels separated by whitespace. The Link class doesn't handle this
-                    // because it doesn't have API to handle it. However, at this level, we can split the rels and create a
-                    // separate Link for each rel.
-                    String[] rels = link.getRel().value().split("\\s");
-                    if (rels.length == 0) {
-                        throw new IllegalArgumentException("A link with missing rel at " + pos[0]);
-                    }
-                    for (String rel : rels) {
-                        links.add(link.withRel(rel));
-                    }
-                    inLink = false;
-                    continue;
-                }
-                else if (ch == ',') {
-                    pos[0]++;
-                    continue;
-                }
-            } else {
-                // there must be a comma to move on to another link
-                if (ch == ',') {
-                    pos[0]++;
-                    inLink = true;
-                    continue;
-                }
-            }
-            // The parsing algorithm in appendix B.2 of RFC-8288 suggests ignoring unexpected content at the end of a link.
-            // At the same time it specifies that implementations aren't required to support them. We believe that missing
-            // terminal `>` or unexpected data after the end point to more serious problem, and we throw an exception
-            // in that case.
-            throw new IllegalArgumentException("Unexpected data at the end of Link header at index " + pos[0]);
-        }
+	public static List<Link> parseLinks(String source) {
+		var links = new ArrayList<Link>();
+		int[] pos = { 0 }; // single-element array used as a mutable integer
+		int l = source.length();
+		boolean inLink = true; // true if we're expecting to find a link; false if we're expecting end of input, or a comma
+		while (pos[0] < l) {
+			char ch = source.charAt(pos[0]);
+			if (Character.isWhitespace(ch)) {
+				pos[0]++;
+				continue;
+			}
+			if (inLink) {
+				if (ch == '<') {
+					// start of a link, consume it using the Link class
+					Link link = parseLink(source, pos);
+					// In a single link there can be multiple rels separated by whitespace. The Link class doesn't handle this
+					// because it doesn't have API to handle it. However, at this level, we can split the rels and create a
+					// separate Link for each rel.
+					String[] rels = link.getRel().value().split("\\s");
+					if (rels.length == 0) {
+						throw new IllegalArgumentException("A link with missing rel at " + pos[0]);
+					}
+					for (String rel : rels) {
+						links.add(link.withRel(rel));
+					}
+					inLink = false;
+					continue;
+				} else if (ch == ',') {
+					pos[0]++;
+					continue;
+				}
+			} else {
+				// there must be a comma to move on to another link
+				if (ch == ',') {
+					pos[0]++;
+					inLink = true;
+					continue;
+				}
+			}
+			// The parsing algorithm in appendix B.2 of RFC-8288 suggests ignoring unexpected content at the end of a link.
+			// At the same time it specifies that implementations aren't required to support them. We believe that missing
+			// terminal `>` or unexpected data after the end point to more serious problem, and we throw an exception
+			// in that case.
+			throw new IllegalArgumentException("Unexpected data at the end of Link header at index " + pos[0]);
+		}
 
-        return links;
-    }
+		return links;
+	}
 
-    /**
-     * Internal method to parse and consume one link from input string.
-     *
-     * @param input The input string
-     * @param pos Position to start from. It must be a 1-element array. The element will be
-     *              mutated to point to the first non-consumed character (either ',' or the end of input).
-     * @return a non-null Link
-     */
-    @NonNull
-    static Link parseLink(@NonNull String input, @NonNull int[] pos) {
-        assert pos.length == 1;
-        int l = input.length();
-        while (pos[0] < l && Character.isWhitespace(input.charAt(pos[0]))) {
-            pos[0]++;
-        }
-        if (input.charAt(pos[0]) != '<') {
-            throw new IllegalArgumentException("Expecting '<' at index " + pos[0]);
-        }
-        pos[0]++;
-        int urlEnd = input.indexOf('>', pos[0]);
-        if (urlEnd < 0) {
-            throw new IllegalArgumentException("Missing closing '>' at index " + input.length());
-        }
-        String url = input.substring(pos[0], urlEnd);
-        pos[0] = urlEnd + 1;
+	/**
+	 * Internal method to parse and consume one link from input string.
+	 *
+	 * @param input The input string
+	 * @param pos   Position to start from. It must be a 1-element array. The element will be mutated to point to the
+	 *              first non-consumed character (either ',' or the end of input).
+	 * @return a non-null Link
+	 */
+	@NonNull
+	static Link parseLink(@NonNull String input, @NonNull int[] pos) {
+		assert pos.length == 1;
+		int l = input.length();
+		while (pos[0] < l && Character.isWhitespace(input.charAt(pos[0]))) {
+			pos[0]++;
+		}
+		if (input.charAt(pos[0]) != '<') {
+			throw new IllegalArgumentException("Expecting '<' at index " + pos[0]);
+		}
+		pos[0]++;
+		int urlEnd = input.indexOf('>', pos[0]);
+		if (urlEnd < 0) {
+			throw new IllegalArgumentException("Missing closing '>' at index " + input.length());
+		}
+		String url = input.substring(pos[0], urlEnd);
+		pos[0] = urlEnd + 1;
 
-        // parse parameters
-        Map<String, String> params = new HashMap<>();
-        enum State { INITIAL, IN_KEY, BEFORE_VALUE, IN_VALUE };
-        State state = State.INITIAL;
-        StringBuilder
-                key = new StringBuilder(),
-                value = new StringBuilder();
+		// parse parameters
+		Map<String, String> params = new HashMap<>();
+		enum State {INITIAL, IN_KEY, BEFORE_VALUE, IN_VALUE}
+		;
+		State state = State.INITIAL;
+		StringBuilder key = new StringBuilder(), value = new StringBuilder();
 
-        outer:
-        while (pos[0] <= l) {
-            boolean eoi = pos[0] == l; // EOI - end of input
-            char ch = eoi ? 0 : input.charAt(pos[0]);
-            switch (state) {
-                // searching for the initial `;`
-                case INITIAL:
-                    if (Character.isWhitespace(ch)) {
-                        pos[0]++;
-                    }
-                    else if (ch == ';') {
-                        state = State.IN_KEY;
-                        pos[0]++;
-                    }
-                    else {
-                        // if there's something else, it's the end of this link
-                        break outer;
-                    }
-                    break;
+		outer:
+		while (pos[0] <= l) {
+			boolean eoi = pos[0] == l; // EOI - end of input
+			char ch = eoi ? 0 : input.charAt(pos[0]);
+			switch (state) {
+				// searching for the initial `;`
+				case INITIAL:
+					if (Character.isWhitespace(ch)) {
+						pos[0]++;
+					} else if (ch == ';') {
+						state = State.IN_KEY;
+						pos[0]++;
+					} else {
+						// if there's something else, it's the end of this link
+						break outer;
+					}
+					break;
 
-                // consuming the key up to `=`
-                case IN_KEY:
-                    if (ch == '=') {
-                        state = State.BEFORE_VALUE;
-                    }
-                    // value isn't mandatory, so param separator, link separator, or end of input all create a new param
-                    else if (ch == ';' || ch == ',' || eoi) {
-                        if (!key.isEmpty()) {
-                            params.put(key.toString().trim(), "");
-                            key.setLength(0);
-                        }
-                    } else {
-                        key.append(ch);
-                    }
-                    pos[0]++;
-                    break;
+				// consuming the key up to `=`
+				case IN_KEY:
+					if (ch == '=') {
+						state = State.BEFORE_VALUE;
+					}
+					// value isn't mandatory, so param separator, link separator, or end of input all create a new param
+					else if (ch == ';' || ch == ',' || eoi) {
+						if (!key.isEmpty()) {
+							params.put(key.toString().trim(), "");
+							key.setLength(0);
+						}
+					} else {
+						key.append(ch);
+					}
+					pos[0]++;
+					break;
 
-                case BEFORE_VALUE:
-                    if (Character.isWhitespace(ch)) {
-                        pos[0]++;
-                    }
-                    else if (ch == '"' || ch == '\'') {
-                        consumeQuotedString(input, value, pos);
-                        params.putIfAbsent(key.toString().trim(), value.toString());
-                        key.setLength(0);
-                        value.setLength(0);
-                        state = State.INITIAL;
-                    } else {
-                        state = State.IN_VALUE;
-                    }
-                    break;
+				case BEFORE_VALUE:
+					if (Character.isWhitespace(ch)) {
+						pos[0]++;
+					} else if (ch == '"' || ch == '\'') {
+						consumeQuotedString(input, value, pos);
+						params.putIfAbsent(key.toString().trim(), value.toString());
+						key.setLength(0);
+						value.setLength(0);
+						state = State.INITIAL;
+					} else {
+						state = State.IN_VALUE;
+					}
+					break;
 
-                case IN_VALUE:
-                    if (ch == ';' || ch == ',' || eoi) {
-                        params.putIfAbsent(key.toString().trim(), value.toString().trim());
-                        key.setLength(0);
-                        value.setLength(0);
-                        state = State.INITIAL;
-                    } else {
-                        value.append(ch);
-                        pos[0]++;
-                    }
-                    break;
+				case IN_VALUE:
+					if (ch == ';' || ch == ',' || eoi) {
+						params.putIfAbsent(key.toString().trim(), value.toString().trim());
+						key.setLength(0);
+						value.setLength(0);
+						state = State.INITIAL;
+					} else {
+						value.append(ch);
+						pos[0]++;
+					}
+					break;
 
-                default:
-                    throw new AssertionError();
-            }
-        }
+				default:
+					throw new AssertionError();
+			}
+		}
 
-        String sRel = params.get("rel");
-        if (!StringUtils.hasText(sRel)) {
-            throw new IllegalArgumentException("Missing 'rel' attribute at index " + pos[0]);
-        }
-        LinkRelation rel = LinkRelation.of(sRel);
-        String hrefLang = params.get("hreflang");
-        String media = params.get("media");
-        String title = params.get("title");
-        String type = params.get("type");
-        String deprecation = params.get("deprecation");
-        String profile = params.get("profile");
-        String name = params.get("name");
+		String sRel = params.get("rel");
+		if (!StringUtils.hasText(sRel)) {
+			throw new IllegalArgumentException("Missing 'rel' attribute at index " + pos[0]);
+		}
+		LinkRelation rel = LinkRelation.of(sRel);
+		String hrefLang = params.get("hreflang");
+		String media = params.get("media");
+		String title = params.get("title");
+		String type = params.get("type");
+		String deprecation = params.get("deprecation");
+		String profile = params.get("profile");
+		String name = params.get("name");
 
-        return new Link(rel, url, hrefLang, media, title, type, deprecation, profile, name, Link.templateOrNull(url),
-                Collections.emptyList());
-    }
+		return new Link(rel, url, hrefLang, media, title, type, deprecation, profile, name, Link.templateOrNull(url),
+				Collections.emptyList());
+	}
 
-    /**
-     * Consume a quoted string from `input`, adding its contents to `target`. The starting position should be at
-     * starting quote. After consuming, the ending position will be just after the last final quote.
-     */
-    private static void consumeQuotedString(String input, StringBuilder target, int[] pos) {
-        int l = input.length();
-        char quotingChar = input.charAt(pos[0]);
-        assert quotingChar == '"' || quotingChar == '\'';
-        // skip quoting char
-        pos[0]++;
-        for (; pos[0] < l; pos[0]++) {
-            char ch = input.charAt(pos[0]);
-            if (ch == quotingChar) {
-                pos[0]++; // consume the final quote
-                return;
-            }
-            if (ch == '\\') {
-                ch = input.charAt(++pos[0]);
-            }
-            target.append(ch);
-        }
-        throw new IllegalArgumentException("Missing final quote at index " + pos[0]);
-    }
+	/**
+	 * Consume a quoted string from `input`, adding its contents to `target`. The starting position should be at starting
+	 * quote. After consuming, the ending position will be just after the last final quote.
+	 */
+	private static void consumeQuotedString(String input, StringBuilder target, int[] pos) {
+		int l = input.length();
+		char quotingChar = input.charAt(pos[0]);
+		assert quotingChar == '"' || quotingChar == '\'';
+		// skip quoting char
+		pos[0]++;
+		for (; pos[0] < l; pos[0]++) {
+			char ch = input.charAt(pos[0]);
+			if (ch == quotingChar) {
+				pos[0]++; // consume the final quote
+				return;
+			}
+			if (ch == '\\') {
+				ch = input.charAt(++pos[0]);
+			}
+			target.append(ch);
+		}
+		throw new IllegalArgumentException("Missing final quote at index " + pos[0]);
+	}
 }

--- a/src/main/java/org/springframework/hateoas/LinkParser.java
+++ b/src/main/java/org/springframework/hateoas/LinkParser.java
@@ -1,0 +1,59 @@
+package org.springframework.hateoas;
+
+import java.util.ArrayList;
+
+class LinkParser {
+    public static Links parse(String source) {
+        var links = new ArrayList<Link>();
+        int[] pos = {0}; // single-element array used as a mutable integer
+        int l = source.length();
+        boolean inLink = true; // true if we're expecting to find a link; false if we're expecting end of input, or a comma
+        while (pos[0] < l) {
+            char ch = source.charAt(pos[0]);
+            if (Character.isWhitespace(ch)) {
+                pos[0]++;
+                continue;
+            }
+            if (inLink) {
+                if (ch == '<') {
+                    // start of a link, consume it using the Link class
+                    Link link = Link.valueOfInt(source, pos);
+                    // In a single link there can be multiple rels separated by whitespace. The Link class doesn't handle this
+                    // because it doesn't have API to handle it. However, at this level, we can split the rels and create a
+                    // separate Link for each rel.
+                    String[] rels = link.getRel().value().split("\\s");
+                    if (rels.length == 0) {
+                        throw new IllegalArgumentException("A link with missing rel at " + pos[0]);
+                    }
+                    for (String rel : rels) {
+                        links.add(link.withRel(rel));
+                    }
+                    inLink = false;
+                    continue;
+                }
+                else if (ch == ',') {
+                    pos[0]++;
+                    continue;
+                }
+            } else {
+                // there must be a comma to move on to another link
+                if (ch == ',') {
+                    pos[0]++;
+                    inLink = true;
+                    continue;
+                }
+            }
+            // The parsing algorithm in appendix B.2 of RFC-8288 suggests ignoring unexpected content at the end of a link.
+            // At the same time it specifies that implementations aren't required to support them. We believe that missing
+            // terminal `>` or unexpected data after the end point to more serious problem, and we throw an exception
+            // in that case.
+            throw new IllegalArgumentException("Unexpected data at the end of Link header at index " + pos[0]);
+        }
+
+        if (links.isEmpty()) {
+            return Links.NONE;
+        }
+
+        return new Links(links);
+    }
+}

--- a/src/main/java/org/springframework/hateoas/Links.java
+++ b/src/main/java/org/springframework/hateoas/Links.java
@@ -88,7 +88,11 @@ public class Links implements Iterable<Link> {
 			return NONE;
 		}
 
-		return LinkParser.parse(source);
+		List<Link> links = LinkParser.parseLinks(source);
+		if (links.isEmpty()) {
+			return NONE;
+		}
+		return new Links(links);
 	}
 
 	/**

--- a/src/main/java/org/springframework/hateoas/Links.java
+++ b/src/main/java/org/springframework/hateoas/Links.java
@@ -92,12 +92,12 @@ public class Links implements Iterable<Link> {
 		int[] pos = {0}; // single-element array used as a mutable integer
 		int l = source.length();
 		boolean inLink = true; // true if we're expecting to find a link; false if we're expecting end of input, or a comma
-        while (pos[0] < l) {
-            char ch = source.charAt(pos[0]);
-            if (Character.isWhitespace(ch)) {
-                pos[0]++;
-                continue;
-            }
+		while (pos[0] < l) {
+			char ch = source.charAt(pos[0]);
+			if (Character.isWhitespace(ch)) {
+				pos[0]++;
+				continue;
+			}
 			if (inLink) {
 				if (ch == '<') {
 					// start of a link, consume it using the Link class
@@ -126,7 +126,7 @@ public class Links implements Iterable<Link> {
 					inLink = true;
 					continue;
 				}
-            }
+			}
 			// The parsing algorithm in appendix B.2 of RFC-8288 suggests ignoring unexpected content at the end of a link.
 			// At the same time it specifies that implementations aren't required to support them. We believe that missing
 			// terminal `>` or unexpected data after the end point to more serious problem, and we throw an exception
@@ -134,7 +134,7 @@ public class Links implements Iterable<Link> {
 			throw new IllegalArgumentException("Unexpected data at the end of Link header at index " + pos[0]);
 		}
 
-        if (links.isEmpty()) {
+		if (links.isEmpty()) {
 			return NONE;
 		}
 

--- a/src/main/java/org/springframework/hateoas/Links.java
+++ b/src/main/java/org/springframework/hateoas/Links.java
@@ -47,7 +47,7 @@ public class Links implements Iterable<Link> {
 
 	private final List<Link> links;
 
-	private Links(Iterable<Link> links) {
+	Links(Iterable<Link> links) {
 
 		Assert.notNull(links, "Links must not be null!");
 
@@ -88,57 +88,7 @@ public class Links implements Iterable<Link> {
 			return NONE;
 		}
 
-		var links = new ArrayList<Link>();
-		int[] pos = {0}; // single-element array used as a mutable integer
-		int l = source.length();
-		boolean inLink = true; // true if we're expecting to find a link; false if we're expecting end of input, or a comma
-		while (pos[0] < l) {
-			char ch = source.charAt(pos[0]);
-			if (Character.isWhitespace(ch)) {
-				pos[0]++;
-				continue;
-			}
-			if (inLink) {
-				if (ch == '<') {
-					// start of a link, consume it using the Link class
-					Link link = Link.valueOfInt(source, pos);
-					// In a single link there can be multiple rels separated by whitespace. The Link class doesn't handle this
-					// because it doesn't have API to handle it. However, at this level, we can split the rels and create a
-					// separate Link for each rel.
-					String[] rels = link.getRel().value().split("\\s");
-					if (rels.length == 0) {
-						throw new IllegalArgumentException("A link with missing rel at " + pos[0]);
-					}
-					for (String rel : rels) {
-						links.add(link.withRel(rel));
-					}
-					inLink = false;
-					continue;
-				}
-				else if (ch == ',') {
-					pos[0]++;
-					continue;
-				}
-			} else {
-				// there must be a comma to move on to another link
-				if (ch == ',') {
-					pos[0]++;
-					inLink = true;
-					continue;
-				}
-			}
-			// The parsing algorithm in appendix B.2 of RFC-8288 suggests ignoring unexpected content at the end of a link.
-			// At the same time it specifies that implementations aren't required to support them. We believe that missing
-			// terminal `>` or unexpected data after the end point to more serious problem, and we throw an exception
-			// in that case.
-			throw new IllegalArgumentException("Unexpected data at the end of Link header at index " + pos[0]);
-		}
-
-		if (links.isEmpty()) {
-			return NONE;
-		}
-
-		return new Links(links);
+		return LinkParser.parse(source);
 	}
 
 	/**

--- a/src/test/java/org/springframework/hateoas/LinksUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/LinksUnitTest.java
@@ -66,6 +66,7 @@ class LinksUnitTest {
 
 	@Test
 	void parsesLinkHeaderLinks() {
+
 		assertThat(Links.parse(LINKS)).isEqualTo(reference);
 		assertThat(Links.parse(LINKS2)).isEqualTo(reference2);
 		assertThat(reference.toString()).isEqualTo(LINKS);
@@ -92,6 +93,7 @@ class LinksUnitTest {
 
 	@Test
 	void returnsNullForNullOrEmptySource() {
+
 		assertThat(Links.parse(null)).isEqualTo(Links.NONE);
 		assertThat(Links.parse("")).isEqualTo(Links.NONE);
 	}
@@ -111,6 +113,7 @@ class LinksUnitTest {
 	 */
 	@Test
 	void parsesLinkWithComma() {
+
 		Link withComma = Link.of("http://localhost:8080/test?page=0&filter=foo,bar", "foo");
 
 		assertThat(Links.parse(WITH_COMMA).getLink("foo")).isEqualTo(Optional.of(withComma));
@@ -131,6 +134,7 @@ class LinksUnitTest {
 
 	@Test // #805
 	void returnsRequiredLink() {
+
 		Link reference = Link.of("http://localhost", "someRel");
 		Links links = Links.of(reference);
 
@@ -139,6 +143,7 @@ class LinksUnitTest {
 
 	@Test // #805
 	void rejectsMissingLinkWithIllegalArgumentException() {
+
 		Links links = Links.of();
 
 		assertThatExceptionOfType(IllegalArgumentException.class) //
@@ -148,6 +153,7 @@ class LinksUnitTest {
 
 	@Test
 	void detectsContainedLinks() {
+
 		Link first = Link.of("http://localhost", "someRel");
 		Link second = Link.of("http://localhost", "someOtherRel");
 
@@ -161,6 +167,7 @@ class LinksUnitTest {
 
 	@TestFactory // #1322, #1341
 	Stream<DynamicTest> conditionallyAddsLink() {
+
 		Links links = Links.NONE;
 		Link link = Link.of("/foo");
 
@@ -187,6 +194,7 @@ class LinksUnitTest {
 
 	@Test // #1322
 	void doesNotEvaluateSupplierIfAddConditionIsFalse() {
+
 		assertThatCode(() -> Links.NONE.andIf(false, () -> {
 			throw new IllegalStateException();
 		})).doesNotThrowAnyException();
@@ -194,6 +202,7 @@ class LinksUnitTest {
 
 	@TestFactory // #1340
 	Stream<DynamicTest> addsStreamOfLinks() {
+
 		Links links = Links.NONE;
 		Link link = Link.of("/foo");
 
@@ -208,6 +217,7 @@ class LinksUnitTest {
 
 	@TestFactory // #1340
 	Stream<DynamicTest> mergesStreamOfLinks() {
+
 		Links links = Links.NONE.and(Link.of("/foo"));
 		Link same = Link.of("/foo");
 		Link sameRel = Link.of("/bar");
@@ -225,6 +235,7 @@ class LinksUnitTest {
 
 	@TestFactory // #1340
 	Stream<DynamicTest> replacesLinksViaMerge() {
+
 		Links links = Links.of(Link.of("/foo"));
 		Link sameRel = Link.of("/bar");
 
@@ -244,6 +255,7 @@ class LinksUnitTest {
 
 	@Test
 	void basics() {
+
 		Links none = Links.NONE;
 
 		assertThat(none.isEmpty()).isTrue();
@@ -269,6 +281,7 @@ class LinksUnitTest {
 
 	@Test // #1458
 	void supportsUnquotedAttributes() {
+
 		assertThat(Links.parse("<https://url.com?page=1>; rel=first").getRequiredLink("first").getHref())
 				.isEqualTo("https://url.com?page=1");
 	}

--- a/src/test/java/org/springframework/hateoas/LinksUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/LinksUnitTest.java
@@ -79,20 +79,15 @@ class LinksUnitTest {
 		assertThat(Links.parse(LINKS2 + ",,,")).isEqualTo(reference2);
 
 		// extra commas inside
-		assertThat(Links.parse("<url1>;rel= \"foo\",,<url2>;rel= \"bar\""))
-				.isEqualTo(Links.of(
-						Link.of("url1", "foo"),
-						Link.of("url2", "bar")));
+		assertThat(Links.parse("<url1>;rel= \"foo\",,<url2>;rel= \"bar\"")).isEqualTo(
+				Links.of(Link.of("url1", "foo"), Link.of("url2", "bar")));
 
 		// extra commas at the beginning
-		assertThat(Links.parse(",,<url1>;rel= \"foo\""))
-				.isEqualTo(Links.of(Link.of("url1", "foo")));
+		assertThat(Links.parse(",,<url1>;rel= \"foo\"")).isEqualTo(Links.of(Link.of("url1", "foo")));
 
 		// extra commas everywhere with whitespace
-		assertThat(Links.parse(" , , <url1>;rel= \"foo\" , , <url2>;rel= \"bar\"  ,  , "))
-				.isEqualTo(Links.of(
-						Link.of("url1", "foo"),
-						Link.of("url2", "bar")));
+		assertThat(Links.parse(" , , <url1>;rel= \"foo\" , , <url2>;rel= \"bar\"  ,  , ")).isEqualTo(
+				Links.of(Link.of("url1", "foo"), Link.of("url2", "bar")));
 	}
 
 	@Test
@@ -288,119 +283,106 @@ class LinksUnitTest {
 	@Test
 	void parsingUnexpectedData() {
 		// two URLs without a comma - the second URL is an unexpected text
-		assertThatThrownBy(() -> Links.parse("<url1>;rel=\"foo\"<url2>;rel= \"bar\""))
-				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessage("Unexpected data at the end of Link header at index 16");
-		assertThatThrownBy(() -> Links.parse("<url1>; rel=\"foo\" <url2>;rel= \"bar\""))
-				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessage("Unexpected data at the end of Link header at index 18");
-		assertThatThrownBy(() -> Links.parse( "<url1> ; rel= \"foo\" <url2>;rel= \"bar\""))
-				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessage("Unexpected data at the end of Link header at index 20");
+		assertThatThrownBy(() -> Links.parse("<url1>;rel=\"foo\"<url2>;rel= \"bar\"")).isInstanceOf(
+				IllegalArgumentException.class).hasMessage("Unexpected data at the end of Link header at index 16");
+		assertThatThrownBy(() -> Links.parse("<url1>; rel=\"foo\" <url2>;rel= \"bar\"")).isInstanceOf(
+				IllegalArgumentException.class).hasMessage("Unexpected data at the end of Link header at index 18");
+		assertThatThrownBy(() -> Links.parse("<url1> ; rel= \"foo\" <url2>;rel= \"bar\"")).isInstanceOf(
+				IllegalArgumentException.class).hasMessage("Unexpected data at the end of Link header at index 20");
 
 		// unexpected text after a quoted string
-		assertThatThrownBy(() -> Links.parse("<url1>;rel=\"foo\"#"))
-				.isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> Links.parse("<url1>;rel=\"foo\"#")).isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("Unexpected data at the end of Link header at index 16");
-		assertThatThrownBy(() -> Links.parse("<url1>;rel=\"foo\" foo bar"))
-				.isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> Links.parse("<url1>;rel=\"foo\" foo bar")).isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("Unexpected data at the end of Link header at index 17");
 
 		// if the value isn't quoted, it can't be unexpected; all is part of the value
-		assertThat(Links.parse("<url1>;rel=foo#"))
-				.isEqualTo(Links.of(Link.of("url1", "foo#")));
+		assertThat(Links.parse("<url1>;rel=foo#")).isEqualTo(Links.of(Link.of("url1", "foo#")));
 
 		// extra text after a comma - looks like a legit value for rel, but comma is special and starts a new link
-		assertThatThrownBy(() -> Links.parse("<url1>;rel=foo,bar"))
-				.isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> Links.parse("<url1>;rel=foo,bar")).isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("Unexpected data at the end of Link header at index 15");
 
 		// a trailing comma is ignored
-		assertThat(Links.parse("<url1>;rel=foo,"))
-				.isEqualTo(Links.of(Link.of("url1", "foo")));
+		assertThat(Links.parse("<url1>;rel=foo,")).isEqualTo(Links.of(Link.of("url1", "foo")));
 
 		// a trailing semicolon is also ignored
-		assertThat(Links.parse("<url1>;rel=foo;"))
-				.isEqualTo(Links.of(Link.of("url1", "foo")));
+		assertThat(Links.parse("<url1>;rel=foo;")).isEqualTo(Links.of(Link.of("url1", "foo")));
 
 		// unexpected text at the beginning
-		assertThatThrownBy(() -> Links.parse("foo bar <url>;rel=\"next\""))
-				.isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> Links.parse("foo bar <url>;rel=\"next\"")).isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("Unexpected data at the end of Link header at index 0");
 	}
 
 	@Test
 	void parsingMissingData() {
 		// missing trailing bracket
-		assertThatThrownBy(() -> Links.parse("<https://example.com/;rel=next"))
-				.isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> Links.parse("<https://example.com/;rel=next")).isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("Missing closing '>' at index 30");
 
 		// missing end quote
-		assertThatThrownBy(() -> Links.parse("<https://example.com/>;rel=\"next"))
-				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessage("Missing final quote at index 32");
-		assertThatThrownBy(() -> Links.parse("<https://example.com/>;rel='next"))
-				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessage("Missing final quote at index 32");
+		assertThatThrownBy(() -> Links.parse("<https://example.com/>;rel=\"next")).isInstanceOf(
+				IllegalArgumentException.class).hasMessage("Missing final quote at index 32");
+		assertThatThrownBy(() -> Links.parse("<https://example.com/>;rel='next")).isInstanceOf(
+				IllegalArgumentException.class).hasMessage("Missing final quote at index 32");
 	}
 
 	@Test
 	void parsingGreedyCapture() {
 		// no greedy capture until `>`
-		assertThat(Links.parse("<url>;title=foo>;rel=\"next\""))
-				.isEqualTo(Links.of(Link.of("url", "next").withTitle("foo>")));
+		assertThat(Links.parse("<url>;title=foo>;rel=\"next\"")).isEqualTo(
+				Links.of(Link.of("url", "next").withTitle("foo>")));
 
 		// no greedy capture until `;`
-		assertThat(Links.parse("<url>;title=\"foo;bar\";rel=next"))
-				.isEqualTo(Links.of(Link.of("url", "next").withTitle("foo;bar")));
+		assertThat(Links.parse("<url>;title=\"foo;bar\";rel=next")).isEqualTo(
+				Links.of(Link.of("url", "next").withTitle("foo;bar")));
 
 		// no greedy capture until `,`
-		assertThat(Links.parse("<url>;title=\"foo,bar\";rel=next"))
-				.isEqualTo(Links.of(Link.of("url", "next").withTitle("foo,bar")));
+		assertThat(Links.parse("<url>;title=\"foo,bar\";rel=next")).isEqualTo(
+				Links.of(Link.of("url", "next").withTitle("foo,bar")));
 	}
 
 	@Test
 	void parsingQuotedText() {
 		// unquoting of double quotes
-		assertThat(Links.parse("<url>;title=\"\\\"bar\\\"\";rel=next"))
-				.isEqualTo(Links.of(Link.of("url", "next").withTitle("\"bar\"")));
+		assertThat(Links.parse("<url>;title=\"\\\"bar\\\"\";rel=next")).isEqualTo(
+				Links.of(Link.of("url", "next").withTitle("\"bar\"")));
 
 		// unquoting of single quotes
-		assertThat(Links.parse("<url>;title='\\'bar\\'';rel=next"))
-				.isEqualTo(Links.of(Link.of("url", "next").withTitle("'bar'")));
+		assertThat(Links.parse("<url>;title='\\'bar\\'';rel=next")).isEqualTo(
+				Links.of(Link.of("url", "next").withTitle("'bar'")));
 
 		// single quote is literal in double-quoted string
-		assertThat(Links.parse("<url>;title=\"'bar'\";rel=next"))
-				.isEqualTo(Links.of(Link.of("url", "next").withTitle("'bar'")));
+		assertThat(Links.parse("<url>;title=\"'bar'\";rel=next")).isEqualTo(
+				Links.of(Link.of("url", "next").withTitle("'bar'")));
 
 		// double quote is literal in single-quoted string
-		assertThat(Links.parse("<url>;title='\"bar\"';rel=next"))
-				.isEqualTo(Links.of(Link.of("url", "next").withTitle("\"bar\"")));
+		assertThat(Links.parse("<url>;title='\"bar\"';rel=next")).isEqualTo(
+				Links.of(Link.of("url", "next").withTitle("\"bar\"")));
 
 		// backslash unquoting
-		assertThat(Links.parse("<url>;title=\"foo\\\\bar\";rel=next"))
-				.isEqualTo(Links.of(Link.of("url", "next").withTitle("foo\\bar")));
-		assertThat(Links.parse("<url>;title='foo\\\\bar';rel=next"))
-				.isEqualTo(Links.of(Link.of("url", "next").withTitle("foo\\bar")));
+		assertThat(Links.parse("<url>;title=\"foo\\\\bar\";rel=next")).isEqualTo(
+				Links.of(Link.of("url", "next").withTitle("foo\\bar")));
+		assertThat(Links.parse("<url>;title='foo\\\\bar';rel=next")).isEqualTo(
+				Links.of(Link.of("url", "next").withTitle("foo\\bar")));
 
 		// unquoting of unnecessarily quoted text
-		assertThat(Links.parse("<url>;title=\"\\f\\o\\o\";rel=next"))
-				.isEqualTo(Links.of(Link.of("url", "next").withTitle("foo")));
-		assertThat(Links.parse("<url>;title='\\f\\o\\o';rel=next"))
-				.isEqualTo(Links.of(Link.of("url", "next").withTitle("foo")));
+		assertThat(Links.parse("<url>;title=\"\\f\\o\\o\";rel=next")).isEqualTo(
+				Links.of(Link.of("url", "next").withTitle("foo")));
+		assertThat(Links.parse("<url>;title='\\f\\o\\o';rel=next")).isEqualTo(
+				Links.of(Link.of("url", "next").withTitle("foo")));
 
 		// no java-style special characters
-		assertThat(Links.parse("<url>;title=\"\\r\\n\\t\";rel=next"))
-				.isEqualTo(Links.of(Link.of("url", "next").withTitle("rnt")));
-		assertThat(Links.parse("<url>;title='\\r\\n\\t';rel=next"))
-				.isEqualTo(Links.of(Link.of("url", "next").withTitle("rnt")));
+		assertThat(Links.parse("<url>;title=\"\\r\\n\\t\";rel=next")).isEqualTo(
+				Links.of(Link.of("url", "next").withTitle("rnt")));
+		assertThat(Links.parse("<url>;title='\\r\\n\\t';rel=next")).isEqualTo(
+				Links.of(Link.of("url", "next").withTitle("rnt")));
 
 		// quote within a token value - the quote, if it's not the first character, is literal
-		assertThat(Links.parse("<url>;title=foo\"bar\";rel=next"))
-				.isEqualTo(Links.of(Link.of("url", "next").withTitle("foo\"bar\"")));
-		assertThat(Links.parse("<url>;title=foo'bar';rel=next"))
-				.isEqualTo(Links.of(Link.of("url", "next").withTitle("foo'bar'")));
+		assertThat(Links.parse("<url>;title=foo\"bar\";rel=next")).isEqualTo(
+				Links.of(Link.of("url", "next").withTitle("foo\"bar\"")));
+		assertThat(Links.parse("<url>;title=foo'bar';rel=next")).isEqualTo(
+				Links.of(Link.of("url", "next").withTitle("foo'bar'")));
 	}
 
 	@Test
@@ -408,80 +390,63 @@ class LinksUnitTest {
 		// at the end
 		Links expected = Links.of(Link.of("url", "next").withTitle(""));
 		// value missing
-		assertThat(Links.parse("<url>;rel=next;title"))
-				.isEqualTo(expected);
+		assertThat(Links.parse("<url>;rel=next;title")).isEqualTo(expected);
 		// empty token-style value
-		assertThat(Links.parse("<url>;rel=next;title="))
-				.isEqualTo(expected);
+		assertThat(Links.parse("<url>;rel=next;title=")).isEqualTo(expected);
 		// empty double-quoted string
-		assertThat(Links.parse("<url>;rel=next;title=\"\""))
-				.isEqualTo(expected);
+		assertThat(Links.parse("<url>;rel=next;title=\"\"")).isEqualTo(expected);
 		// empty single-quoted string
-		assertThat(Links.parse("<url>;rel=next;title=''"))
-				.isEqualTo(expected);
+		assertThat(Links.parse("<url>;rel=next;title=''")).isEqualTo(expected);
 
 		// not at the end
 		expected = Links.of(Link.of("url", "next").withTitle("").withName("a"));
-		assertThat(Links.parse("<url>;rel=next;title;name=a"))
-				.isEqualTo(expected);
-		assertThat(Links.parse("<url>;rel=next;title=;name=a"))
-				.isEqualTo(expected);
-		assertThat(Links.parse("<url>;rel=next;title=\"\";name=a"))
-				.isEqualTo(expected);
-		assertThat(Links.parse("<url>;rel=next;title='';name=a"))
-				.isEqualTo(expected);
+		assertThat(Links.parse("<url>;rel=next;title;name=a")).isEqualTo(expected);
+		assertThat(Links.parse("<url>;rel=next;title=;name=a")).isEqualTo(expected);
+		assertThat(Links.parse("<url>;rel=next;title=\"\";name=a")).isEqualTo(expected);
+		assertThat(Links.parse("<url>;rel=next;title='';name=a")).isEqualTo(expected);
 	}
 
 	@Test
 	void parsingMultipleRels() {
-		assertThat(Links.parse("<url>;rel=next last"))
-				.isEqualTo(Links.of(Link.of("url", "next"), Link.of("url", "last")));
-		assertThat(Links.parse("<url>;rel=\"next last\""))
-				.isEqualTo(Links.of(Link.of("url", "next"), Link.of("url", "last")));
-		assertThat(Links.parse("</prev>;rel=prev first,</next>;rel=next last"))
-				.isEqualTo(Links.of(
-						Link.of("/prev", "prev"),
-						Link.of("/prev", "first"),
-						Link.of("/next", "next"),
-						Link.of("/next", "last") ));
+		assertThat(Links.parse("<url>;rel=next last")).isEqualTo(Links.of(Link.of("url", "next"), Link.of("url", "last")));
+		assertThat(Links.parse("<url>;rel=\"next last\"")).isEqualTo(
+				Links.of(Link.of("url", "next"), Link.of("url", "last")));
+		assertThat(Links.parse("</prev>;rel=prev first,</next>;rel=next last")).isEqualTo(
+				Links.of(Link.of("/prev", "prev"), Link.of("/prev", "first"), Link.of("/next", "next"),
+						Link.of("/next", "last")));
 	}
 
 	@Test
 	void parsingSpecialChars() {
 		// within the href, `,` and `;` aren't special
-		assertThat(Links.parse("<http://example.com/?param=foo,bar;baz>;rel=next"))
-				.isEqualTo(Links.of(Link.of("http://example.com/?param=foo,bar;baz", "next")));
+		assertThat(Links.parse("<http://example.com/?param=foo,bar;baz>;rel=next")).isEqualTo(
+				Links.of(Link.of("http://example.com/?param=foo,bar;baz", "next")));
 	}
 
 	@Test
 	void parsingWhitespaceOtherThanSpace() {
-		assertThat(Links.parse("\n\r\t <url1>\n\r\t ;\n\r\t rel\n\r\t =\r\n\t next \r\n\t , \r\n\t ," +
-				" \r\n\t <url2>\r\n\t ;\r\n\t rel \r\n\t = \r\n\t \"foo\"\r\n\t ; title=\"\r\n\t bar\r\n\t \"\r\n\t "))
-				.isEqualTo(Links.of(
-						Link.of("url1", "next"),
-						Link.of("url2", "foo").withTitle("\r\n\t bar\r\n\t ")
-				));
+		assertThat(Links.parse(
+				"\n\r\t <url1>\n\r\t ;\n\r\t rel\n\r\t =\r\n\t next \r\n\t , \r\n\t ," + " \r\n\t <url2>\r\n\t ;\r\n\t rel \r\n\t = \r\n\t \"foo\"\r\n\t ; title=\"\r\n\t bar\r\n\t \"\r\n\t ")).isEqualTo(
+				Links.of(Link.of("url1", "next"), Link.of("url2", "foo").withTitle("\r\n\t bar\r\n\t ")));
 	}
 
 	@Test
 	void parsingEmptyRel() {
 		// rel is empty string
-		assertThatThrownBy(() -> Links.parse("<url>;rel=''"))
-				.isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> Links.parse("<url>;rel=''")).isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("Missing 'rel' attribute at index 12");
 
 		// rel is a single space - if we split by whitespace, there's no value
-		assertThatThrownBy(() -> Links.parse("<url>;rel=' '"))
-				.isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> Links.parse("<url>;rel=' '")).isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("Missing 'rel' attribute at index 13");
 	}
 
 	@Test
 	void toStringEscaping() {
-		assertThat(Links.of(Link.of("/path?formula=a>b", "next").withTitle("foo\"bar\\baz")).toString())
-				.isEqualTo("</path?formula=a%3eb>;rel=\"next\";title=\"foo\\\"bar\\\\baz\"");
-		assertThat(Links.of(Link.of("/path?formula=a>b", "next").withTitle("")).toString())
-				.isEqualTo("</path?formula=a%3eb>;rel=\"next\";title=\"\"");
+		assertThat(Links.of(Link.of("/path?formula=a>b", "next").withTitle("foo\"bar\\baz")).toString()).isEqualTo(
+				"</path?formula=a%3eb>;rel=\"next\";title=\"foo\\\"bar\\\\baz\"");
+		assertThat(Links.of(Link.of("/path?formula=a>b", "next").withTitle("")).toString()).isEqualTo(
+				"</path?formula=a%3eb>;rel=\"next\";title=\"\"");
 	}
 
 	@Test
@@ -489,12 +454,10 @@ class LinksUnitTest {
 		// here we test only code that isn't covered by the tests using `Links.parse`
 
 		// leading whitespace
-		assertThat(Link.valueOf("  <url>;rel=next"))
-				.isEqualTo(Link.of("url", "next"));
+		assertThat(Link.valueOf("  <url>;rel=next")).isEqualTo(Link.of("url", "next"));
 
 		// unexpected data at the beginning
-		assertThatThrownBy(() -> Link.valueOf("foo <url>;rel=next"))
-				.isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> Link.valueOf("foo <url>;rel=next")).isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("Expecting '<' at index 0");
 	}
 

--- a/src/test/java/org/springframework/hateoas/LinksUnitTest.java
+++ b/src/test/java/org/springframework/hateoas/LinksUnitTest.java
@@ -35,6 +35,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Oliver Gierke
  * @author Greg Turnquist
+ * @author Viliam Durina
  */
 class LinksUnitTest {
 
@@ -65,7 +66,6 @@ class LinksUnitTest {
 
 	@Test
 	void parsesLinkHeaderLinks() {
-
 		assertThat(Links.parse(LINKS)).isEqualTo(reference);
 		assertThat(Links.parse(LINKS2)).isEqualTo(reference2);
 		assertThat(reference.toString()).isEqualTo(LINKS);
@@ -74,13 +74,29 @@ class LinksUnitTest {
 
 	@Test
 	void skipsEmptyLinkElements() {
+		// extra commas at the end
 		assertThat(Links.parse(LINKS + ",,,")).isEqualTo(reference);
 		assertThat(Links.parse(LINKS2 + ",,,")).isEqualTo(reference2);
+
+		// extra commas inside
+		assertThat(Links.parse("<url1>;rel= \"foo\",,<url2>;rel= \"bar\""))
+				.isEqualTo(Links.of(
+						Link.of("url1", "foo"),
+						Link.of("url2", "bar")));
+
+		// extra commas at the beginning
+		assertThat(Links.parse(",,<url1>;rel= \"foo\""))
+				.isEqualTo(Links.of(Link.of("url1", "foo")));
+
+		// extra commas everywhere with whitespace
+		assertThat(Links.parse(" , , <url1>;rel= \"foo\" , , <url2>;rel= \"bar\"  ,  , "))
+				.isEqualTo(Links.of(
+						Link.of("url1", "foo"),
+						Link.of("url2", "bar")));
 	}
 
 	@Test
 	void returnsNullForNullOrEmptySource() {
-
 		assertThat(Links.parse(null)).isEqualTo(Links.NONE);
 		assertThat(Links.parse("")).isEqualTo(Links.NONE);
 	}
@@ -100,7 +116,6 @@ class LinksUnitTest {
 	 */
 	@Test
 	void parsesLinkWithComma() {
-
 		Link withComma = Link.of("http://localhost:8080/test?page=0&filter=foo,bar", "foo");
 
 		assertThat(Links.parse(WITH_COMMA).getLink("foo")).isEqualTo(Optional.of(withComma));
@@ -121,7 +136,6 @@ class LinksUnitTest {
 
 	@Test // #805
 	void returnsRequiredLink() {
-
 		Link reference = Link.of("http://localhost", "someRel");
 		Links links = Links.of(reference);
 
@@ -130,7 +144,6 @@ class LinksUnitTest {
 
 	@Test // #805
 	void rejectsMissingLinkWithIllegalArgumentException() {
-
 		Links links = Links.of();
 
 		assertThatExceptionOfType(IllegalArgumentException.class) //
@@ -140,7 +153,6 @@ class LinksUnitTest {
 
 	@Test
 	void detectsContainedLinks() {
-
 		Link first = Link.of("http://localhost", "someRel");
 		Link second = Link.of("http://localhost", "someOtherRel");
 
@@ -154,7 +166,6 @@ class LinksUnitTest {
 
 	@TestFactory // #1322, #1341
 	Stream<DynamicTest> conditionallyAddsLink() {
-
 		Links links = Links.NONE;
 		Link link = Link.of("/foo");
 
@@ -181,7 +192,6 @@ class LinksUnitTest {
 
 	@Test // #1322
 	void doesNotEvaluateSupplierIfAddConditionIsFalse() {
-
 		assertThatCode(() -> Links.NONE.andIf(false, () -> {
 			throw new IllegalStateException();
 		})).doesNotThrowAnyException();
@@ -189,7 +199,6 @@ class LinksUnitTest {
 
 	@TestFactory // #1340
 	Stream<DynamicTest> addsStreamOfLinks() {
-
 		Links links = Links.NONE;
 		Link link = Link.of("/foo");
 
@@ -204,7 +213,6 @@ class LinksUnitTest {
 
 	@TestFactory // #1340
 	Stream<DynamicTest> mergesStreamOfLinks() {
-
 		Links links = Links.NONE.and(Link.of("/foo"));
 		Link same = Link.of("/foo");
 		Link sameRel = Link.of("/bar");
@@ -222,7 +230,6 @@ class LinksUnitTest {
 
 	@TestFactory // #1340
 	Stream<DynamicTest> replacesLinksViaMerge() {
-
 		Links links = Links.of(Link.of("/foo"));
 		Link sameRel = Link.of("/bar");
 
@@ -242,7 +249,6 @@ class LinksUnitTest {
 
 	@Test
 	void basics() {
-
 		Links none = Links.NONE;
 
 		assertThat(none.isEmpty()).isTrue();
@@ -268,7 +274,6 @@ class LinksUnitTest {
 
 	@Test // #1458
 	void supportsUnquotedAttributes() {
-
 		assertThat(Links.parse("<https://url.com?page=1>; rel=first").getRequiredLink("first").getHref())
 				.isEqualTo("https://url.com?page=1");
 	}
@@ -276,6 +281,221 @@ class LinksUnitTest {
 	@Test // #1899
 	void parsesMultipleLinksContainingUnquotedRels() {
 		assertThat(Links.parse(LINKS3)).isEqualTo(reference3);
+	}
+
+	// ### tests added after https://github.com/spring-projects/spring-hateoas/issues/2099 ###
+
+	@Test
+	void parsingUnexpectedData() {
+		// two URLs without a comma - the second URL is an unexpected text
+		assertThatThrownBy(() -> Links.parse("<url1>;rel=\"foo\"<url2>;rel= \"bar\""))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Unexpected data at the end of Link header at index 16");
+		assertThatThrownBy(() -> Links.parse("<url1>; rel=\"foo\" <url2>;rel= \"bar\""))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Unexpected data at the end of Link header at index 18");
+		assertThatThrownBy(() -> Links.parse( "<url1> ; rel= \"foo\" <url2>;rel= \"bar\""))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Unexpected data at the end of Link header at index 20");
+
+		// unexpected text after a quoted string
+		assertThatThrownBy(() -> Links.parse("<url1>;rel=\"foo\"#"))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Unexpected data at the end of Link header at index 16");
+		assertThatThrownBy(() -> Links.parse("<url1>;rel=\"foo\" foo bar"))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Unexpected data at the end of Link header at index 17");
+
+		// if the value isn't quoted, it can't be unexpected; all is part of the value
+		assertThat(Links.parse("<url1>;rel=foo#"))
+				.isEqualTo(Links.of(Link.of("url1", "foo#")));
+
+		// extra text after a comma - looks like a legit value for rel, but comma is special and starts a new link
+		assertThatThrownBy(() -> Links.parse("<url1>;rel=foo,bar"))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Unexpected data at the end of Link header at index 15");
+
+		// a trailing comma is ignored
+		assertThat(Links.parse("<url1>;rel=foo,"))
+				.isEqualTo(Links.of(Link.of("url1", "foo")));
+
+		// a trailing semicolon is also ignored
+		assertThat(Links.parse("<url1>;rel=foo;"))
+				.isEqualTo(Links.of(Link.of("url1", "foo")));
+
+		// unexpected text at the beginning
+		assertThatThrownBy(() -> Links.parse("foo bar <url>;rel=\"next\""))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Unexpected data at the end of Link header at index 0");
+	}
+
+	@Test
+	void parsingMissingData() {
+		// missing trailing bracket
+		assertThatThrownBy(() -> Links.parse("<https://example.com/;rel=next"))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Missing closing '>' at index 30");
+
+		// missing end quote
+		assertThatThrownBy(() -> Links.parse("<https://example.com/>;rel=\"next"))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Missing final quote at index 32");
+		assertThatThrownBy(() -> Links.parse("<https://example.com/>;rel='next"))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Missing final quote at index 32");
+	}
+
+	@Test
+	void parsingGreedyCapture() {
+		// no greedy capture until `>`
+		assertThat(Links.parse("<url>;title=foo>;rel=\"next\""))
+				.isEqualTo(Links.of(Link.of("url", "next").withTitle("foo>")));
+
+		// no greedy capture until `;`
+		assertThat(Links.parse("<url>;title=\"foo;bar\";rel=next"))
+				.isEqualTo(Links.of(Link.of("url", "next").withTitle("foo;bar")));
+
+		// no greedy capture until `,`
+		assertThat(Links.parse("<url>;title=\"foo,bar\";rel=next"))
+				.isEqualTo(Links.of(Link.of("url", "next").withTitle("foo,bar")));
+	}
+
+	@Test
+	void parsingQuotedText() {
+		// unquoting of double quotes
+		assertThat(Links.parse("<url>;title=\"\\\"bar\\\"\";rel=next"))
+				.isEqualTo(Links.of(Link.of("url", "next").withTitle("\"bar\"")));
+
+		// unquoting of single quotes
+		assertThat(Links.parse("<url>;title='\\'bar\\'';rel=next"))
+				.isEqualTo(Links.of(Link.of("url", "next").withTitle("'bar'")));
+
+		// single quote is literal in double-quoted string
+		assertThat(Links.parse("<url>;title=\"'bar'\";rel=next"))
+				.isEqualTo(Links.of(Link.of("url", "next").withTitle("'bar'")));
+
+		// double quote is literal in single-quoted string
+		assertThat(Links.parse("<url>;title='\"bar\"';rel=next"))
+				.isEqualTo(Links.of(Link.of("url", "next").withTitle("\"bar\"")));
+
+		// backslash unquoting
+		assertThat(Links.parse("<url>;title=\"foo\\\\bar\";rel=next"))
+				.isEqualTo(Links.of(Link.of("url", "next").withTitle("foo\\bar")));
+		assertThat(Links.parse("<url>;title='foo\\\\bar';rel=next"))
+				.isEqualTo(Links.of(Link.of("url", "next").withTitle("foo\\bar")));
+
+		// unquoting of unnecessarily quoted text
+		assertThat(Links.parse("<url>;title=\"\\f\\o\\o\";rel=next"))
+				.isEqualTo(Links.of(Link.of("url", "next").withTitle("foo")));
+		assertThat(Links.parse("<url>;title='\\f\\o\\o';rel=next"))
+				.isEqualTo(Links.of(Link.of("url", "next").withTitle("foo")));
+
+		// no java-style special characters
+		assertThat(Links.parse("<url>;title=\"\\r\\n\\t\";rel=next"))
+				.isEqualTo(Links.of(Link.of("url", "next").withTitle("rnt")));
+		assertThat(Links.parse("<url>;title='\\r\\n\\t';rel=next"))
+				.isEqualTo(Links.of(Link.of("url", "next").withTitle("rnt")));
+
+		// quote within a token value - the quote, if it's not the first character, is literal
+		assertThat(Links.parse("<url>;title=foo\"bar\";rel=next"))
+				.isEqualTo(Links.of(Link.of("url", "next").withTitle("foo\"bar\"")));
+		assertThat(Links.parse("<url>;title=foo'bar';rel=next"))
+				.isEqualTo(Links.of(Link.of("url", "next").withTitle("foo'bar'")));
+	}
+
+	@Test
+	void parsingEmptyString() {
+		// at the end
+		Links expected = Links.of(Link.of("url", "next").withTitle(""));
+		// value missing
+		assertThat(Links.parse("<url>;rel=next;title"))
+				.isEqualTo(expected);
+		// empty token-style value
+		assertThat(Links.parse("<url>;rel=next;title="))
+				.isEqualTo(expected);
+		// empty double-quoted string
+		assertThat(Links.parse("<url>;rel=next;title=\"\""))
+				.isEqualTo(expected);
+		// empty single-quoted string
+		assertThat(Links.parse("<url>;rel=next;title=''"))
+				.isEqualTo(expected);
+
+		// not at the end
+		expected = Links.of(Link.of("url", "next").withTitle("").withName("a"));
+		assertThat(Links.parse("<url>;rel=next;title;name=a"))
+				.isEqualTo(expected);
+		assertThat(Links.parse("<url>;rel=next;title=;name=a"))
+				.isEqualTo(expected);
+		assertThat(Links.parse("<url>;rel=next;title=\"\";name=a"))
+				.isEqualTo(expected);
+		assertThat(Links.parse("<url>;rel=next;title='';name=a"))
+				.isEqualTo(expected);
+	}
+
+	@Test
+	void parsingMultipleRels() {
+		assertThat(Links.parse("<url>;rel=next last"))
+				.isEqualTo(Links.of(Link.of("url", "next"), Link.of("url", "last")));
+		assertThat(Links.parse("<url>;rel=\"next last\""))
+				.isEqualTo(Links.of(Link.of("url", "next"), Link.of("url", "last")));
+		assertThat(Links.parse("</prev>;rel=prev first,</next>;rel=next last"))
+				.isEqualTo(Links.of(
+						Link.of("/prev", "prev"),
+						Link.of("/prev", "first"),
+						Link.of("/next", "next"),
+						Link.of("/next", "last") ));
+	}
+
+	@Test
+	void parsingSpecialChars() {
+		// within the href, `,` and `;` aren't special
+		assertThat(Links.parse("<http://example.com/?param=foo,bar;baz>;rel=next"))
+				.isEqualTo(Links.of(Link.of("http://example.com/?param=foo,bar;baz", "next")));
+	}
+
+	@Test
+	void parsingWhitespaceOtherThanSpace() {
+		assertThat(Links.parse("\n\r\t <url1>\n\r\t ;\n\r\t rel\n\r\t =\r\n\t next \r\n\t , \r\n\t ," +
+				" \r\n\t <url2>\r\n\t ;\r\n\t rel \r\n\t = \r\n\t \"foo\"\r\n\t ; title=\"\r\n\t bar\r\n\t \"\r\n\t "))
+				.isEqualTo(Links.of(
+						Link.of("url1", "next"),
+						Link.of("url2", "foo").withTitle("\r\n\t bar\r\n\t ")
+				));
+	}
+
+	@Test
+	void parsingEmptyRel() {
+		// rel is empty string
+		assertThatThrownBy(() -> Links.parse("<url>;rel=''"))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Missing 'rel' attribute at index 12");
+
+		// rel is a single space - if we split by whitespace, there's no value
+		assertThatThrownBy(() -> Links.parse("<url>;rel=' '"))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Missing 'rel' attribute at index 13");
+	}
+
+	@Test
+	void toStringEscaping() {
+		assertThat(Links.of(Link.of("/path?formula=a>b", "next").withTitle("foo\"bar\\baz")).toString())
+				.isEqualTo("</path?formula=a%3eb>;rel=\"next\";title=\"foo\\\"bar\\\\baz\"");
+		assertThat(Links.of(Link.of("/path?formula=a>b", "next").withTitle("")).toString())
+				.isEqualTo("</path?formula=a%3eb>;rel=\"next\";title=\"\"");
+	}
+
+	@Test
+	void directLinkParsing() {
+		// here we test only code that isn't covered by the tests using `Links.parse`
+
+		// leading whitespace
+		assertThat(Link.valueOf("  <url>;rel=next"))
+				.isEqualTo(Link.of("url", "next"));
+
+		// unexpected data at the beginning
+		assertThatThrownBy(() -> Link.valueOf("foo <url>;rel=next"))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Expecting '<' at index 0");
 	}
 
 	@Value(staticConstructor = "of")


### PR DESCRIPTION
The previous implementation used naive parsing suffering from many issues, especially when special characters were part of values. It also didn't escape the special characters when serializing a link to string.

I marked the `Link.valueOf` method as deprecated because it doesn't correctly parse multiple links, nor does it handle multiple values for the `rel` param. One should use `Links.parse`. There are no other incompatible API changes.

I had to change one current test: we no longer ignore missing final `>` after the URL - such link is invalid anyway because it didn't have the rel parameter.

Fixes #2099

Tests have 100% coverage of the new code, except for one line that cannot currently happen, but is there for robustness.