### PR TITLE
Refactor null checks to use Objects::nonNull for improved readability

### DIFF
--- a/src/main/java/org/springframework/hateoas/CollectionModel.java
+++ b/src/main/java/org/springframework/hateoas/CollectionModel.java
@@ -350,7 +350,7 @@ public class CollectionModel<T> extends RepresentationModel<CollectionModel<T>>
 		}
 
 		return elements.stream()
-				.filter(it -> it != null)
+				.filter(Objects::nonNull)
 				.<Class<?>> map(Object::getClass)
 				.reduce(ClassUtils::determineCommonAncestor)
 				.map(ResolvableType::forClass)

--- a/src/main/java/org/springframework/hateoas/UriTemplate.java
+++ b/src/main/java/org/springframework/hateoas/UriTemplate.java
@@ -28,6 +28,7 @@ import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.Objects;
 
 import org.jspecify.annotations.Nullable;
 import org.springframework.hateoas.TemplateVariable.VariableType;
@@ -462,7 +463,7 @@ public class UriTemplate implements Iterable<TemplateVariable>, Serializable {
 
 			return type.join(variables.stream()
 					.map(it -> it.expand(parameters))
-					.filter(it -> it != null)
+					.filter(Objects::nonNull)
 					.collect(Collectors.toList()));
 		}
 

--- a/src/main/java/org/springframework/hateoas/mediatype/PropertyUtils.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/PropertyUtils.java
@@ -346,7 +346,7 @@ public class PropertyUtils {
 					.orElseThrow(() -> new IllegalStateException("Could not resolve value!"));
 
 			this.annotations = Stream.of(property.getReadMethod(), property.getWriteMethod(), field) //
-					.filter(it -> it != null) //
+					.filter(Objects::nonNull) //
 					.map(MergedAnnotations::from) //
 					.collect(Collectors.toList());
 


### PR DESCRIPTION
This PR replaces lambda expressions it -> it != null with method references Objects::nonNull in three files for improved code readability. 