### PR TITLE
refactor: Use `Collection#isEmpty()` instead of comparing `size()`

### DIFF
--- a/src/main/java/org/springframework/hateoas/client/Traverson.java
+++ b/src/main/java/org/springframework/hateoas/client/Traverson.java
@@ -373,7 +373,7 @@ public class Traverson {
 
 		private Link traverseToLink(boolean expandFinalUrl) {
 
-			Assert.isTrue(rels.size() > 0, "At least one rel needs to be provided!");
+			Assert.isTrue(!rels.isEmpty(), "At least one rel needs to be provided!");
 
 			return Link.of(expandFinalUrl ? traverseToExpandedFinalUrl().getUri().toString() : traverseToFinalUrl().getUri(),
 					rels.get(rels.size() - 1).getRel());

--- a/src/main/java/org/springframework/hateoas/mediatype/collectionjson/Jackson2CollectionJsonModule.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/collectionjson/Jackson2CollectionJsonModule.java
@@ -524,7 +524,7 @@ public class Jackson2CollectionJsonModule extends SimpleModule {
 		@Override
 		@SuppressWarnings("null")
 		public boolean isEmpty(PagedModel<?> value) {
-			return value.getContent().size() == 0;
+			return value.getContent().isEmpty();
 		}
 
 		/*

--- a/src/main/java/org/springframework/hateoas/server/core/WebHandler.java
+++ b/src/main/java/org/springframework/hateoas/server/core/WebHandler.java
@@ -140,7 +140,7 @@ public class WebHandler {
 				if (mappingVariable.isCapturing()) {
 
 					List<String> segments = Arrays.asList(((String) preparedValue).split("/"));
-					Object value = segments.size() != 0 ? "/" + segment.composite().prepareAndEncode(segments) : "";
+					Object value = !segments.isEmpty() ? "/" + segment.composite().prepareAndEncode(segments) : "";
 
 					values.put(key, value);
 


### PR DESCRIPTION
**What**:
Changing calls to `Collections.size() == 0` to `Collection.isEmpty()`.

**Why**:
This is more readable and likely also more efficient.

**How**:
This has been generated using OpenRewrite's https://docs.openrewrite.org/recipes/staticanalysis/isemptycalloncollections
