### PR TITLE
Remove duplicated "the"

### DIFF
--- a/src/main/java/org/springframework/hateoas/server/core/UriTemplateFactory.java
+++ b/src/main/java/org/springframework/hateoas/server/core/UriTemplateFactory.java
@@ -33,7 +33,7 @@ public class UriTemplateFactory {
 	private static final Map<String, UriTemplate> CACHE = new ConcurrentReferenceHashMap<>();
 
 	/**
-	 * Returns the the {@link UriTemplate} for the given mapping.
+	 * Returns the {@link UriTemplate} for the given mapping.
 	 *
 	 * @param mapping must not be {@literal null} or empty.
 	 * @return

--- a/src/test/java/org/springframework/hateoas/mediatype/MediaTypeTestUtils.java
+++ b/src/test/java/org/springframework/hateoas/mediatype/MediaTypeTestUtils.java
@@ -40,7 +40,7 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
 public class MediaTypeTestUtils {
 
 	/**
-	 * Looks up the the media types supported for {@link RepresentationModel} in the {@link RequestMappingHandlerAdapter}
+	 * Looks up the media types supported for {@link RepresentationModel} in the {@link RequestMappingHandlerAdapter}
 	 * within the given {@link ApplicationContext}.
 	 *
 	 * @param context must not be {@literal null}.
@@ -51,7 +51,7 @@ public class MediaTypeTestUtils {
 	}
 
 	/**
-	 * Looks up the the media types supported for the given type in the {@link RequestMappingHandlerAdapter} within the
+	 * Looks up the media types supported for the given type in the {@link RequestMappingHandlerAdapter} within the
 	 * given {@link ApplicationContext}.
 	 *
 	 * @param context must not be {@literal null}.


### PR DESCRIPTION
This PR fixes typos of "the the" to "the".