### PR TITLE
fix https://github.com/spring-projects/spring-hateoas/issues/2469

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
 		<logback.version>1.5.32</logback.version>
 		<jacoco>0.8.12</jacoco>
 		<jacoco.destfile>${project.build.directory}/jacoco.exec</jacoco.destfile>
-		<jackson-bom.version>2.19.4</jackson-bom.version>
+		<jackson-bom.version>2.21.1</jackson-bom.version>
 		<java-module-name>spring.hateoas</java-module-name>
 		<jsonpath.version>2.9.0</jsonpath.version>
 		<junit.version>5.11.4</junit.version>

--- a/src/main/java/org/springframework/hateoas/mediatype/hal/Jackson2HalModule.java
+++ b/src/main/java/org/springframework/hateoas/mediatype/hal/Jackson2HalModule.java
@@ -55,7 +55,6 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.NamingBase;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.PropertyNamingStrategyBase;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.deser.std.ContainerDeserializerBase;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
@@ -849,8 +848,8 @@ public class Jackson2HalModule extends SimpleModule {
 		 */
 		public EmbeddedMapper with(@Nullable PropertyNamingStrategy strategy) {
 
-			Function<String, String> mapper = strategy instanceof PropertyNamingStrategyBase
-					? ((PropertyNamingStrategyBase) strategy)::translate
+			Function<String, String> mapper = strategy instanceof NamingBase
+					? ((NamingBase) strategy)::translate
 					: strategy instanceof NamingBase ? ((NamingBase) strategy)::translate : null;
 
 			return mapper == null

--- a/src/test/java/org/springframework/hateoas/mediatype/hal/Jackson2HalIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/hal/Jackson2HalIntegrationTest.java
@@ -538,7 +538,7 @@ class Jackson2HalIntegrationTest {
 		model.add(Link.of("/foo/form", IanaLinkRelations.EDIT_FORM));
 
 		ObjectMapper objectMapper = mapper.copy() //
-				.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE) //
+				.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE) //
 				.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
 
 		String result = objectMapper.writeValueAsString(model);
@@ -560,7 +560,7 @@ class Jackson2HalIntegrationTest {
 
 		ObjectMapper mapper = HalTestUtils.halObjectMapper(new HalConfiguration() //
 				.withApplyPropertyNamingStrategy(false)) //
-				.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE) //
+				.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE) //
 				.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
 
 		String result = mapper.writeValueAsString(model);


### PR DESCRIPTION
fix issue https://github.com/spring-projects/spring-hateoas/issues/2469

spring-hateoas:2.5.2 is incompatible with spring boot 3.5.13 + jackson 2.21.x. this PR intends to fix PropertyNamingStrategyBase not anymore presents in the classpath

```java
java.lang.NoClassDefFoundError: com/fasterxml/jackson/databind/PropertyNamingStrategy$PropertyNamingStrategyBase\r\n\tat org.springframework.hateoas.mediatype.hal.Jackson2HalModule$EmbeddedMapper.with(Jackson2HalModule.java:852)\r\n\tat org.springframework.hateoas.mediatype.hal.Jackson2HalModule$HalResourcesSerializer.serialize(Jackson2HalModule.java:323)
```