### PR TITLE
In some situations, HateoasConfiguration#lookupMessageSource wrongly returns null instead of ReloadableResourceBundleMessageSource

### DIFF
--- a/src/main/java/org/springframework/hateoas/config/HateoasConfiguration.java
+++ b/src/main/java/org/springframework/hateoas/config/HateoasConfiguration.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.hateoas.config;
 
+import org.springframework.core.io.support.ResourcePatternResolver;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
@@ -59,6 +60,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author Oliver Gierke
  * @author Greg Turnquist
+ * @author Réda Housni Alaoui
  * @soundtrack Elephants Crossing - Wait (Live at Stadtfest Dresden)
  * @since 0.19
  */
@@ -173,7 +175,8 @@ public class HateoasConfiguration {
 
 		try {
 			return Arrays //
-					.stream(context.getResources(String.format("classpath:%s%s.properties", baseName, withWildcard ? "*" : ""))) //
+					.stream(context.getResources(String.format("%s%s%s.properties", //
+							ResourcePatternResolver.CLASSPATH_ALL_URL_PREFIX, baseName, withWildcard ? "*" : ""))) //
 					.filter(Resource::exists) //
 					.collect(Collectors.toList());
 

--- a/src/test/java/org/springframework/hateoas/config/EnableHypermediaSupportIntegrationTest.java
+++ b/src/test/java/org/springframework/hateoas/config/EnableHypermediaSupportIntegrationTest.java
@@ -74,6 +74,7 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
  *
  * @author Oliver Gierke
  * @author Greg Turnquist
+ * @author Réda Housni Alaoui
  */
 @ExtendWith(MockitoExtension.class)
 class EnableHypermediaSupportIntegrationTest {
@@ -465,7 +466,7 @@ class EnableHypermediaSupportIntegrationTest {
 
 			try {
 
-				doReturn(new Resource[0]).when(spy).getResources("classpath:rest-default-messages.properties");
+				doReturn(new Resource[0]).when(spy).getResources("classpath*:rest-default-messages.properties");
 				doReturn(new Resource[] { resource }).when(spy).getResources(contains("rest-messages"));
 
 			} catch (IOException o_O) {


### PR DESCRIPTION
Fix #2478 